### PR TITLE
feat: add CORS support for HTTP transport mode

### DIFF
--- a/doris_mcp_server/main.py
+++ b/doris_mcp_server/main.py
@@ -518,6 +518,7 @@ class DorisServer:
             from starlette.routing import Route
             from starlette.responses import JSONResponse, Response
             from starlette.types import Scope
+            from starlette.middleware.cors import CORSMiddleware
             
             # Create session manager
             session_manager = StreamableHTTPSessionManager(
@@ -600,6 +601,15 @@ class DorisServer:
                 ],
                 lifespan=lifespan,
             )
+
+            # Add CORS middleware allowing all origins
+            starlette_app.add_middleware(
+                CORSMiddleware,
+                allow_origins=["*"],
+                allow_credentials=True,
+                allow_methods=["*"],
+                allow_headers=["*"],
+            )
             
             # Custom ASGI app that handles both /mcp and /mcp/ without redirects
             async def mcp_app(scope, receive, send):
@@ -663,6 +673,18 @@ class DorisServer:
                                 await response(scope, receive, send)
                                 return
                             
+                            # Handle CORS preflight OPTIONS requests
+                            if method == "OPTIONS":
+                                from starlette.responses import Response
+                                request_headers = headers.get(b'access-control-request-headers', b'').decode('utf-8')
+                                response = Response("", status_code=204)
+                                response.headers["Access-Control-Allow-Origin"] = "*"
+                                response.headers["Access-Control-Allow-Methods"] = "GET, POST, DELETE, OPTIONS"
+                                response.headers["Access-Control-Allow-Headers"] = request_headers or "*"
+                                response.headers["Access-Control-Max-Age"] = "86400"
+                                await response(scope, receive, send)
+                                return
+
                             # Handle Dify compatibility for GET requests
                             if method == "GET":
                                 accept_header = headers.get(b'accept', b'').decode('utf-8')
@@ -687,7 +709,23 @@ class DorisServer:
                                     scope["headers"] = new_headers
                                     self.logger.info(f"Modified Accept header to: {new_value}")
                             
-                            await session_manager.handle_request(scope, receive, send)
+                            # Wrap send to inject CORS headers into session_manager responses
+                            async def send_with_cors(message):
+                                if message.get("type") == "http.response.start":
+                                    headers = list(message.get("headers", []))
+                                    cors_headers = [
+                                        (b"access-control-allow-origin", b"*"),
+                                        (b"access-control-allow-credentials", b"true"),
+                                        (b"access-control-expose-headers", b"*"),
+                                    ]
+                                    for name, value in cors_headers:
+                                        # Avoid duplicate headers
+                                        if not any(h[0] == name for h in headers):
+                                            headers.append((name, value))
+                                    message["headers"] = headers
+                                await send(message)
+
+                            await session_manager.handle_request(scope, receive, send_with_cors)
                             return
                         
                         # 404 for other paths

--- a/doris_mcp_server/multiworker_app.py
+++ b/doris_mcp_server/multiworker_app.py
@@ -212,6 +212,7 @@ if not _import_mcp_with_compatibility():
 from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.responses import JSONResponse, Response
+from starlette.middleware.cors import CORSMiddleware
 
 # Import Doris MCP components
 from .tools.tools_manager import DorisToolsManager
@@ -612,6 +613,15 @@ basic_app = Starlette(
         Route("/token/management", token_management, methods=["GET"]),
     ],
     lifespan=lifespan
+)
+
+# Add CORS middleware allowing all origins
+basic_app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 # Create main ASGI app that routes between basic app and MCP


### PR DESCRIPTION
## Summary

- Add CORS middleware to both `main.py` (DorisServer HTTP mode) and `multiworker_app.py` to enable cross-origin requests from browser-based MCP clients
- Handle CORS preflight OPTIONS requests with proper headers
- Inject CORS headers (`Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`, `Access-Control-Expose-Headers`) into all responses via a custom `send_with_cors` wrapper

## Motivation

Browser-based MCP clients (e.g., web dashboards, Dify integration) cannot directly communicate with the Doris MCP Server due to CORS restrictions. This change enables cross-origin access for the HTTP transport mode, making it possible to use the server from any web origin.

## Changes

- `doris_mcp_server/main.py`: Added CORSMiddleware to the Starlette app, OPTIONS preflight handling, and CORS header injection via send wrapper
- `doris_mcp_server/multiworker_app.py`: Added CORSMiddleware to the multi-worker basic_app

## Test plan

- [ ] Verify CORS preflight OPTIONS requests return proper headers
- [ ] Verify cross-origin POST/GET requests succeed from a browser
- [ ] Verify existing MCP client functionality is not affected
- [ ] Verify stdio transport mode is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)