### PR TITLE
[bugfix]Fix line ending issues in start_server.sh script for Docker container execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y \
     g++ \
     pkg-config \
     default-libmysqlclient-dev \
+    dos2unix \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements file
@@ -43,11 +44,12 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
+# Convert line endings for shell scripts and ensure proper execution format
+RUN find . -name "*.sh" -exec dos2unix {} \; && \
+    find . -name "*.sh" -exec chmod +x {} \;
+
 # Create necessary directories
 RUN mkdir -p /app/logs /app/config /app/data
-
-# Set permissions
-RUN chmod +x /app/start_server.sh
 
 # Create non-root user
 RUN groupadd -r doris && useradd -r -g doris doris
@@ -62,4 +64,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
 EXPOSE 3000 3001 3002
 
 # Start command
-CMD ["/app/start_server.sh"] 
+CMD ["/app/start_server.sh"]


### PR DESCRIPTION
bug #38 

Problem:
When running the start_server.sh script in a Docker container, the following errors occurred:
- : not foundserver.sh: 18: (and other lines)
- /app/start_server.sh: 35: Syntax error: "elif" unexpected (expecting "then")

Root cause:
The script file was using Windows-style line endings (CRLF) instead of Unix/Linux-style line endings (LF), which caused syntax errors when executed in a Linux environment.

Solution:
1. Ensure start_server.sh file uses proper Unix line endings (LF)
2. Add dos2unix command in Dockerfile to convert line ending format of the script file
3. Automatically fix line ending issues during image build to ensure proper script execution in containers

This fixes the issue with starting Doris MCP Server in Linux-based Docker containers.