### PR TITLE
[bugfix]Release connection after executing query

### DIFF
--- a/doris_mcp_server/utils/query_executor.py
+++ b/doris_mcp_server/utils/query_executor.py
@@ -432,21 +432,17 @@ class DorisQueryExecutor:
         )
 
         # Execute query
-        connection = await self.connection_manager.get_connection(
-            query_request.session_id
-        )
-
         # Set timeout if specified
         if query_request.timeout:
             try:
                 result = await asyncio.wait_for(
-                    connection.execute(optimized_sql, query_request.parameters, auth_context),
+                    self.connection_manager.execute_query(query_request.session_id, optimized_sql, query_request.parameters, auth_context),
                     timeout=query_request.timeout
                 )
             except asyncio.TimeoutError:
                 raise Exception(f"Query timeout after {query_request.timeout} seconds")
         else:
-            result = await connection.execute(optimized_sql, query_request.parameters, auth_context)
+            result = await self.connection_manager.execute_query(query_request.session_id, optimized_sql, query_request.parameters, auth_context)
 
         return result
 


### PR DESCRIPTION
This PR fixes `Connection acquisition timed out for session mcp_session` issue mentioned in https://github.com/apache/doris-mcp-server/issues/31

close #31 