### PR TITLE
[feat] Refactor configuration management and fix default host

### DIFF
--- a/doris_mcp_server/utils/config.py
+++ b/doris_mcp_server/utils/config.py
@@ -225,6 +225,7 @@ class DorisConfig:
     # Basic configuration
     server_name: str = "doris-mcp-server"
     server_version: str = "0.4.1"
+    server_host: str = "localhost"
     server_port: int = 3000
     transport: str = "stdio"
     
@@ -267,6 +268,9 @@ class DorisConfig:
     @classmethod
     def from_env(cls, env_file: str | None = None) -> "DorisConfig":
         """Load configuration from environment variables
+
+        The kv pairs in the. env file will be loaded as environment variables,
+        but the existing environment variables will not be overridden.
         
         Args:
             env_file: .env file path, if None, search in the following order:
@@ -286,7 +290,7 @@ class DorisConfig:
                 env_files = [".env", ".env.local", ".env.production", ".env.development"]
                 for env_path in env_files:
                     if Path(env_path).exists():
-                        load_dotenv(env_path)
+                        load_dotenv(env_path, override=False)
                         logging.getLogger(__name__).info(f"Loaded environment configuration file: {env_path}")
                         break
                 else:

--- a/doris_mcp_server/utils/schema_extractor.py
+++ b/doris_mcp_server/utils/schema_extractor.py
@@ -36,9 +36,6 @@ from .logger import get_logger
 # Configure logging
 logger = get_logger(__name__)
 
-# Load environment variables
-load_dotenv(override=True)
-
 METADATA_DB_NAME="information_schema"
 ENABLE_MULTI_DATABASE=os.getenv("ENABLE_MULTI_DATABASE",True)
 MULTI_DATABASE_NAMES=os.getenv("MULTI_DATABASE_NAMES","")


### PR DESCRIPTION
This PR refactors the configuration management to unify the handling of command-line arguments, environment variables, and default settings.

Key changes:
- All configuration is now consistently managed through the `DorisConfig` object.
- Command-line arguments now correctly override environment variables and default settings.
- The default server host/port is now correctly read from the configuration.
- Wrong environment variable loading in `schema_extractor.py` has been removed.

closes #37