### PR TITLE
feat: add Doris-backed OAuth authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -219,6 +219,92 @@ OAUTH_STATE_EXPIRY=300
 # OAUTH_JWKS_URL=https://your-keycloak-server.com/auth/realms/{realm}/protocol/openid-connect/certs
 # OAUTH_SCOPE=openid profile email
 
+# ===================================================================
+# Doris-backed OAuth Configuration (Enable with ENABLE_DORIS_OAUTH_AUTH=true)
+# ===================================================================
+
+# Doris-backed OAuth is separate from external OAuth/OIDC.
+# Do not enable ENABLE_OAUTH_AUTH, OAUTH_ENABLED, or AUTH_TYPE=oauth with this mode.
+# If both Doris-backed OAuth and external OAuth/OIDC are enabled, startup/config
+# validation fails fast instead of exposing two OAuth behaviors on one MCP URL.
+# Default is disabled.
+ENABLE_DORIS_OAUTH_AUTH=false
+DORIS_OAUTH_BASE_URL=http://localhost:3000
+
+# Doris-backed OAuth requires HTTP transport and one effective worker.
+# WORKERS=0 expands to CPU count and will fail when Doris-backed OAuth is enabled.
+# TRANSPORT=http
+# WORKERS=1
+
+# Doris OAuth operation gates. When enabled, these scopes are included in the
+# default OAuth grant; normal MCP clients do not need to pass long --scopes
+# lists. MySQL-channel operations run through the logged-in Doris user pool,
+# so Doris RBAC is the final data authorization backend.
+DORIS_OAUTH_DB_TOOLS_ENABLED=false
+DORIS_OAUTH_DB_TOOL_ALLOWLIST=get_db_list,get_db_table_list,get_table_schema,get_table_comment,get_table_column_comments,get_table_indexes,get_catalog_list
+
+# Query/explain are configurable Doris-user MySQL channels. If you want SQL,
+# DDL, or DML to be decided only by Doris RBAC, also set
+# ENABLE_SECURITY_CHECK=false; otherwise the legacy MCP SQL security layer can
+# reject some SQL before Doris sees it.
+DORIS_OAUTH_QUERY_TOOLS_ENABLED=false
+DORIS_OAUTH_QUERY_TOOL_ALLOWLIST=exec_query
+DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED=false
+DORIS_OAUTH_EXPLAIN_TOOL_ALLOWLIST=get_sql_explain
+
+# Token/code/client lifetime settings. Current OAuth store is memory-only and
+# process-local; tokens, auth codes, DCR clients, and client secrets do not
+# survive process restart.
+DORIS_OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS=900
+DORIS_OAUTH_REFRESH_TOKEN_EXPIRE_SECONDS=86400
+DORIS_OAUTH_AUTH_CODE_EXPIRE_SECONDS=300
+DORIS_OAUTH_GC_INTERVAL_SECONDS=60
+DORIS_OAUTH_IDLE_TIMEOUT_SECONDS=
+# Compatibility-retained. The current Doris OAuth login page ignores this value
+# and displays the fixed label "doris".
+DORIS_OAUTH_LOGIN_PAGE_TITLE="doris"
+
+# Dynamic Client Registration:
+# auto: enabled only for loopback/local development base URLs.
+# disabled: do not register /oauth/register.
+# enabled: requires ENABLE_DORIS_OAUTH_PRODUCTION_DCR=true for non-loopback URLs.
+DORIS_OAUTH_DYNAMIC_CLIENT_REGISTRATION_MODE=auto
+ENABLE_DORIS_OAUTH_PRODUCTION_DCR=false
+DORIS_OAUTH_DCR_MAX_CLIENTS=1000
+DORIS_OAUTH_DCR_CLIENT_TTL_SECONDS=86400
+DORIS_OAUTH_DCR_RATE_LIMIT_PER_IP=30
+DORIS_OAUTH_CLIENTS_FILE=
+DORIS_OAUTH_ALLOWED_REDIRECT_URIS=
+ENABLE_DORIS_OAUTH_PRODUCTION_WILDCARD_REDIRECTS=false
+
+# Rate limits. Keep these enabled for public or shared deployments.
+DORIS_OAUTH_RATE_LIMIT_WINDOW_SECONDS=300
+DORIS_OAUTH_LOGIN_RATE_LIMIT_PER_IP=20
+DORIS_OAUTH_LOGIN_RATE_LIMIT_PER_USER=10
+DORIS_OAUTH_LOGIN_RATE_LIMIT_PER_CLIENT=30
+DORIS_OAUTH_LOGIN_RATE_LIMIT_PER_TXN=5
+DORIS_OAUTH_AUTHORIZE_RATE_LIMIT_PER_IP=120
+DORIS_OAUTH_TOKEN_RATE_LIMIT_PER_IP=120
+DORIS_OAUTH_TOKEN_RATE_LIMIT_PER_CLIENT=240
+DORIS_OAUTH_REVOKE_RATE_LIMIT_PER_IP=120
+DORIS_OAUTH_REVOKE_RATE_LIMIT_PER_CLIENT=240
+DORIS_OAUTH_API_AUTH_TOKEN_RATE_LIMIT_PER_IP=20
+DORIS_OAUTH_API_AUTH_TOKEN_RATE_LIMIT_PER_USER=10
+DORIS_OAUTH_API_AUTH_REFRESH_RATE_LIMIT_PER_IP=120
+DORIS_OAUTH_API_AUTH_REFRESH_RATE_LIMIT_PER_CLIENT=240
+
+# TLS and reverse proxy handling.
+# Production should use an HTTPS DORIS_OAUTH_BASE_URL.
+# Non-loopback http:// is rejected unless DORIS_OAUTH_ALLOW_INSECURE_HTTP=true.
+# Trust proxy headers only from explicitly trusted reverse proxy CIDRs.
+DORIS_OAUTH_ALLOW_INSECURE_HTTP=false
+DORIS_OAUTH_TRUST_PROXY_HEADERS=false
+DORIS_OAUTH_TRUSTED_PROXY_CIDRS=
+# Example:
+# DORIS_OAUTH_BASE_URL=https://mcp.example.com
+# DORIS_OAUTH_TRUST_PROXY_HEADERS=true
+# DORIS_OAUTH_TRUSTED_PROXY_CIDRS=10.0.0.0/8,192.168.0.0/16
+
 # Legacy token settings (for backward compatibility)
 TOKEN_SECRET=your_secret_key_here
 TOKEN_EXPIRY=3600

--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ cp .env.example .env
     *   `ENABLE_TOKEN_AUTH`: Enable token-based authentication (default: false)
     *   `ENABLE_JWT_AUTH`: Enable JWT authentication (default: false)
     *   `ENABLE_OAUTH_AUTH`: Enable OAuth authentication (default: false)
+    *   `ENABLE_DORIS_OAUTH_AUTH`: Enable Doris-backed OAuth authentication (default: false)
+    *   `DORIS_OAUTH_BASE_URL`: Public base URL used by Doris-backed OAuth discovery and token endpoints
     *   `TOKEN_FILE_PATH`: Path to tokens.json file for token management (default: tokens.json)
     *   `TOKEN_HOT_RELOAD`: Enable hot reloading of token configuration (default: true)
     *   `DEFAULT_ADMIN_TOKEN`: Default admin token (customizable via env)
@@ -307,6 +309,8 @@ The following table lists the main tools currently available for invocation via 
 | `get_adbc_connection_info` | ADBC connection diagnostics and status monitoring for Arrow Flight SQL. | No parameters required |
 
 **Note:** All metadata tools support catalog federation for multi-catalog environments. Enhanced monitoring tools provide comprehensive memory tracking and metrics collection capabilities. **New in v0.5.0**: 7 advanced analytics tools for enterprise data governance and 2 ADBC tools for high-performance data transfer with 3-10x performance improvements for large datasets.
+
+**Doris-backed OAuth note:** The table above describes global server capabilities. Doris-backed OAuth uses configuration gates for its operation surface. MCP resources are available with resource metadata caching disabled. Reviewed metadata tools are callable when `DORIS_OAUTH_DB_TOOLS_ENABLED=true`; `exec_query` and `get_sql_explain` are callable when their Doris OAuth query/explain gates are enabled. These MySQL-channel operations run through the logged-in Doris user pool, so Doris RBAC is the final data authorization backend. Prompts, ADBC, FE HTTP profile/monitoring, audit/governance, and performance analytics remain closed until they have per-user routing or an explicit service-account/admin design.
 
 ### 4. Run the Service
 
@@ -455,6 +459,85 @@ DEFAULT_READONLY_TOKEN=doris_readonly_token_123456
 # AUTH_TYPE=token               # Use individual switches instead
 # TOKEN_SECRET=your_secret_key  # Use token-based auth instead
 ```
+
+### Doris-Backed OAuth Authentication
+
+Doris-backed OAuth is a separate OAuth mode where Doris itself is the authorization backend. The MCP client discovers this server's OAuth metadata, the user signs in with a Doris username and password, the server validates those credentials by creating a per-user Doris connection pool, and issued `doa_` access tokens route tool calls through that Doris user's pool. MCP scopes control which MCP operations can be called; Doris RBAC controls which catalogs, databases, tables, and metadata the user can see.
+
+This mode is not the same as external OAuth/OIDC. `ENABLE_DORIS_OAUTH_AUTH=true` conflicts with `ENABLE_OAUTH_AUTH=true`, `OAUTH_ENABLED=true`, and legacy `AUTH_TYPE=oauth`; startup fails fast if both modes are configured. A standard MCP agent enters one MCP URL and should discover exactly one OAuth behavior for that URL, so the existing `/auth/*` external OAuth login flow is not used in Doris-backed OAuth mode.
+
+#### Minimal Local Configuration
+
+The following example is for local development on a single worker:
+
+```bash
+TRANSPORT=http
+WORKERS=1
+
+DORIS_HOST=localhost
+DORIS_PORT=9030
+DORIS_USER=root
+DORIS_PASSWORD=<service-account-password>
+DORIS_DATABASE=information_schema
+
+ENABLE_DORIS_OAUTH_AUTH=true
+DORIS_OAUTH_BASE_URL=http://localhost:3000
+ENABLE_OAUTH_AUTH=false
+
+DORIS_OAUTH_DB_TOOLS_ENABLED=true
+DORIS_OAUTH_DB_TOOL_ALLOWLIST=get_db_list,get_db_table_list,get_table_schema,get_table_comment,get_table_column_comments,get_table_indexes,get_catalog_list
+DORIS_OAUTH_QUERY_TOOLS_ENABLED=true
+DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED=true
+
+# Optional: let Doris RBAC, not the legacy MCP SQL guard, decide DDL/DML.
+ENABLE_SECURITY_CHECK=false
+```
+
+The configured service Doris account is still required by startup validation and by non-Doris-OAuth compatibility paths. Doris-backed OAuth requests are fail-closed if the per-user pool is missing and must not fall back to the service/global account.
+
+#### Doris OAuth Tool Access
+
+`DORIS_OAUTH_DB_TOOLS_ENABLED=true` opens the reviewed metadata bucket. The reviewed tools are:
+
+*   `get_db_list`
+*   `get_db_table_list`
+*   `get_table_schema`
+*   `get_table_comment`
+*   `get_table_column_comments`
+*   `get_table_indexes`
+*   `get_catalog_list`
+
+For normal MCP OAuth flows, clients do not need to pass a long `--scopes` list. If the OAuth request omits scope, the server grants the configured Doris OAuth capability envelope. For MySQL-channel operations, Doris RBAC decides whether the logged-in Doris user can actually read metadata, run SQL, or explain SQL.
+
+`DORIS_OAUTH_QUERY_TOOLS_ENABLED=true` opens `exec_query`. `DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED=true` opens `get_sql_explain`. If `ENABLE_SECURITY_CHECK=true`, the legacy MCP SQL security layer can still reject some SQL before Doris sees it. Set `ENABLE_SECURITY_CHECK=false` when the intended policy is to let Doris RBAC decide SQL/DDL/DML.
+
+Doris-backed OAuth still does not open prompts, ADBC, FE HTTP profile/monitoring, audit/governance, or performance analytics in this phase unless those paths are separately routed through per-user credentials or given an explicit service-account/admin design.
+
+#### Current Operational Limits
+
+Doris-backed OAuth is currently single-process and single-worker:
+
+*   `WORKERS=1` is required. `WORKERS=0` expands to CPU count and fails when Doris-backed OAuth is enabled.
+*   OAuth clients, authorization transactions, authorization codes, access tokens, refresh tokens, and DCR clients are memory-only and process-local.
+*   Per-user Doris connection pools are process-local.
+*   Process restart requires users to sign in again.
+*   Tokens and pools are not shared across workers, processes, or nodes.
+*   Stateless horizontal scaling and multi-node deployment are not supported for Doris-backed OAuth yet.
+
+If an access token is otherwise valid but its Doris user pool is gone, the request fails with login required / `DORIS_OAUTH_POOL_MISSING`. The server does not store raw Doris passwords for automatic pool reconstruction.
+
+#### Production Hardening
+
+For production deployments:
+
+*   Use an HTTPS `DORIS_OAUTH_BASE_URL` for any non-loopback address.
+*   Keep `DORIS_OAUTH_ALLOW_INSECURE_HTTP=false`; non-loopback `http://` is rejected unless explicitly overridden for development.
+*   Enable `DORIS_OAUTH_TRUST_PROXY_HEADERS` only behind a controlled reverse proxy and set `DORIS_OAUTH_TRUSTED_PROXY_CIDRS`.
+*   Keep login, authorize, token, refresh, revoke, and DCR rate limits enabled.
+*   Use Doris RBAC as the final data authorization boundary and grant Doris users only the data they should inspect.
+*   Do not log Doris passwords, authorization headers, access tokens, refresh tokens, authorization codes, PKCE verifiers, or client secrets.
+*   Treat the `doa_` prefix as reserved for Doris-backed OAuth access tokens; static tokens and JWT bearer values must not use it.
+*   Keep Dynamic Client Registration in `auto` for loopback development or explicitly configure production DCR with `ENABLE_DORIS_OAUTH_PRODUCTION_DCR=true`.
 
 ### Token-Bound Database Configuration (New in v0.6.0)
 
@@ -715,6 +798,7 @@ sensitive_tables = {
 4. **🛡️ Input Validation**: All SQL queries are automatically validated
 5. **🎭 Data Classification**: Properly classify data with security levels
 6. **🔄 Regular Updates**: Keep security rules and configurations updated
+7. **Doris-backed OAuth Hardening**: Use HTTPS, keep external OAuth disabled in this mode, keep `WORKERS=1`, rely on Doris RBAC for MySQL-channel data access, and expose only operations that are configured and verified to use the logged-in Doris user's credentials.
 
 ### Security Monitoring
 
@@ -1468,6 +1552,20 @@ cat logs/doris_mcp_server_critical.log
    curl -H "Authorization: Bearer tenant_alpha_secure_token_123" http://localhost:3000/mcp
    curl -H "Authorization: Bearer tenant_beta_secure_token_456" http://localhost:3000/mcp
    ```
+
+### Q: How is Doris-backed OAuth different from external OAuth/OIDC?
+
+**A:** External OAuth/OIDC delegates identity to an external provider such as Google, Azure AD, GitHub, GitLab, or Keycloak. Doris-backed OAuth is issued by this MCP server after the user signs in with Doris credentials. The server validates the Doris username/password, creates a per-user Doris connection pool, issues `doa_` access and refresh tokens, and lets Doris RBAC decide what data and metadata that user can access.
+
+These modes are mutually exclusive on one MCP URL. Do not enable `ENABLE_DORIS_OAUTH_AUTH=true` together with `ENABLE_OAUTH_AUTH=true`, `OAUTH_ENABLED=true`, or `AUTH_TYPE=oauth`; startup fails fast if both OAuth modes are configured.
+
+Doris-backed OAuth currently exposes MCP resources with disabled resources metadata cache. It exposes reviewed metadata tools when `DORIS_OAUTH_DB_TOOLS_ENABLED=true`, `exec_query` when `DORIS_OAUTH_QUERY_TOOLS_ENABLED=true`, and SQL explain when `DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED=true`. Normal clients do not need to pass a long scope list; omitted OAuth scope grants the configured Doris OAuth capability envelope. Doris RBAC remains the final data authorization backend for these MySQL-channel operations.
+
+### Q: Can Doris-backed OAuth run with multiple workers or multiple nodes?
+
+**A:** Not in the current implementation. Doris-backed OAuth uses a memory-only OAuth store and process-local per-user Doris pools. Access tokens, refresh tokens, authorization codes, DCR clients, and pools are not shared between workers, processes, or nodes.
+
+Use `WORKERS=1` with Doris-backed OAuth. `WORKERS=0` expands to CPU count and fails because it would create multiple effective workers. Stateless horizontal scaling, shared token storage, shared encrypted Doris credentials, sticky-session recovery, and pool reconstruction are future designs, not current capabilities.
 
 ### Q: How does Hot Reload work and is it safe? (New in v0.6.0)
 

--- a/doris_mcp_server/auth/__init__.py
+++ b/doris_mcp_server/auth/__init__.py
@@ -32,6 +32,8 @@ from .oauth_types import (
     OAuthProvider, OAuthState, OAuthTokens, OAuthUserInfo,
     OIDCDiscovery, OAuthError, OAuthProviderConfig
 )
+from .doris_oauth_provider import DorisOAuthProvider
+from .doris_oauth_store import DorisOAuthStore
 
 __all__ = [
     "JWTManager",
@@ -52,5 +54,7 @@ __all__ = [
     "OAuthUserInfo",
     "OIDCDiscovery",
     "OAuthError",
-    "OAuthProviderConfig"
+    "OAuthProviderConfig",
+    "DorisOAuthProvider",
+    "DorisOAuthStore",
 ]

--- a/doris_mcp_server/auth/auth_middleware.py
+++ b/doris_mcp_server/auth/auth_middleware.py
@@ -125,7 +125,9 @@ class AuthMiddleware:
                 session_id=payload.get('jti'),  # Use JWT ID as session ID
                 login_time=datetime.fromtimestamp(payload.get('iat', 0)),
                 last_activity=datetime.utcnow(),
-                token=token  # Store raw token for token-bound database configuration
+                token="",
+                auth_method="jwt",
+                pool_key="global",
             )
             
             logger.info(f"JWT authentication successful for user: {auth_context.user_id}")

--- a/doris_mcp_server/auth/doris_oauth_handlers.py
+++ b/doris_mcp_server/auth/doris_oauth_handlers.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Starlette handlers and response adapters for Doris-backed OAuth."""
+
+import html
+import ipaddress
+import time
+from urllib.parse import urlencode
+
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
+from starlette.routing import Route
+
+from .doris_oauth_rate_limit import rate_limited_response
+from .doris_oauth_types import (
+    AuthorizeError,
+    DorisOAuthError,
+    ProtectedResourceAuthError,
+    RevocationEndpointError,
+    TokenEndpointError,
+)
+
+
+LOGIN_CSRF_COOKIE = "doris_oauth_login_csrf"
+
+
+def _oauth_error_payload(error: DorisOAuthError) -> dict[str, str]:
+    return {
+        "error": error.error,
+        "error_description": error.description,
+    }
+
+
+def protected_resource_challenge_header(
+    base_url: str,
+    *,
+    challenge_error: str = "invalid_token",
+    scope: str = "tool:list",
+) -> str:
+    resource_metadata = f"{base_url.rstrip('/')}/.well-known/oauth-protected-resource"
+    return (
+        f'Bearer error="{challenge_error}", '
+        f'resource_metadata="{resource_metadata}", scope="{scope}"'
+    )
+
+
+def protected_resource_error_response(error: Exception, base_url: str) -> JSONResponse:
+    if isinstance(error, ProtectedResourceAuthError):
+        challenge_error = error.challenge_error
+        scope = error.required_scope or "tool:list"
+        body = {
+            "error": error.error,
+            "error_description": error.description,
+        }
+        if error.error_code:
+            body["error_code"] = error.error_code
+        status_code = error.status_code
+    else:
+        challenge_error = "invalid_token"
+        scope = "tool:list"
+        body = {
+            "error": "authentication_required",
+            "error_description": str(error) or "Authentication required",
+        }
+        status_code = 401
+    return JSONResponse(
+        body,
+        status_code=status_code,
+        headers={
+            "WWW-Authenticate": protected_resource_challenge_header(
+                base_url,
+                challenge_error=challenge_error,
+                scope=scope,
+            )
+        },
+    )
+
+
+def insufficient_scope_response(base_url: str, required_scope: str | None, body: dict) -> JSONResponse:
+    return JSONResponse(
+        body,
+        status_code=403,
+        headers={
+            "WWW-Authenticate": protected_resource_challenge_header(
+                base_url,
+                challenge_error="insufficient_scope",
+                scope=required_scope or "tool:list",
+            )
+        },
+    )
+
+
+def authorize_error_response(error: AuthorizeError) -> Response:
+    if error.redirect_allowed and error.redirect_uri:
+        params = {"error": error.error, "error_description": error.description}
+        if error.state:
+            params["state"] = error.state
+        separator = "&" if "?" in error.redirect_uri else "?"
+        return RedirectResponse(f"{error.redirect_uri}{separator}{urlencode(params)}", status_code=302)
+    return HTMLResponse(
+        f"<html><body><h1>OAuth Error</h1><p>{html.escape(error.error)}</p></body></html>",
+        status_code=error.status_code,
+    )
+
+
+def token_error_response(error: TokenEndpointError) -> JSONResponse:
+    headers = {}
+    if error.www_authenticate:
+        headers["WWW-Authenticate"] = error.www_authenticate
+    payload = _oauth_error_payload(error)
+    if error.error_code and error.error_code != error.error:
+        payload["error_code"] = error.error_code
+    return JSONResponse(payload, status_code=error.status_code, headers=headers)
+
+
+def revoke_error_response(error: RevocationEndpointError) -> JSONResponse:
+    return JSONResponse(_oauth_error_payload(error), status_code=error.status_code)
+
+
+class DorisOAuthHandlers:
+    def __init__(self, provider):
+        self.provider = provider
+        self.security_config = provider.security_config
+
+    def routes(self) -> list[Route]:
+        routes = [
+            Route("/.well-known/oauth-protected-resource", self.protected_resource_metadata, methods=["GET"]),
+            Route("/.well-known/oauth-authorization-server", self.authorization_server_metadata, methods=["GET"]),
+            Route("/oauth/authorize", self.authorize, methods=["GET"]),
+            Route("/oauth/token", self.token, methods=["POST"]),
+            Route("/oauth/revoke", self.revoke, methods=["POST"]),
+            Route("/doris-login", self.login, methods=["GET", "POST"]),
+            Route("/api/auth/token", self.api_token, methods=["POST"]),
+            Route("/api/auth/refresh", self.api_refresh, methods=["POST"]),
+        ]
+        if self.provider.dcr_enabled():
+            routes.append(Route("/oauth/register", self.register, methods=["POST"]))
+        return routes
+
+    async def protected_resource_metadata(self, request: Request) -> JSONResponse:
+        return JSONResponse(self.provider.protected_resource_metadata())
+
+    async def authorization_server_metadata(self, request: Request) -> JSONResponse:
+        return JSONResponse(self.provider.authorization_server_metadata())
+
+    async def register(self, request: Request) -> JSONResponse:
+        ip = self._client_ip(request)
+        if not self._limit("oauth_register_ip", ip, self.security_config.doris_oauth_dcr_rate_limit_per_ip):
+            return rate_limited_response()
+        try:
+            payload = await request.json()
+            response = await self.provider.register_client(payload, client_ip=ip)
+            return JSONResponse(response, status_code=201)
+        except TokenEndpointError as exc:
+            return token_error_response(exc)
+        except Exception:
+            return JSONResponse({"error": "server_error"}, status_code=500)
+
+    async def authorize(self, request: Request) -> Response:
+        ip = self._client_ip(request)
+        if not self._limit("oauth_authorize_ip", ip, self.security_config.doris_oauth_authorize_rate_limit_per_ip):
+            return rate_limited_response()
+        try:
+            redirect_path = await self.provider.create_authorization_transaction(
+                dict(request.query_params),
+                client_ip=ip,
+            )
+            return RedirectResponse(redirect_path, status_code=302)
+        except AuthorizeError as exc:
+            return authorize_error_response(exc)
+
+    async def login(self, request: Request) -> Response:
+        if request.method == "GET":
+            return await self._login_get(request)
+        return await self._login_post(request)
+
+    async def _login_get(self, request: Request) -> Response:
+        txn_id = request.query_params.get("txn_id") or ""
+        record = self.provider.get_login_transaction(txn_id)
+        if not record:
+            return self._login_error("Login session expired or invalid")
+        csrf, record = self.provider.prepare_login_csrf(txn_id)
+        max_age = max(1, int(min(
+            self.security_config.doris_oauth_auth_code_expire_seconds,
+            record.expires_at - time.time(),
+        )))
+        response = HTMLResponse(self._render_login_html(txn_id, csrf), status_code=200)
+        response.set_cookie(
+            LOGIN_CSRF_COOKIE,
+            csrf,
+            max_age=max_age,
+            expires=max_age,
+            path="/doris-login",
+            httponly=True,
+            samesite="lax",
+            secure=self.provider.issuer.startswith("https://"),
+        )
+        return response
+
+    async def _login_post(self, request: Request) -> Response:
+        form = await request.form()
+        ip = self._client_ip(request)
+        username = str(form.get("username") or "")
+        txn_id = str(form.get("txn_id") or "")
+        csrf = str(form.get("login_csrf") or "")
+        record = self.provider.get_login_transaction(txn_id)
+        client_id = record.client_id if record else "unknown"
+        txn_key = self.provider.store.hmac_lookup(txn_id, "txn") if txn_id else "missing"
+        user_key = self.provider.store.hash_public_value(username or "missing")
+        checks = [
+            ("login_ip", ip, self.security_config.doris_oauth_login_rate_limit_per_ip),
+            ("login_user", user_key, self.security_config.doris_oauth_login_rate_limit_per_user),
+            ("login_client", client_id, self.security_config.doris_oauth_login_rate_limit_per_client),
+            ("login_txn", txn_key, self.security_config.doris_oauth_login_rate_limit_per_txn),
+        ]
+        if any(not self._limit(bucket, key, limit) for bucket, key, limit in checks):
+            return rate_limited_response()
+        if request.cookies.get(LOGIN_CSRF_COOKIE) != csrf:
+            return self._login_error("Login session expired or invalid")
+        try:
+            redirect_uri = await self.provider.complete_login(
+                txn_id,
+                username,
+                str(form.get("password") or ""),
+                csrf,
+            )
+            return RedirectResponse(redirect_uri, status_code=302)
+        except TokenEndpointError:
+            return self._login_error("Invalid username or password", txn_id=txn_id, csrf=csrf)
+        except Exception:
+            return self._login_error("Invalid username or password", txn_id=txn_id, csrf=csrf)
+
+    def _render_login_html(
+        self,
+        txn_id: str,
+        csrf: str,
+        *,
+        error_message: str = "",
+    ) -> str:
+        title = "doris"
+        error_html = ""
+        if error_message:
+            error_html = (
+                '<div class="error" role="alert">'
+                f"{html.escape(error_message)}"
+                "</div>"
+            )
+        return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style>
+  :root {{
+    color-scheme: light;
+    --bg: #f5f5f5;
+    --card: #ffffff;
+    --text: #333333;
+    --muted: #666666;
+    --border: #dddddd;
+    --focus: #4a90d9;
+    --focus-ring: rgba(74, 144, 217, 0.2);
+    --button: #4a90d9;
+    --button-hover: #357abd;
+    --error-text: #dc3545;
+    --error-bg: #f8d7da;
+    --error-border: #f5c6cb;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{
+    min-height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  }}
+  .card {{
+    width: 100%;
+    max-width: 380px;
+    padding: 32px;
+    background: var(--card);
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }}
+  h2 {{
+    margin: 0 0 6px;
+    text-align: center;
+    color: var(--text);
+    font-size: 20px;
+    font-weight: 600;
+  }}
+  .subtitle {{
+    margin: 0 0 24px;
+    text-align: center;
+    color: var(--muted);
+    font-size: 14px;
+  }}
+  label {{
+    display: block;
+    margin-bottom: 6px;
+    color: #555555;
+    font-size: 14px;
+  }}
+  input[type=text],
+  input[type=password] {{
+    width: 100%;
+    margin-bottom: 16px;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 14px;
+  }}
+  input[type=text]:focus,
+  input[type=password]:focus {{
+    outline: none;
+    border-color: var(--focus);
+    box-shadow: 0 0 0 2px var(--focus-ring);
+  }}
+  button {{
+    width: 100%;
+    padding: 10px;
+    border: 0;
+    border-radius: 4px;
+    background: var(--button);
+    color: #ffffff;
+    font-size: 16px;
+    cursor: pointer;
+  }}
+  button:hover {{ background: var(--button-hover); }}
+  .error {{
+    margin-bottom: 16px;
+    padding: 10px;
+    border: 1px solid var(--error-border);
+    border-radius: 4px;
+    background: var(--error-bg);
+    color: var(--error-text);
+    font-size: 14px;
+  }}
+</style>
+</head>
+<body>
+<div class="card">
+  <h2>{title}</h2>
+  <p class="subtitle">Doris account login</p>
+  {error_html}
+  <form method="POST" action="/doris-login">
+    <input type="hidden" name="txn_id" value="{html.escape(txn_id)}">
+    <input type="hidden" name="login_csrf" value="{html.escape(csrf)}">
+    <label for="username">Doris Username</label>
+    <input type="text" id="username" name="username" required autocomplete="username">
+    <label for="password">Doris Password</label>
+    <input type="password" id="password" name="password" required autocomplete="current-password">
+    <button type="submit">Login</button>
+  </form>
+</div>
+</body>
+</html>"""
+
+    async def token(self, request: Request) -> JSONResponse:
+        ip = self._client_ip(request)
+        form = await request.form()
+        payload = dict(form)
+        client_key = payload.get("client_id") or "unknown"
+        if not self._limit("oauth_token_ip", ip, self.security_config.doris_oauth_token_rate_limit_per_ip):
+            return rate_limited_response()
+        if not self._limit("oauth_token_client", client_key, self.security_config.doris_oauth_token_rate_limit_per_client):
+            return rate_limited_response()
+        try:
+            grant_type = payload.get("grant_type")
+            if grant_type == "authorization_code":
+                return JSONResponse(await self.provider.exchange_code(payload))
+            if grant_type == "refresh_token":
+                refresh_key = self.provider.store.hmac_lookup(payload.get("refresh_token", ""), "refresh")
+                if not self._limit("oauth_token_refresh", refresh_key, self.security_config.doris_oauth_token_rate_limit_per_client):
+                    return rate_limited_response()
+                return JSONResponse(await self.provider.refresh_token(payload))
+            raise TokenEndpointError("unsupported_grant_type", "Unsupported grant type", status_code=400)
+        except TokenEndpointError as exc:
+            return token_error_response(exc)
+
+    async def revoke(self, request: Request) -> Response:
+        ip = self._client_ip(request)
+        if not self._limit("oauth_revoke_ip", ip, self.security_config.doris_oauth_revoke_rate_limit_per_ip):
+            return rate_limited_response()
+        form = await request.form()
+        payload = dict(form)
+        revoke_client_key = payload.get("client_id")
+        if not revoke_client_key:
+            revoke_client_key = self.provider.store.hmac_lookup(payload.get("token", ""), "revoke_token")
+        if not self._limit(
+            "oauth_revoke_client",
+            str(revoke_client_key or "unknown"),
+            self.security_config.doris_oauth_revoke_rate_limit_per_client,
+        ):
+            return rate_limited_response()
+        try:
+            await self.provider.revoke(payload)
+            return Response(status_code=200)
+        except RevocationEndpointError as exc:
+            return revoke_error_response(exc)
+
+    async def api_token(self, request: Request) -> JSONResponse:
+        ip = self._client_ip(request)
+        payload = await request.json()
+        username = str(payload.get("username") or "")
+        user_key = self.provider.store.hash_public_value(username or "missing")
+        if not self._limit("api_auth_token_ip", ip, self.security_config.doris_oauth_api_auth_token_rate_limit_per_ip):
+            return rate_limited_response()
+        if not self._limit("api_auth_token_user", user_key, self.security_config.doris_oauth_api_auth_token_rate_limit_per_user):
+            return rate_limited_response()
+        try:
+            response = await self.provider.issue_cli_token(
+                username,
+                str(payload.get("password") or ""),
+                payload.get("scope"),
+            )
+            return JSONResponse(response)
+        except TokenEndpointError as exc:
+            return token_error_response(exc)
+
+    async def api_refresh(self, request: Request) -> JSONResponse:
+        ip = self._client_ip(request)
+        payload = await request.json()
+        refresh_key = self.provider.store.hmac_lookup(payload.get("refresh_token", ""), "refresh")
+        if not self._limit("api_auth_refresh_ip", ip, self.security_config.doris_oauth_api_auth_refresh_rate_limit_per_ip):
+            return rate_limited_response()
+        if not self._limit("api_auth_refresh_token", refresh_key, self.security_config.doris_oauth_api_auth_refresh_rate_limit_per_client):
+            return rate_limited_response()
+        try:
+            refresh = self.provider.store.get_refresh_token(str(payload.get("refresh_token") or ""))
+            if not refresh:
+                raise TokenEndpointError("invalid_grant", "Refresh token is invalid or expired", status_code=400)
+            if "client_id" not in payload:
+                payload["client_id"] = refresh.client_id
+            return JSONResponse(await self.provider.refresh_token(payload))
+        except TokenEndpointError as exc:
+            return token_error_response(exc)
+
+    def _login_error(self, message: str, *, txn_id: str = "", csrf: str = "") -> HTMLResponse:
+        if txn_id and csrf:
+            return HTMLResponse(
+                self._render_login_html(txn_id, csrf, error_message=message),
+                status_code=400,
+            )
+        return HTMLResponse(
+            f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>doris</title>
+<style>
+  body {{
+    min-height: 100vh;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f5f5f5;
+    color: #333333;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  }}
+  .card {{
+    width: 100%;
+    max-width: 380px;
+    padding: 32px;
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    text-align: center;
+  }}
+  h2 {{ margin: 0 0 12px; font-size: 20px; }}
+  p {{ margin: 0; color: #666666; font-size: 14px; }}
+</style>
+</head>
+<body>
+<div class="card">
+  <h2>doris</h2>
+  <p>{html.escape(message)}</p>
+</div>
+</body>
+</html>""",
+            status_code=400,
+        )
+
+    def _client_ip(self, request: Request) -> str:
+        socket_ip = request.client.host if request.client else "unknown"
+        if not getattr(self.security_config, "doris_oauth_trust_proxy_headers", False):
+            return socket_ip
+        trusted_cidrs = getattr(self.security_config, "doris_oauth_trusted_proxy_cidrs", [])
+        if not self._ip_in_trusted_proxy(socket_ip, trusted_cidrs):
+            return socket_ip
+        forwarded_for = request.headers.get("x-forwarded-for", "")
+        first_hop = forwarded_for.split(",", 1)[0].strip()
+        return first_hop or socket_ip
+
+    def _ip_in_trusted_proxy(self, ip_value: str, trusted_cidrs: list[str]) -> bool:
+        try:
+            address = ipaddress.ip_address(ip_value)
+        except ValueError:
+            return False
+        for cidr in trusted_cidrs:
+            try:
+                if address in ipaddress.ip_network(cidr, strict=False):
+                    return True
+            except ValueError:
+                continue
+        return False
+
+    def _limit(self, bucket: str, key: str, limit: int) -> bool:
+        return self.provider.rate_limiter.check(bucket, key, limit).allowed
+
+
+def build_doris_oauth_routes(provider) -> list[Route]:
+    return DorisOAuthHandlers(provider).routes()

--- a/doris_mcp_server/auth/doris_oauth_provider.py
+++ b/doris_mcp_server/auth/doris_oauth_provider.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""Doris-backed OAuth provider core logic."""
+
+import asyncio
+import base64
+import hashlib
+import secrets
+import time
+from datetime import UTC, datetime
+from urllib.parse import urlencode
+
+from ..utils.logger import get_logger
+from ..utils.security import AuthContext, RESERVED_DORIS_OAUTH_TOKEN_PREFIX, SecurityLevel
+from .doris_oauth_redirects import DorisOAuthRedirectPolicy, is_loopback_url
+from .doris_oauth_rate_limit import DorisOAuthRateLimiter
+from .doris_oauth_scope_policy import DorisOAuthScopePolicy
+from .doris_oauth_store import DorisOAuthStore
+from .doris_oauth_types import (
+    AccessTokenRecord,
+    AuthTransactionRecord,
+    AuthorizeError,
+    ProtectedResourceAuthError,
+    RefreshTokenRecord,
+    RevocationEndpointError,
+    TokenEndpointError,
+)
+
+
+class DorisOAuthProvider:
+    """Memory-only Doris OAuth provider."""
+
+    def __init__(self, config, store: DorisOAuthStore | None = None):
+        self.config = config
+        self.security_config = config.security
+        self.effective_auth = getattr(config, "effective_auth", None)
+        self.store = store or DorisOAuthStore()
+        self.scope_policy = DorisOAuthScopePolicy(self.security_config)
+        self.redirect_policy = DorisOAuthRedirectPolicy(
+            allow_production_wildcards=getattr(
+                self.security_config,
+                "enable_doris_oauth_production_wildcard_redirects",
+                False,
+            )
+        )
+        self.rate_limiter = DorisOAuthRateLimiter(
+            getattr(self.security_config, "doris_oauth_rate_limit_window_seconds", 300)
+        )
+        self.connection_manager = None
+        self._lock = asyncio.Lock()
+        self.logger = get_logger(__name__)
+
+    @property
+    def issuer(self) -> str:
+        return self.security_config.doris_oauth_base_url.rstrip("/")
+
+    @property
+    def resource(self) -> str:
+        return f"{self.issuer}/mcp"
+
+    def configure_connection_manager(self, connection_manager) -> None:
+        self.connection_manager = connection_manager
+
+    async def shutdown(self) -> None:
+        return None
+
+    def dcr_enabled(self) -> bool:
+        mode = getattr(self.security_config, "doris_oauth_dynamic_client_registration_mode", "auto")
+        if mode == "disabled":
+            return False
+        if mode == "enabled":
+            return True
+        return is_loopback_url(self.issuer)
+
+    def protected_resource_metadata(self) -> dict:
+        return {
+            "resource": self.resource,
+            "authorization_servers": [self.issuer],
+            "scopes_supported": sorted(self.scope_policy.server_allowed_scopes),
+            "bearer_methods_supported": ["header"],
+        }
+
+    def authorization_server_metadata(self) -> dict:
+        metadata = {
+            "issuer": self.issuer,
+            "authorization_endpoint": f"{self.issuer}/oauth/authorize",
+            "token_endpoint": f"{self.issuer}/oauth/token",
+            "revocation_endpoint": f"{self.issuer}/oauth/revoke",
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["authorization_code", "refresh_token"],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["none", "client_secret_post"],
+        }
+        if self.dcr_enabled():
+            metadata["registration_endpoint"] = f"{self.issuer}/oauth/register"
+        return metadata
+
+    async def register_client(self, payload: dict, *, client_ip: str) -> dict:
+        if not self.dcr_enabled():
+            raise TokenEndpointError("invalid_request", "Dynamic client registration is disabled", status_code=404)
+
+        grant_types = payload.get("grant_types") or ["authorization_code", "refresh_token"]
+        if any(grant not in {"authorization_code", "refresh_token"} for grant in grant_types):
+            raise TokenEndpointError("invalid_client_metadata", "Unsupported grant type", status_code=400)
+        response_types = payload.get("response_types") or ["code"]
+        if response_types != ["code"]:
+            raise TokenEndpointError("invalid_client_metadata", "Unsupported response type", status_code=400)
+
+        redirect_uris = self.redirect_policy.validate_redirect_uris(payload.get("redirect_uris") or [], source="dcr")
+        requested_scope = payload.get("scope")
+        requested_scopes = self.scope_policy.parse_scope(requested_scope)
+        if requested_scopes:
+            scopes = self.scope_policy.grant_client_scopes(requested_scope, explicit=True)
+        else:
+            scopes = tuple(sorted(self.scope_policy.server_allowed_scopes))
+        token_auth_method = payload.get("token_endpoint_auth_method") or "none"
+        if token_auth_method not in {"none", "client_secret_post"}:
+            raise TokenEndpointError("invalid_client_metadata", "Unsupported token endpoint auth method", status_code=400)
+
+        async with self._lock:
+            self.store.cleanup_expired()
+            dcr_clients = [
+                client for client in self.store.clients_by_id.values() if client.source == "dcr"
+            ]
+            if len(dcr_clients) >= getattr(self.security_config, "doris_oauth_dcr_max_clients", 1000):
+                raise TokenEndpointError("invalid_request", "Dynamic client registration capacity exceeded", status_code=400)
+
+            client_id = f"dcr_{secrets.token_urlsafe(16)}"
+            client_secret = (
+                f"dos_{secrets.token_urlsafe(32)}"
+                if token_auth_method == "client_secret_post"
+                else None
+            )
+            ttl = getattr(self.security_config, "doris_oauth_dcr_client_ttl_seconds", 86400)
+            expires_at = time.time() + ttl if ttl else None
+            record = self.store.add_client(
+                client_id=client_id,
+                client_secret=client_secret,
+                token_endpoint_auth_method=token_auth_method,
+                redirect_uris=redirect_uris,
+                client_allowed_scopes=scopes,
+                source="dcr",
+                expires_at=expires_at,
+                registration_ip=client_ip,
+            )
+
+        response = {
+            "client_id": record.client_id,
+            "redirect_uris": list(record.redirect_uris),
+            "scope": " ".join(record.client_allowed_scopes),
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": record.token_endpoint_auth_method,
+            "client_id_issued_at": int(record.created_at),
+        }
+        if record.expires_at is not None:
+            response["client_secret_expires_at"] = int(record.expires_at)
+        if client_secret:
+            response["client_secret"] = client_secret
+        return response
+
+    async def create_authorization_transaction(self, params: dict, *, client_ip: str) -> str:
+        state = str(params.get("state") or "")
+        client_id = str(params.get("client_id") or "")
+        redirect_uri = params.get("redirect_uri")
+        client = self.store.get_client(client_id)
+        if not client:
+            raise AuthorizeError("invalid_request", "Invalid client", redirect_allowed=False)
+
+        try:
+            redirect = self.redirect_policy.choose_redirect_uri(client.redirect_uris, redirect_uri)
+        except TokenEndpointError as exc:
+            raise AuthorizeError(exc.error, exc.description, redirect_allowed=False) from exc
+
+        if params.get("response_type") != "code":
+            raise AuthorizeError("unsupported_response_type", "response_type must be code", redirect_uri=redirect, state=state, redirect_allowed=True)
+        if not state:
+            raise AuthorizeError("invalid_request", "state is required", redirect_uri=redirect, redirect_allowed=False)
+        code_challenge = str(params.get("code_challenge") or "")
+        if not code_challenge or params.get("code_challenge_method") != "S256":
+            raise AuthorizeError("invalid_request", "S256 PKCE is required", redirect_uri=redirect, state=state, redirect_allowed=True)
+
+        resource = str(params.get("resource") or self.resource)
+        if resource not in {self.resource, self.issuer}:
+            raise AuthorizeError("invalid_target", "Invalid resource", redirect_uri=redirect, state=state, redirect_allowed=True)
+
+        try:
+            scope_explicit = "scope" in params
+            scopes = self.scope_policy.grant_authorized_scopes(
+                params.get("scope"),
+                client_allowed_scopes=client.client_allowed_scopes,
+                explicit=scope_explicit,
+            )
+        except TokenEndpointError as exc:
+            raise AuthorizeError(exc.error, exc.description, redirect_uri=redirect, state=state, redirect_allowed=True) from exc
+
+        ttl = getattr(self.security_config, "doris_oauth_auth_code_expire_seconds", 300)
+        async with self._lock:
+            txn_id, _record = self.store.create_auth_transaction(
+                client_id=client.client_id,
+                redirect_uri=redirect,
+                state=state,
+                code_challenge=code_challenge,
+                requested_scopes=self.scope_policy.parse_scope(params.get("scope")),
+                candidate_granted_scopes=scopes,
+                resource=resource,
+                client_ip=client_ip,
+                ttl_seconds=ttl,
+            )
+        return f"/doris-login?{urlencode({'txn_id': txn_id})}"
+
+    def get_login_transaction(self, txn_id: str) -> AuthTransactionRecord | None:
+        return self.store.get_auth_transaction(txn_id)
+
+    def prepare_login_csrf(self, txn_id: str) -> tuple[str, AuthTransactionRecord]:
+        csrf = f"dcsrf_{secrets.token_urlsafe(32)}"
+        record = self.store.set_transaction_csrf(txn_id, csrf)
+        if not record:
+            raise TokenEndpointError("invalid_request", "Login session expired or invalid", status_code=400)
+        return csrf, record
+
+    async def complete_login(self, txn_id: str, username: str, password: str, csrf_value: str) -> str:
+        if not username or not password:
+            raise TokenEndpointError("invalid_request", "Invalid username or password", status_code=400)
+        record = self.store.get_auth_transaction(txn_id)
+        if not record or not self.store.validate_transaction_csrf(txn_id, csrf_value):
+            raise TokenEndpointError("invalid_request", "Login session expired or invalid", status_code=400)
+        if not self.connection_manager:
+            raise TokenEndpointError("server_error", "Doris OAuth provider is not ready", status_code=500)
+
+        await self.connection_manager.create_or_replace_doris_user_pool(username, password)
+        code, _code_record = self.store.create_authorization_code(
+            client_id=record.client_id,
+            doris_user=username,
+            redirect_uri=record.redirect_uri,
+            scopes=record.candidate_granted_scopes,
+            resource=record.resource,
+            code_challenge=record.code_challenge,
+            code_challenge_method=record.code_challenge_method,
+            ttl_seconds=getattr(self.security_config, "doris_oauth_auth_code_expire_seconds", 300),
+        )
+        self.store.delete_auth_transaction(txn_id)
+        return self._redirect_with_params(record.redirect_uri, {"code": code, "state": record.state})
+
+    async def exchange_code(self, payload: dict) -> dict:
+        client = self._authenticate_token_client(payload)
+        code = payload.get("code")
+        if not code:
+            raise TokenEndpointError("invalid_request", "Missing authorization code", status_code=400)
+        record = self.store.pop_authorization_code(str(code))
+        if not record:
+            raise TokenEndpointError("invalid_grant", "Authorization code is invalid or expired", status_code=400)
+        if record.client_id != client.client_id:
+            raise TokenEndpointError("invalid_grant", "Authorization code is invalid or expired", status_code=400)
+        if payload.get("redirect_uri") != record.redirect_uri:
+            raise TokenEndpointError("invalid_grant", "Authorization code is invalid or expired", status_code=400)
+        if not self._verify_pkce(record.code_challenge, payload.get("code_verifier") or ""):
+            raise TokenEndpointError("invalid_grant", "Authorization code is invalid or expired", status_code=400)
+        if payload.get("scope"):
+            requested = set(self.scope_policy.parse_scope(payload.get("scope")))
+            if not requested <= set(record.scopes):
+                raise TokenEndpointError("invalid_scope", "Requested scope cannot exceed the authorization grant", status_code=400)
+
+        async with self._lock:
+            pair = self.store.issue_token_pair(
+                client_id=record.client_id,
+                doris_user=record.doris_user,
+                scopes=record.scopes,
+                resource=record.resource,
+                access_ttl_seconds=getattr(self.security_config, "doris_oauth_access_token_expire_seconds", 900),
+                refresh_ttl_seconds=getattr(self.security_config, "doris_oauth_refresh_token_expire_seconds", 86400),
+            )
+        return self._token_response(pair.access_token, pair.refresh_token, record.scopes)
+
+    async def refresh_token(self, payload: dict) -> dict:
+        client = self._authenticate_token_client(payload)
+        raw_refresh = payload.get("refresh_token")
+        if not raw_refresh:
+            raise TokenEndpointError("invalid_request", "Missing refresh token", status_code=400)
+        async with self._lock:
+            refresh = self.store.get_refresh_token(str(raw_refresh))
+            if not refresh or refresh.revoked_at is not None or refresh.client_id != client.client_id:
+                raise TokenEndpointError("invalid_grant", "Refresh token is invalid or expired", status_code=400)
+            scopes = self.scope_policy.validate_refresh_scope(payload.get("scope"), refresh.scopes)
+            if not self.connection_manager or not self.connection_manager.has_doris_user_pool(refresh.doris_user):
+                self.store.revoke_family_by_refresh_token_id(refresh.token_id)
+                raise TokenEndpointError(
+                    "login_required",
+                    "Doris login is required",
+                    status_code=401,
+                    error_code="DORIS_OAUTH_POOL_MISSING",
+                )
+
+            self.store.revoke_pair_for_refresh_id(refresh.token_id)
+            pair = self.store.issue_token_pair(
+                client_id=refresh.client_id,
+                doris_user=refresh.doris_user,
+                scopes=scopes,
+                resource=refresh.resource,
+                access_ttl_seconds=getattr(self.security_config, "doris_oauth_access_token_expire_seconds", 900),
+                refresh_ttl_seconds=getattr(self.security_config, "doris_oauth_refresh_token_expire_seconds", 86400),
+                family_id=refresh.family_id,
+                rotated_from=refresh.token_id,
+            )
+        return self._token_response(pair.access_token, pair.refresh_token, scopes)
+
+    async def revoke(self, payload: dict) -> None:
+        raw_token = payload.get("token")
+        if not raw_token:
+            raise RevocationEndpointError("invalid_request", "Missing token", status_code=400)
+        request_client_id = payload.get("client_id")
+        if request_client_id:
+            request_client = self.store.get_client(str(request_client_id))
+            if not request_client:
+                raise RevocationEndpointError("invalid_client", "Invalid client authentication", status_code=401)
+            if not self.store.validate_client_secret(request_client, payload.get("client_secret")):
+                raise RevocationEndpointError("invalid_client", "Invalid client authentication", status_code=401)
+        record = self.store.find_access_or_refresh(str(raw_token))
+        if record:
+            client = self.store.get_client(record.client_id)
+            if client and client.token_endpoint_auth_method != "none":
+                if request_client_id and request_client_id != record.client_id:
+                    raise RevocationEndpointError("invalid_client", "Invalid client authentication", status_code=401)
+                if not request_client_id and not self.store.validate_client_secret(client, payload.get("client_secret")):
+                    raise RevocationEndpointError("invalid_client", "Invalid client authentication", status_code=401)
+        async with self._lock:
+            self.store.revoke_token(str(raw_token))
+            await self._cleanup_inactive_pools()
+
+    async def issue_cli_token(self, username: str, password: str, scope: str | None) -> dict:
+        if not username or not password:
+            raise TokenEndpointError("invalid_request", "Invalid username or password", status_code=400)
+        if not self.connection_manager:
+            raise TokenEndpointError("server_error", "Doris OAuth provider is not ready", status_code=500)
+        client = self._get_or_create_cli_client()
+        scopes = self.scope_policy.grant_authorized_scopes(
+            scope,
+            client_allowed_scopes=client.client_allowed_scopes,
+            explicit=scope is not None and bool(str(scope).strip()),
+        )
+        await self.connection_manager.create_or_replace_doris_user_pool(username, password)
+        async with self._lock:
+            pair = self.store.issue_token_pair(
+                client_id=client.client_id,
+                doris_user=username,
+                scopes=scopes,
+                resource=self.resource,
+                access_ttl_seconds=getattr(self.security_config, "doris_oauth_access_token_expire_seconds", 900),
+                refresh_ttl_seconds=getattr(self.security_config, "doris_oauth_refresh_token_expire_seconds", 86400),
+            )
+        return self._token_response(pair.access_token, pair.refresh_token, scopes)
+
+    async def authenticate_access_token(self, auth_info: dict) -> AuthContext:
+        token = self._extract_bearer(auth_info)
+        if not token or not token.startswith(RESERVED_DORIS_OAUTH_TOKEN_PREFIX):
+            raise ProtectedResourceAuthError("authentication_required", "Missing Doris OAuth access token")
+        record = self.store.get_access_token(token)
+        if not record or record.revoked_at is not None:
+            raise ProtectedResourceAuthError("authentication_required", "Invalid Doris OAuth access token")
+        if not self.connection_manager or not self.connection_manager.has_doris_user_pool(record.doris_user):
+            async with self._lock:
+                self.store.revoke_family_by_access_token_id(record.token_id)
+            raise ProtectedResourceAuthError(
+                "login_required",
+                "Doris login is required",
+                status_code=401,
+                required_scope="tool:list",
+                challenge_error="invalid_token",
+                error_code="DORIS_OAUTH_POOL_MISSING",
+            )
+        updated = self.store.update_access_last_used(record.token_id) or record
+        last_activity = datetime.fromtimestamp(updated.last_used_at or updated.issued_at, UTC)
+        login_time = datetime.fromtimestamp(updated.issued_at, UTC)
+        auth_context = AuthContext(
+            token_id=updated.token_id,
+            user_id=updated.doris_user,
+            roles=["doris_oauth_user"],
+            permissions=["read_data"],
+            security_level=SecurityLevel.INTERNAL,
+            client_ip=auth_info.get("client_ip", "unknown"),
+            session_id=auth_info.get("session_id") or f"doris_oauth:{updated.token_id}",
+            login_time=login_time,
+            last_activity=last_activity,
+            token="",
+            auth_method="doris_oauth",
+            doris_user=updated.doris_user,
+            oauth_client_id=updated.client_id,
+            oauth_scopes=list(updated.scopes),
+            oauth_token_id=updated.token_id,
+            pool_key=f"doris_user:{updated.doris_user}",
+        )
+        auth_context.doris_oauth_db_tools_enabled = bool(
+            getattr(self.security_config, "doris_oauth_db_tools_enabled", False)
+        )
+        auth_context.doris_oauth_db_tool_allowlist = tuple(
+            getattr(self.security_config, "doris_oauth_db_tool_allowlist", ())
+        )
+        auth_context.doris_oauth_query_tools_enabled = bool(
+            getattr(self.security_config, "doris_oauth_query_tools_enabled", False)
+        )
+        auth_context.doris_oauth_query_tool_allowlist = tuple(
+            getattr(self.security_config, "doris_oauth_query_tool_allowlist", ())
+        )
+        auth_context.doris_oauth_explain_tools_enabled = bool(
+            getattr(self.security_config, "doris_oauth_explain_tools_enabled", False)
+        )
+        auth_context.doris_oauth_explain_tool_allowlist = tuple(
+            getattr(self.security_config, "doris_oauth_explain_tool_allowlist", ())
+        )
+        return auth_context
+
+    def _authenticate_token_client(self, payload: dict):
+        client_id = payload.get("client_id")
+        if not client_id:
+            raise TokenEndpointError("invalid_client", "Missing client_id", status_code=401)
+        client = self.store.get_client(str(client_id))
+        if not client:
+            raise TokenEndpointError("invalid_client", "Invalid client authentication", status_code=401)
+        if not self.store.validate_client_secret(client, payload.get("client_secret")):
+            raise TokenEndpointError(
+                "invalid_client",
+                "Invalid client authentication",
+                status_code=401,
+                www_authenticate='Basic realm="doris-oauth"',
+            )
+        return client
+
+    def _get_or_create_cli_client(self):
+        client_id = "cli"
+        client = self.store.get_client(client_id)
+        if client:
+            return client
+        return self.store.add_client(
+            client_id=client_id,
+            client_secret=None,
+            token_endpoint_auth_method="none",
+            redirect_uris=("urn:doris-mcp-cli",),
+            client_allowed_scopes=tuple(sorted(self.scope_policy.server_allowed_scopes)),
+            source="preconfigured",
+            expires_at=None,
+            registration_ip=None,
+        )
+
+    def _token_response(self, access_token: str, refresh_token: str, scopes: tuple[str, ...]) -> dict:
+        return {
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": getattr(self.security_config, "doris_oauth_access_token_expire_seconds", 900),
+            "refresh_token": refresh_token,
+            "refresh_expires_in": getattr(self.security_config, "doris_oauth_refresh_token_expire_seconds", 86400),
+            "scope": " ".join(scopes),
+        }
+
+    def _redirect_with_params(self, uri: str, params: dict[str, str]) -> str:
+        separator = "&" if "?" in uri else "?"
+        return f"{uri}{separator}{urlencode(params)}"
+
+    def _verify_pkce(self, expected_challenge: str, verifier: str) -> bool:
+        if not verifier:
+            return False
+        digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+        return secrets.compare_digest(challenge, expected_challenge)
+
+    def _extract_bearer(self, auth_info: dict) -> str:
+        token = auth_info.get("token") or ""
+        if token:
+            return str(token)
+        authorization = auth_info.get("authorization") or ""
+        if authorization.startswith("Bearer "):
+            return authorization[7:]
+        return ""
+
+    async def _cleanup_inactive_pools(self) -> None:
+        if self.connection_manager and hasattr(self.connection_manager, "cleanup_idle_doris_user_pools"):
+            await self.connection_manager.cleanup_idle_doris_user_pools(self.store.active_users())

--- a/doris_mcp_server/auth/doris_oauth_rate_limit.py
+++ b/doris_mcp_server/auth/doris_oauth_rate_limit.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Small in-memory fixed-window rate limiter for Doris OAuth endpoints."""
+
+import time
+from dataclasses import dataclass
+
+from starlette.responses import JSONResponse
+
+
+@dataclass
+class RateLimitDecision:
+    allowed: bool
+    remaining: int
+    reset_at: float
+
+
+class DorisOAuthRateLimiter:
+    def __init__(self, window_seconds: int = 300):
+        self.window_seconds = max(1, int(window_seconds))
+        self._buckets: dict[tuple[str, str], tuple[int, float]] = {}
+
+    def check(self, bucket: str, key: str, limit: int) -> RateLimitDecision:
+        if limit <= 0:
+            return RateLimitDecision(False, 0, time.time() + self.window_seconds)
+
+        now = time.time()
+        bucket_key = (bucket, key)
+        count, reset_at = self._buckets.get(bucket_key, (0, now + self.window_seconds))
+        if now >= reset_at:
+            count = 0
+            reset_at = now + self.window_seconds
+
+        if count >= limit:
+            self._buckets[bucket_key] = (count, reset_at)
+            return RateLimitDecision(False, 0, reset_at)
+
+        count += 1
+        self._buckets[bucket_key] = (count, reset_at)
+        return RateLimitDecision(True, max(0, limit - count), reset_at)
+
+    def cleanup(self) -> None:
+        now = time.time()
+        expired = [key for key, (_, reset_at) in self._buckets.items() if now >= reset_at]
+        for key in expired:
+            self._buckets.pop(key, None)
+
+
+def rate_limited_response() -> JSONResponse:
+    return JSONResponse({"error": "rate_limited"}, status_code=429)

--- a/doris_mcp_server/auth/doris_oauth_redirects.py
+++ b/doris_mcp_server/auth/doris_oauth_redirects.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Redirect URI policy for Doris-backed OAuth."""
+
+from urllib.parse import urlparse
+
+from .doris_oauth_types import TokenEndpointError
+
+
+LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def is_loopback_host(hostname: str | None) -> bool:
+    return bool(hostname and hostname.lower() in LOOPBACK_HOSTS)
+
+
+def is_loopback_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return is_loopback_host(parsed.hostname)
+
+
+class DorisOAuthRedirectPolicy:
+    """Validate and match OAuth redirect URIs."""
+
+    def __init__(self, allow_production_wildcards: bool = False):
+        self.allow_production_wildcards = allow_production_wildcards
+
+    def validate_redirect_uri(self, uri: str, *, source: str = "dcr") -> str:
+        parsed = urlparse(uri)
+        if not parsed.scheme or not parsed.netloc:
+            raise TokenEndpointError("invalid_redirect_uri", "Redirect URI must be absolute", status_code=400)
+        if parsed.fragment:
+            raise TokenEndpointError("invalid_redirect_uri", "Redirect URI must not contain a fragment", status_code=400)
+        if parsed.username or parsed.password:
+            raise TokenEndpointError("invalid_redirect_uri", "Redirect URI credentials are not allowed", status_code=400)
+        if "*" in uri:
+            if source == "dcr" or not self.allow_production_wildcards:
+                raise TokenEndpointError("invalid_redirect_uri", "Wildcard redirect URI is not allowed", status_code=400)
+        if parsed.scheme == "https":
+            return uri
+        if parsed.scheme == "http" and is_loopback_host(parsed.hostname):
+            return uri
+        raise TokenEndpointError("invalid_redirect_uri", "Redirect URI must use HTTPS", status_code=400)
+
+    def validate_redirect_uris(self, uris: list[str] | tuple[str, ...], *, source: str = "dcr") -> tuple[str, ...]:
+        if not uris:
+            raise TokenEndpointError("invalid_redirect_uri", "At least one redirect URI is required", status_code=400)
+        return tuple(self.validate_redirect_uri(str(uri), source=source) for uri in uris)
+
+    def choose_redirect_uri(self, registered_uris: tuple[str, ...], requested_uri: str | None) -> str:
+        if requested_uri:
+            if requested_uri not in registered_uris:
+                raise TokenEndpointError("invalid_redirect_uri", "Redirect URI is not registered", status_code=400)
+            return requested_uri
+        if len(registered_uris) == 1:
+            return registered_uris[0]
+        raise TokenEndpointError("invalid_request", "redirect_uri is required", status_code=400)

--- a/doris_mcp_server/auth/doris_oauth_scope_policy.py
+++ b/doris_mcp_server/auth/doris_oauth_scope_policy.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Scope issuance policy for Doris-backed OAuth."""
+
+from .doris_oauth_types import TokenEndpointError
+
+
+BASE_DORIS_OAUTH_SCOPES = frozenset({"tool:list"})
+RESOURCE_SCOPES = frozenset({"resource:list", "resource:read"})
+
+DORIS_OAUTH_METADATA_TOOLS = (
+    "get_db_list",
+    "get_db_table_list",
+    "get_table_schema",
+    "get_table_comment",
+    "get_table_column_comments",
+    "get_table_indexes",
+    "get_catalog_list",
+)
+
+METADATA_DB_SCOPES = frozenset(
+    {
+        f"tool:call:{tool_name}" for tool_name in DORIS_OAUTH_METADATA_TOOLS
+    }
+)
+
+QUERY_DB_SCOPES = frozenset({"tool:call:exec_query"})
+EXPLAIN_DB_SCOPES = frozenset({"tool:call:get_sql_explain"})
+PENDING_DB_SCOPES = METADATA_DB_SCOPES | QUERY_DB_SCOPES | EXPLAIN_DB_SCOPES
+TOOL_SCOPE_ALIASES = {
+    tool_name: f"tool:call:{tool_name}"
+    for tool_name in (*DORIS_OAUTH_METADATA_TOOLS, "exec_query", "get_sql_explain")
+}
+
+FORBIDDEN_DORIS_OAUTH_SCOPES = frozenset(
+    {
+        "*",
+        "scope:admin",
+        "scope:service_account",
+        "scope:profile:read",
+        "scope:monitoring:read",
+        "scope:adbc:execute",
+        "scope:audit:read",
+        "scope:governance:read",
+        "scope:performance:read",
+        "prompt:list",
+        "prompt:get",
+    }
+)
+
+
+class DorisOAuthScopePolicy:
+    """Doris OAuth scope issuance policy.
+
+    Doris OAuth binds runtime database access to the logged-in Doris user.
+    Scopes are therefore a client capability envelope, not a replacement for
+    Doris RBAC. When no scope is requested, grant the configured safe server
+    allowlist so standard MCP clients can work without hand-authored scopes.
+    """
+
+    def __init__(self, security_config=None, server_allowed_scopes: set[str] | None = None):
+        if server_allowed_scopes is None:
+            self.server_allowed_scopes = self._build_server_allowed_scopes(security_config)
+        else:
+            self.server_allowed_scopes = set(server_allowed_scopes)
+        self.server_default_scopes = set(self.server_allowed_scopes)
+        self.forbidden_scopes = set(FORBIDDEN_DORIS_OAUTH_SCOPES)
+        self.known_scopes = (
+            set(BASE_DORIS_OAUTH_SCOPES)
+            | set(RESOURCE_SCOPES)
+            | set(PENDING_DB_SCOPES)
+            | set(FORBIDDEN_DORIS_OAUTH_SCOPES)
+        )
+
+    def _build_server_allowed_scopes(self, security_config) -> set[str]:
+        allowed = set(BASE_DORIS_OAUTH_SCOPES)
+        allowed.update(RESOURCE_SCOPES)
+
+        if getattr(security_config, "doris_oauth_db_tools_enabled", False):
+            tool_names = self._configured_tool_names(
+                getattr(
+                    security_config,
+                    "doris_oauth_db_tool_allowlist",
+                    DORIS_OAUTH_METADATA_TOOLS,
+                )
+            )
+            metadata_tool_set = set(DORIS_OAUTH_METADATA_TOOLS)
+            allowed.update(f"tool:call:{tool_name}" for tool_name in tool_names if tool_name in metadata_tool_set)
+
+        if getattr(security_config, "doris_oauth_query_tools_enabled", False):
+            tool_names = self._configured_tool_names(
+                getattr(security_config, "doris_oauth_query_tool_allowlist", ("exec_query",))
+            )
+            if "exec_query" in tool_names:
+                allowed.update(QUERY_DB_SCOPES)
+
+        if getattr(security_config, "doris_oauth_explain_tools_enabled", False):
+            tool_names = self._configured_tool_names(
+                getattr(security_config, "doris_oauth_explain_tool_allowlist", ("get_sql_explain",))
+            )
+            if "get_sql_explain" in tool_names:
+                allowed.update(EXPLAIN_DB_SCOPES)
+
+        return allowed
+
+    def _configured_tool_names(self, configured_tools) -> list[str]:
+        if isinstance(configured_tools, str):
+            return [part.strip() for part in configured_tools.split(",") if part.strip()]
+        return [str(tool).strip() for tool in configured_tools if str(tool).strip()]
+
+    def parse_scope(self, scope: str | None) -> tuple[str, ...]:
+        if scope is None:
+            return ()
+        return tuple(
+            TOOL_SCOPE_ALIASES.get(part, part)
+            for part in str(scope).split()
+            if part
+        )
+
+    def grant_client_scopes(self, requested_scope: str | None, *, explicit: bool) -> tuple[str, ...]:
+        requested = self.parse_scope(requested_scope)
+        return self._grant(requested, explicit=explicit, client_allowed_scopes=self.server_allowed_scopes)
+
+    def grant_authorized_scopes(
+        self,
+        requested_scope: str | None,
+        *,
+        client_allowed_scopes: tuple[str, ...],
+        explicit: bool,
+    ) -> tuple[str, ...]:
+        requested = self.parse_scope(requested_scope)
+        return self._grant(
+            requested,
+            explicit=explicit,
+            client_allowed_scopes=set(client_allowed_scopes),
+        )
+
+    def validate_refresh_scope(
+        self,
+        requested_scope: str | None,
+        original_scopes: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        requested = self.parse_scope(requested_scope)
+        if not requested:
+            return original_scopes
+        original = set(original_scopes)
+        requested_set = set(requested)
+        if not requested_set <= original:
+            raise TokenEndpointError(
+                "invalid_scope",
+                "Requested scope cannot exceed the original grant",
+                status_code=400,
+            )
+        return tuple(scope for scope in original_scopes if scope in requested_set)
+
+    def _grant(
+        self,
+        requested: tuple[str, ...],
+        *,
+        explicit: bool,
+        client_allowed_scopes: set[str],
+    ) -> tuple[str, ...]:
+        requested_set = set(requested)
+        if not requested_set:
+            requested_set = set(self.server_default_scopes)
+
+        unknown = requested_set - self.known_scopes
+        forbidden = requested_set & self.forbidden_scopes
+        not_allowed = requested_set - self.server_allowed_scopes
+        client_denied = requested_set - client_allowed_scopes
+
+        if explicit and (unknown or forbidden or not_allowed or client_denied):
+            raise TokenEndpointError(
+                "invalid_scope",
+                "Requested scope is not allowed",
+                status_code=400,
+            )
+
+        granted = requested_set & self.server_allowed_scopes & client_allowed_scopes
+        if not granted:
+            raise TokenEndpointError(
+                "invalid_scope",
+                "Requested scope is not allowed",
+                status_code=400,
+            )
+        return tuple(sorted(granted))

--- a/doris_mcp_server/auth/doris_oauth_store.py
+++ b/doris_mcp_server/auth/doris_oauth_store.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""In-memory HMAC-backed store for Doris-backed OAuth."""
+
+import hmac
+import hashlib
+import secrets
+import time
+from dataclasses import replace
+
+from .doris_oauth_types import (
+    AccessTokenRecord,
+    AuthTransactionRecord,
+    AuthorizationCodeRecord,
+    IssuedTokenPair,
+    RefreshTokenRecord,
+    RegisteredClientRecord,
+)
+from ..utils.security import RESERVED_DORIS_OAUTH_TOKEN_PREFIX
+
+
+class DorisOAuthStore:
+    """Process-local OAuth store with hash-only credential lookup."""
+
+    def __init__(self):
+        self._hash_key = secrets.token_bytes(32)
+        self.clients_by_id: dict[str, RegisteredClientRecord] = {}
+        self.transactions_by_txn_hash: dict[str, AuthTransactionRecord] = {}
+        self.codes_by_hash: dict[str, AuthorizationCodeRecord] = {}
+        self.access_by_hash: dict[str, AccessTokenRecord] = {}
+        self.refresh_by_hash: dict[str, RefreshTokenRecord] = {}
+        self.access_id_to_hash: dict[str, str] = {}
+        self.refresh_id_to_hash: dict[str, str] = {}
+        self.access_to_refresh_id: dict[str, str] = {}
+        self.refresh_to_access_id: dict[str, str] = {}
+        self.user_token_ids: dict[str, set[str]] = {}
+
+    def hmac_lookup(self, value: str, purpose: str) -> str:
+        payload = f"{purpose}:{value}".encode("utf-8")
+        return hmac.new(self._hash_key, payload, hashlib.sha256).hexdigest()
+
+    def hash_client_secret(self, client_secret: str) -> str:
+        return self.hmac_lookup(client_secret, "client_secret")
+
+    def hash_public_value(self, value: str) -> str:
+        return self.hmac_lookup(value, "public")
+
+    def add_client(
+        self,
+        *,
+        client_id: str,
+        client_secret: str | None,
+        token_endpoint_auth_method: str,
+        redirect_uris: tuple[str, ...],
+        client_allowed_scopes: tuple[str, ...],
+        source: str,
+        expires_at: float | None,
+        registration_ip: str | None = None,
+    ) -> RegisteredClientRecord:
+        record = RegisteredClientRecord(
+            client_id=client_id,
+            client_secret_hash=self.hash_client_secret(client_secret) if client_secret else None,
+            token_endpoint_auth_method=token_endpoint_auth_method,
+            redirect_uris=redirect_uris,
+            client_allowed_scopes=client_allowed_scopes,
+            source=source,
+            created_at=time.time(),
+            expires_at=expires_at,
+            registration_ip_hash=self.hash_public_value(registration_ip) if registration_ip else None,
+        )
+        self.clients_by_id[client_id] = record
+        return record
+
+    def get_client(self, client_id: str) -> RegisteredClientRecord | None:
+        record = self.clients_by_id.get(client_id)
+        if record and record.expires_at is not None and record.expires_at <= time.time():
+            self.clients_by_id.pop(client_id, None)
+            return None
+        return record
+
+    def validate_client_secret(self, client: RegisteredClientRecord, client_secret: str | None) -> bool:
+        if client.token_endpoint_auth_method == "none":
+            return True
+        if not client_secret or not client.client_secret_hash:
+            return False
+        return hmac.compare_digest(self.hash_client_secret(client_secret), client.client_secret_hash)
+
+    def create_auth_transaction(
+        self,
+        *,
+        client_id: str,
+        redirect_uri: str,
+        state: str,
+        code_challenge: str,
+        requested_scopes: tuple[str, ...],
+        candidate_granted_scopes: tuple[str, ...],
+        resource: str,
+        client_ip: str,
+        ttl_seconds: int,
+    ) -> tuple[str, AuthTransactionRecord]:
+        txn_id = f"dot_{secrets.token_urlsafe(32)}"
+        txn_hash = self.hmac_lookup(txn_id, "txn")
+        now = time.time()
+        record = AuthTransactionRecord(
+            txn_id_hash=txn_hash,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            state=state,
+            code_challenge=code_challenge,
+            code_challenge_method="S256",
+            requested_scopes=requested_scopes,
+            candidate_granted_scopes=candidate_granted_scopes,
+            resource=resource,
+            login_csrf_hash="",
+            client_ip_hash=self.hash_public_value(client_ip),
+            created_at=now,
+            expires_at=now + ttl_seconds,
+        )
+        self.transactions_by_txn_hash[txn_hash] = record
+        return txn_id, record
+
+    def get_auth_transaction(self, txn_id: str) -> AuthTransactionRecord | None:
+        txn_hash = self.hmac_lookup(txn_id, "txn")
+        record = self.transactions_by_txn_hash.get(txn_hash)
+        if record and record.expires_at <= time.time():
+            self.transactions_by_txn_hash.pop(txn_hash, None)
+            return None
+        return record
+
+    def set_transaction_csrf(self, txn_id: str, csrf_value: str) -> AuthTransactionRecord | None:
+        txn_hash = self.hmac_lookup(txn_id, "txn")
+        record = self.get_auth_transaction(txn_id)
+        if not record:
+            return None
+        updated = replace(record, login_csrf_hash=self.hmac_lookup(csrf_value, "csrf"))
+        self.transactions_by_txn_hash[txn_hash] = updated
+        return updated
+
+    def validate_transaction_csrf(self, txn_id: str, csrf_value: str) -> bool:
+        record = self.get_auth_transaction(txn_id)
+        if not record or not record.login_csrf_hash:
+            return False
+        return hmac.compare_digest(record.login_csrf_hash, self.hmac_lookup(csrf_value, "csrf"))
+
+    def delete_auth_transaction(self, txn_id: str) -> None:
+        self.transactions_by_txn_hash.pop(self.hmac_lookup(txn_id, "txn"), None)
+
+    def create_authorization_code(
+        self,
+        *,
+        client_id: str,
+        doris_user: str,
+        redirect_uri: str,
+        scopes: tuple[str, ...],
+        resource: str,
+        code_challenge: str,
+        code_challenge_method: str,
+        ttl_seconds: int,
+    ) -> tuple[str, AuthorizationCodeRecord]:
+        code = f"doc_{secrets.token_urlsafe(32)}"
+        code_hash = self.hmac_lookup(code, "code")
+        now = time.time()
+        record = AuthorizationCodeRecord(
+            code_hash=code_hash,
+            code_id=f"code_{secrets.token_urlsafe(12)}",
+            client_id=client_id,
+            doris_user=doris_user,
+            redirect_uri=redirect_uri,
+            scopes=scopes,
+            resource=resource,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+            created_at=now,
+            expires_at=now + ttl_seconds,
+        )
+        self.codes_by_hash[code_hash] = record
+        return code, record
+
+    def pop_authorization_code(self, code: str) -> AuthorizationCodeRecord | None:
+        code_hash = self.hmac_lookup(code, "code")
+        record = self.codes_by_hash.pop(code_hash, None)
+        if record and record.expires_at <= time.time():
+            return None
+        if record and record.used_at is not None:
+            return None
+        return record
+
+    def issue_token_pair(
+        self,
+        *,
+        client_id: str,
+        doris_user: str,
+        scopes: tuple[str, ...],
+        resource: str,
+        access_ttl_seconds: int,
+        refresh_ttl_seconds: int,
+        family_id: str | None = None,
+        rotated_from: str | None = None,
+    ) -> IssuedTokenPair:
+        access_token = f"{RESERVED_DORIS_OAUTH_TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+        refresh_token = f"dor_{secrets.token_urlsafe(40)}"
+        access_hash = self.hmac_lookup(access_token, "access")
+        refresh_hash = self.hmac_lookup(refresh_token, "refresh")
+        now = time.time()
+        access_id = f"at_{secrets.token_urlsafe(12)}"
+        refresh_id = f"rt_{secrets.token_urlsafe(12)}"
+        token_family_id = family_id or f"fam_{secrets.token_urlsafe(12)}"
+
+        access_record = AccessTokenRecord(
+            token_hash=access_hash,
+            token_id=access_id,
+            client_id=client_id,
+            doris_user=doris_user,
+            scopes=scopes,
+            resource=resource,
+            refresh_token_id=refresh_id,
+            family_id=token_family_id,
+            issued_at=now,
+            expires_at=now + access_ttl_seconds,
+        )
+        refresh_record = RefreshTokenRecord(
+            token_hash=refresh_hash,
+            token_id=refresh_id,
+            client_id=client_id,
+            doris_user=doris_user,
+            scopes=scopes,
+            resource=resource,
+            access_token_id=access_id,
+            family_id=token_family_id,
+            issued_at=now,
+            expires_at=now + refresh_ttl_seconds,
+            rotated_from=rotated_from,
+        )
+
+        self.access_by_hash[access_hash] = access_record
+        self.refresh_by_hash[refresh_hash] = refresh_record
+        self.access_id_to_hash[access_id] = access_hash
+        self.refresh_id_to_hash[refresh_id] = refresh_hash
+        self.access_to_refresh_id[access_id] = refresh_id
+        self.refresh_to_access_id[refresh_id] = access_id
+        self.user_token_ids.setdefault(doris_user, set()).update({access_id, refresh_id})
+        return IssuedTokenPair(access_token, refresh_token, access_record, refresh_record)
+
+    def get_access_token(self, raw_access_token: str) -> AccessTokenRecord | None:
+        record = self.access_by_hash.get(self.hmac_lookup(raw_access_token, "access"))
+        if record and record.expires_at <= time.time():
+            return None
+        return record
+
+    def get_refresh_token(self, raw_refresh_token: str) -> RefreshTokenRecord | None:
+        record = self.refresh_by_hash.get(self.hmac_lookup(raw_refresh_token, "refresh"))
+        if record and record.expires_at <= time.time():
+            return None
+        return record
+
+    def find_access_or_refresh(self, raw_token: str) -> AccessTokenRecord | RefreshTokenRecord | None:
+        return self.get_access_token(raw_token) or self.get_refresh_token(raw_token)
+
+    def update_access_last_used(self, access_token_id: str) -> AccessTokenRecord | None:
+        access_hash = self.access_id_to_hash.get(access_token_id)
+        if not access_hash:
+            return None
+        record = self.access_by_hash.get(access_hash)
+        if not record:
+            return None
+        updated = replace(record, last_used_at=time.time())
+        self.access_by_hash[access_hash] = updated
+        return updated
+
+    def revoke_pair_for_refresh_id(self, refresh_token_id: str) -> None:
+        refresh_hash = self.refresh_id_to_hash.get(refresh_token_id)
+        if not refresh_hash:
+            return
+        now = time.time()
+        refresh = self.refresh_by_hash.get(refresh_hash)
+        if refresh:
+            self.refresh_by_hash[refresh_hash] = replace(refresh, revoked_at=refresh.revoked_at or now)
+            access_hash = self.access_id_to_hash.get(refresh.access_token_id)
+            access = self.access_by_hash.get(access_hash or "")
+            if access:
+                self.access_by_hash[access_hash] = replace(access, revoked_at=access.revoked_at or now)
+
+    def revoke_family_by_access_token_id(self, access_token_id: str) -> None:
+        access_hash = self.access_id_to_hash.get(access_token_id)
+        access = self.access_by_hash.get(access_hash or "")
+        if access:
+            self._revoke_family(access.family_id)
+
+    def revoke_family_by_refresh_token_id(self, refresh_token_id: str) -> None:
+        refresh_hash = self.refresh_id_to_hash.get(refresh_token_id)
+        refresh = self.refresh_by_hash.get(refresh_hash or "")
+        if refresh:
+            self._revoke_family(refresh.family_id)
+
+    def revoke_token(self, raw_token: str) -> bool:
+        record = self.find_access_or_refresh(raw_token)
+        if isinstance(record, AccessTokenRecord):
+            self.revoke_family_by_access_token_id(record.token_id)
+            return True
+        if isinstance(record, RefreshTokenRecord):
+            self.revoke_family_by_refresh_token_id(record.token_id)
+            return True
+        return False
+
+    def _revoke_family(self, family_id: str) -> None:
+        now = time.time()
+        for token_hash, access in list(self.access_by_hash.items()):
+            if access.family_id == family_id:
+                self.access_by_hash[token_hash] = replace(access, revoked_at=access.revoked_at or now)
+        for token_hash, refresh in list(self.refresh_by_hash.items()):
+            if refresh.family_id == family_id:
+                self.refresh_by_hash[token_hash] = replace(refresh, revoked_at=refresh.revoked_at or now)
+
+    def active_users(self) -> set[str]:
+        now = time.time()
+        users: set[str] = set()
+        for record in self.access_by_hash.values():
+            if record.revoked_at is None and record.expires_at > now:
+                users.add(record.doris_user)
+        for record in self.refresh_by_hash.values():
+            if record.revoked_at is None and record.expires_at > now:
+                users.add(record.doris_user)
+        return users
+
+    def cleanup_expired(self) -> None:
+        now = time.time()
+        for client_id, record in list(self.clients_by_id.items()):
+            if record.source == "dcr" and record.expires_at is not None and record.expires_at <= now:
+                self.clients_by_id.pop(client_id, None)
+        for txn_hash, record in list(self.transactions_by_txn_hash.items()):
+            if record.expires_at <= now:
+                self.transactions_by_txn_hash.pop(txn_hash, None)
+        for code_hash, record in list(self.codes_by_hash.items()):
+            if record.expires_at <= now or record.used_at is not None:
+                self.codes_by_hash.pop(code_hash, None)
+        for access_hash, record in list(self.access_by_hash.items()):
+            if record.expires_at <= now and record.revoked_at is not None:
+                self.access_by_hash.pop(access_hash, None)
+                self.access_id_to_hash.pop(record.token_id, None)
+        for refresh_hash, record in list(self.refresh_by_hash.items()):
+            if record.expires_at <= now and record.revoked_at is not None:
+                self.refresh_by_hash.pop(refresh_hash, None)
+                self.refresh_id_to_hash.pop(record.token_id, None)

--- a/doris_mcp_server/auth/doris_oauth_types.py
+++ b/doris_mcp_server/auth/doris_oauth_types.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Types and endpoint-specific errors for Doris-backed OAuth."""
+
+from dataclasses import dataclass
+
+
+class DorisOAuthError(Exception):
+    """Base typed OAuth error."""
+
+    def __init__(
+        self,
+        error: str,
+        description: str = "",
+        *,
+        status_code: int = 400,
+        error_code: str | None = None,
+    ):
+        super().__init__(description or error)
+        self.error = error
+        self.description = description or error
+        self.status_code = status_code
+        self.error_code = error_code or error
+
+
+class ProtectedResourceAuthError(DorisOAuthError):
+    """Error for protected MCP resource authentication/challenge."""
+
+    def __init__(
+        self,
+        error: str = "authentication_required",
+        description: str = "Authentication required",
+        *,
+        status_code: int = 401,
+        required_scope: str | None = "tool:list",
+        challenge_error: str = "invalid_token",
+        error_code: str | None = None,
+    ):
+        super().__init__(
+            error,
+            description,
+            status_code=status_code,
+            error_code=error_code,
+        )
+        self.required_scope = required_scope
+        self.challenge_error = challenge_error
+
+
+class AuthorizeError(DorisOAuthError):
+    """Error for /oauth/authorize direct or redirect response."""
+
+    def __init__(
+        self,
+        error: str,
+        description: str,
+        *,
+        status_code: int = 400,
+        redirect_uri: str | None = None,
+        state: str | None = None,
+        redirect_allowed: bool = False,
+    ):
+        super().__init__(error, description, status_code=status_code)
+        self.redirect_uri = redirect_uri
+        self.state = state
+        self.redirect_allowed = redirect_allowed
+
+
+class TokenEndpointError(DorisOAuthError):
+    """Error for /oauth/token and /api/auth/refresh."""
+
+    def __init__(
+        self,
+        error: str,
+        description: str,
+        *,
+        status_code: int = 400,
+        www_authenticate: str | None = None,
+        error_code: str | None = None,
+    ):
+        super().__init__(
+            error,
+            description,
+            status_code=status_code,
+            error_code=error_code,
+        )
+        self.www_authenticate = www_authenticate
+
+
+class RevocationEndpointError(DorisOAuthError):
+    """Error for /oauth/revoke."""
+
+
+@dataclass
+class RegisteredClientRecord:
+    client_id: str
+    client_secret_hash: str | None
+    token_endpoint_auth_method: str
+    redirect_uris: tuple[str, ...]
+    client_allowed_scopes: tuple[str, ...]
+    source: str
+    created_at: float
+    expires_at: float | None
+    last_used_at: float | None = None
+    registration_ip_hash: str | None = None
+
+
+@dataclass
+class AuthTransactionRecord:
+    txn_id_hash: str
+    client_id: str
+    redirect_uri: str
+    state: str
+    code_challenge: str
+    code_challenge_method: str
+    requested_scopes: tuple[str, ...]
+    candidate_granted_scopes: tuple[str, ...]
+    resource: str
+    login_csrf_hash: str
+    client_ip_hash: str
+    created_at: float
+    expires_at: float
+    login_attempt_count: int = 0
+
+
+@dataclass
+class AuthorizationCodeRecord:
+    code_hash: str
+    code_id: str
+    client_id: str
+    doris_user: str
+    redirect_uri: str
+    scopes: tuple[str, ...]
+    resource: str
+    code_challenge: str
+    code_challenge_method: str
+    created_at: float
+    expires_at: float
+    used_at: float | None = None
+
+
+@dataclass
+class AccessTokenRecord:
+    token_hash: str
+    token_id: str
+    client_id: str
+    doris_user: str
+    scopes: tuple[str, ...]
+    resource: str
+    refresh_token_id: str
+    family_id: str
+    issued_at: float
+    expires_at: float
+    last_used_at: float | None = None
+    revoked_at: float | None = None
+
+
+@dataclass
+class RefreshTokenRecord:
+    token_hash: str
+    token_id: str
+    client_id: str
+    doris_user: str
+    scopes: tuple[str, ...]
+    resource: str
+    access_token_id: str
+    family_id: str
+    issued_at: float
+    expires_at: float
+    revoked_at: float | None = None
+    rotated_from: str | None = None
+
+
+@dataclass(frozen=True)
+class IssuedTokenPair:
+    access_token: str
+    refresh_token: str
+    access_record: AccessTokenRecord
+    refresh_record: RefreshTokenRecord

--- a/doris_mcp_server/auth/mcp_auth_middleware.py
+++ b/doris_mcp_server/auth/mcp_auth_middleware.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Shared ASGI authentication middleware for MCP HTTP routes."""
+
+from typing import Any, Awaitable, Callable
+from urllib.parse import parse_qs
+
+from starlette.responses import JSONResponse
+
+from .doris_oauth_handlers import (
+    insufficient_scope_response,
+    protected_resource_error_response,
+)
+from .operation_policy import OperationAuthorizationError
+from ..utils.config import EffectiveAuthConfig
+from ..utils.logger import get_logger
+from ..utils.security import (
+    clear_current_auth_context,
+    get_current_auth_context,
+    reset_auth_context,
+    set_current_auth_context,
+)
+
+
+ASGIApp = Callable[[dict[str, Any], Callable[..., Awaitable[Any]], Callable[..., Awaitable[Any]]], Awaitable[Any]]
+logger = get_logger(__name__)
+
+
+async def extract_auth_info_from_scope(scope: dict[str, Any]) -> dict[str, Any]:
+    """Extract auth info from ASGI scope."""
+    headers = dict(scope.get("headers", []))
+    authorization = headers.get(b"authorization", b"").decode("utf-8")
+    client = scope.get("client") or ("unknown", 0)
+    client_ip = client[0] if client else "unknown"
+
+    auth_info = {
+        "authorization": authorization,
+        "client_ip": client_ip,
+        "session_id": scope.get("session_id", ""),
+    }
+    if authorization.startswith("Bearer "):
+        auth_info["token"] = authorization[7:]
+    elif authorization.startswith("Token "):
+        auth_info["token"] = authorization[6:]
+    else:
+        query_string = scope.get("query_string", b"")
+        if query_string:
+            query_params = parse_qs(query_string.decode("utf-8", errors="ignore"))
+            token_values = query_params.get("token") or []
+            if token_values:
+                auth_info["token"] = token_values[0]
+    return auth_info
+
+
+class MCPAuthASGIMiddleware:
+    """Authenticate protected /mcp ASGI requests and manage AuthContext lifecycle."""
+
+    def __init__(self, security_manager: Any, downstream: ASGIApp, effective_auth: EffectiveAuthConfig):
+        self.security_manager = security_manager
+        self.downstream = downstream
+        self.effective_auth = effective_auth
+
+    async def __call__(self, scope, receive, send):
+        try:
+            auth_info = await extract_auth_info_from_scope(scope)
+            auth_context = await self.security_manager.authenticate_request(auth_info)
+        except Exception as exc:
+            if self.effective_auth.oauth_discovery_mode == "doris_oauth":
+                response = protected_resource_error_response(
+                    exc,
+                    self.effective_auth.doris_oauth_base_url,
+                )
+            else:
+                response = JSONResponse(
+                    {"error": "Authentication required", "message": str(exc)},
+                    status_code=401,
+                )
+            await response(scope, receive, send)
+            return
+
+        scoped_request = dict(scope)
+        scoped_request["auth_context"] = auth_context
+
+        context_token = None
+        try:
+            context_token = set_current_auth_context(auth_context)
+            if get_current_auth_context() is not auth_context:
+                raise RuntimeError("AuthContext ContextVar verification failed")
+        except Exception as exc:
+            if context_token is not None:
+                try:
+                    reset_auth_context(context_token)
+                except Exception as reset_exc:
+                    logger.error(f"Failed to reset auth context after verification failure: {reset_exc}")
+                    clear_current_auth_context()
+            response = JSONResponse(
+                {"error": "auth_context_unavailable", "message": str(exc)},
+                status_code=500,
+            )
+            await response(scope, receive, send)
+            return
+
+        try:
+            await self.downstream(scoped_request, receive, send)
+        except OperationAuthorizationError as exc:
+            body = exc.to_dict()
+            if (
+                self.effective_auth.oauth_discovery_mode == "doris_oauth"
+                and exc.required_scope
+                and exc.error_code == "PERMISSION_DENIED"
+            ):
+                response = insufficient_scope_response(
+                    self.effective_auth.doris_oauth_base_url,
+                    exc.required_scope,
+                    body,
+                )
+            else:
+                response = JSONResponse(body, status_code=exc.status_code)
+            await response(scope, receive, send)
+        finally:
+            try:
+                reset_auth_context(context_token)
+            except Exception as exc:
+                logger.error(f"Failed to reset auth context after request: {exc}")
+                clear_current_auth_context()

--- a/doris_mcp_server/auth/oauth_client.py
+++ b/doris_mcp_server/auth/oauth_client.py
@@ -183,7 +183,11 @@ class OAuthClient:
         else:
             security_config = config
             
-        self.enabled = security_config.oauth_enabled
+        effective_auth = getattr(config, "effective_auth", None)
+        if effective_auth is not None:
+            self.enabled = effective_auth.enable_external_oauth_auth
+        else:
+            self.enabled = security_config.oauth_enabled
         if not self.enabled:
             logger.info("OAuth client disabled by configuration")
             return

--- a/doris_mcp_server/auth/operation_policy.py
+++ b/doris_mcp_server/auth/operation_policy.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""MCP operation policy for Doris OAuth."""
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class OperationPolicy:
+    name: str
+    required_scope: str | None
+    doris_oauth_policy: str  # allow, deny
+    channel: str = "none"
+    risk: str = "low"
+    error_code: str | None = None
+
+
+class OperationAuthorizationError(Exception):
+    """Raised when an MCP operation is not authorized."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int = 403,
+        error_code: str = "PERMISSION_DENIED",
+        required_scope: str | None = None,
+        operation: str = "",
+    ):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.error_code = error_code
+        self.required_scope = required_scope
+        self.operation = operation
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "error": self.error_code,
+            "message": self.message,
+            "operation": self.operation,
+            "status_code": self.status_code,
+        }
+        if self.required_scope:
+            payload["required_scope"] = self.required_scope
+        return payload
+
+
+P4_DORIS_OAUTH_METADATA_TOOLS = frozenset(
+    {
+        "get_db_list",
+        "get_db_table_list",
+        "get_table_schema",
+        "get_table_comment",
+        "get_table_column_comments",
+        "get_table_indexes",
+        "get_catalog_list",
+    }
+)
+
+P4_DORIS_OAUTH_QUERY_TOOLS = frozenset({"exec_query"})
+P4_DORIS_OAUTH_EXPLAIN_TOOLS = frozenset({"get_sql_explain"})
+P4_DORIS_OAUTH_DEFAULT_METADATA_TOOL_ALLOWLIST = tuple(
+    [
+        "get_db_list",
+        "get_db_table_list",
+        "get_table_schema",
+        "get_table_comment",
+        "get_table_column_comments",
+        "get_table_indexes",
+        "get_catalog_list",
+    ]
+)
+
+# Phase 4 keeps DB-backed Doris OAuth tools fail-closed unless configuration and
+# exact tool scope both allow a reviewed metadata tool.
+DORIS_OAUTH_DB_TOOLS_ENABLED = False
+DORIS_OAUTH_DB_TOOL_ALLOWLIST = P4_DORIS_OAUTH_DEFAULT_METADATA_TOOL_ALLOWLIST
+
+DORIS_OAUTH_QUERY_TOOLS_ENABLED = False
+DORIS_OAUTH_QUERY_TOOL_ALLOWLIST = ("exec_query",)
+DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED = False
+DORIS_OAUTH_EXPLAIN_TOOL_ALLOWLIST = ("get_sql_explain",)
+
+HIGH_RISK_TOOLS = {
+    "get_recent_audit_logs",
+    "get_sql_profile",
+    "get_table_data_size",
+    "get_monitoring_metrics",
+    "get_memory_stats",
+    "get_monitoring_metrics_info",
+    "get_monitoring_metrics_data",
+    "get_realtime_memory_stats",
+    "get_historical_memory_stats",
+    "get_table_basic_info",
+    "analyze_columns",
+    "analyze_table_storage",
+    "trace_column_lineage",
+    "monitor_data_freshness",
+    "analyze_data_access_patterns",
+    "analyze_data_flow_dependencies",
+    "analyze_slow_queries_topn",
+    "analyze_resource_growth_curves",
+    "exec_adbc_query",
+    "get_adbc_connection_info",
+}
+
+
+def normalize_doris_oauth_metadata_tool_allowlist(tools: Any = None) -> tuple[str, ...]:
+    if tools is None:
+        return P4_DORIS_OAUTH_DEFAULT_METADATA_TOOL_ALLOWLIST
+    if isinstance(tools, str):
+        candidates = [part.strip() for part in tools.split(",") if part.strip()]
+    else:
+        candidates = [str(tool).strip() for tool in tools if str(tool).strip()]
+
+    normalized = []
+    seen = set()
+    invalid = []
+    for tool_name in candidates:
+        if tool_name not in P4_DORIS_OAUTH_METADATA_TOOLS:
+            invalid.append(tool_name)
+            continue
+        if tool_name not in seen:
+            normalized.append(tool_name)
+            seen.add(tool_name)
+    if invalid:
+        invalid_list = ", ".join(sorted(set(invalid)))
+        raise ValueError(
+            "DORIS_OAUTH_DB_TOOL_ALLOWLIST can only contain Phase 4 metadata tools; "
+            f"invalid entries: {invalid_list}"
+        )
+    return tuple(normalized)
+
+
+def _setting(auth_context: Any, name: str, default: Any) -> Any:
+    return getattr(auth_context, name, default)
+
+
+def _metadata_tools_enabled(auth_context: Any) -> bool:
+    return bool(
+        _setting(
+            auth_context,
+            "doris_oauth_db_tools_enabled",
+            DORIS_OAUTH_DB_TOOLS_ENABLED,
+        )
+    )
+
+
+def _metadata_tool_allowlist(auth_context: Any) -> tuple[str, ...]:
+    raw_allowlist = _setting(
+        auth_context,
+        "doris_oauth_db_tool_allowlist",
+        DORIS_OAUTH_DB_TOOL_ALLOWLIST,
+    )
+    return normalize_doris_oauth_metadata_tool_allowlist(raw_allowlist)
+
+
+def _query_tools_enabled(auth_context: Any) -> bool:
+    return bool(
+        _setting(
+            auth_context,
+            "doris_oauth_query_tools_enabled",
+            DORIS_OAUTH_QUERY_TOOLS_ENABLED,
+        )
+    )
+
+
+def _query_tool_allowlist(auth_context: Any) -> tuple[str, ...]:
+    raw_allowlist = _setting(
+        auth_context,
+        "doris_oauth_query_tool_allowlist",
+        DORIS_OAUTH_QUERY_TOOL_ALLOWLIST,
+    )
+    if isinstance(raw_allowlist, str):
+        return tuple(part.strip() for part in raw_allowlist.split(",") if part.strip())
+    return tuple(str(tool).strip() for tool in raw_allowlist if str(tool).strip())
+
+
+def _explain_tools_enabled(auth_context: Any) -> bool:
+    return bool(
+        _setting(
+            auth_context,
+            "doris_oauth_explain_tools_enabled",
+            DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED,
+        )
+    )
+
+
+def _explain_tool_allowlist(auth_context: Any) -> tuple[str, ...]:
+    raw_allowlist = _setting(
+        auth_context,
+        "doris_oauth_explain_tool_allowlist",
+        DORIS_OAUTH_EXPLAIN_TOOL_ALLOWLIST,
+    )
+    if isinstance(raw_allowlist, str):
+        return tuple(part.strip() for part in raw_allowlist.split(",") if part.strip())
+    return tuple(str(tool).strip() for tool in raw_allowlist if str(tool).strip())
+
+
+def _denied_tool_policy(
+    tool_name: str,
+    *,
+    channel: str,
+    risk: str,
+    error_code: str,
+) -> OperationPolicy:
+    return OperationPolicy(
+        name=f"tool:{tool_name}",
+        required_scope=f"tool:call:{tool_name}",
+        doris_oauth_policy="deny",
+        channel=channel,
+        risk=risk,
+        error_code=error_code,
+    )
+
+
+def _allowed_metadata_tool_policy(tool_name: str) -> OperationPolicy:
+    return OperationPolicy(
+        name=f"tool:{tool_name}",
+        required_scope=f"tool:call:{tool_name}",
+        doris_oauth_policy="allow",
+        channel="mysql_metadata",
+        risk="metadata",
+    )
+
+
+def _tool_policy(tool_name: str, auth_context: Any = None) -> OperationPolicy:
+    if tool_name in P4_DORIS_OAUTH_METADATA_TOOLS:
+        if not _metadata_tools_enabled(auth_context):
+            return _denied_tool_policy(
+                tool_name,
+                channel="doris_oauth_metadata_disabled",
+                risk="metadata",
+                error_code="DORIS_OAUTH_DB_TOOLS_NOT_ENABLED",
+            )
+        try:
+            allowlist = set(_metadata_tool_allowlist(auth_context))
+        except ValueError:
+            return _denied_tool_policy(
+                tool_name,
+                channel="doris_oauth_metadata_misconfigured",
+                risk="metadata",
+                error_code="DORIS_OAUTH_DB_TOOL_ALLOWLIST_INVALID",
+            )
+        if tool_name not in allowlist:
+            return _denied_tool_policy(
+                tool_name,
+                channel="doris_oauth_metadata_not_allowed",
+                risk="metadata",
+                error_code="DORIS_OAUTH_TOOL_NOT_ALLOWED",
+            )
+        return _allowed_metadata_tool_policy(tool_name)
+
+    if tool_name in P4_DORIS_OAUTH_QUERY_TOOLS:
+        if not _query_tools_enabled(auth_context):
+            return _denied_tool_policy(
+                tool_name,
+                channel="doris_oauth_query_disabled",
+                risk="query",
+                error_code="DORIS_OAUTH_QUERY_TOOL_NOT_ENABLED",
+            )
+        if tool_name not in set(_query_tool_allowlist(auth_context)):
+            return _denied_tool_policy(
+                tool_name,
+                channel="doris_oauth_query_not_allowed",
+                risk="query",
+                error_code="DORIS_OAUTH_TOOL_NOT_ALLOWED",
+            )
+        return OperationPolicy(
+            name=f"tool:{tool_name}",
+            required_scope=f"tool:call:{tool_name}",
+            doris_oauth_policy="allow",
+            channel="mysql_query",
+            risk="query",
+        )
+
+    if tool_name in P4_DORIS_OAUTH_EXPLAIN_TOOLS:
+        if not _explain_tools_enabled(auth_context):
+            return _denied_tool_policy(
+                tool_name,
+                channel="doris_oauth_explain_disabled",
+                risk="explain",
+                error_code="DORIS_OAUTH_EXPLAIN_TOOL_NOT_ENABLED",
+            )
+        if tool_name not in set(_explain_tool_allowlist(auth_context)):
+            return _denied_tool_policy(
+                tool_name,
+                channel="doris_oauth_explain_not_allowed",
+                risk="explain",
+                error_code="DORIS_OAUTH_TOOL_NOT_ALLOWED",
+            )
+        return OperationPolicy(
+            name=f"tool:{tool_name}",
+            required_scope=f"tool:call:{tool_name}",
+            doris_oauth_policy="allow",
+            channel="mysql_explain",
+            risk="explain",
+        )
+
+    if tool_name in HIGH_RISK_TOOLS:
+        return _denied_tool_policy(
+            tool_name,
+            channel="unsupported",
+            risk="high",
+            error_code="UNSUPPORTED_FOR_DORIS_OAUTH",
+        )
+
+    return _denied_tool_policy(
+        tool_name,
+        channel="unknown",
+        risk="unknown",
+        error_code="UNKNOWN_OPERATION",
+    )
+
+
+OPERATION_POLICIES: dict[str, OperationPolicy] = {
+    "list_tools": OperationPolicy("list_tools", "tool:list", "allow"),
+    "list_resources": OperationPolicy("list_resources", "resource:list", "allow", "mysql", "metadata"),
+    "read_resource": OperationPolicy("read_resource", "resource:read", "allow", "mysql", "metadata"),
+    "list_prompts": OperationPolicy("list_prompts", "prompt:list", "deny", "local", "medium"),
+    "get_prompt": OperationPolicy("get_prompt", "prompt:get", "deny", "mysql", "medium"),
+    "http:/": OperationPolicy("http:/", None, "allow"),
+    "http:/health": OperationPolicy("http:/health", None, "allow"),
+    "http:/auth/login": OperationPolicy("http:/auth/login", None, "deny", "external_oauth", "medium"),
+    "http:/auth/callback": OperationPolicy("http:/auth/callback", None, "deny", "external_oauth", "medium"),
+    "http:/auth/provider": OperationPolicy("http:/auth/provider", None, "deny", "external_oauth", "medium"),
+    "http:/auth/demo": OperationPolicy("http:/auth/demo", None, "deny", "external_oauth", "medium"),
+    "http:/token/create": OperationPolicy("http:/token/create", None, "deny", "token_admin", "high"),
+    "http:/token/revoke": OperationPolicy("http:/token/revoke", None, "deny", "token_admin", "high"),
+    "http:/token/list": OperationPolicy("http:/token/list", None, "deny", "token_admin", "high"),
+    "http:/token/stats": OperationPolicy("http:/token/stats", None, "deny", "token_admin", "high"),
+    "http:/token/cleanup": OperationPolicy("http:/token/cleanup", None, "deny", "token_admin", "high"),
+    "http:/token/management": OperationPolicy("http:/token/management", None, "deny", "token_admin", "high"),
+}
+
+
+def resolve_operation_policy(operation: str, auth_context: Any = None) -> OperationPolicy:
+    if operation.startswith("tool:"):
+        return _tool_policy(operation.split(":", 1)[1], auth_context)
+    return OPERATION_POLICIES.get(
+        operation,
+        OperationPolicy(operation, None, "deny", "unknown", "unknown", "UNKNOWN_OPERATION"),
+    )
+
+
+def _has_scope(auth_context: Any, required_scope: str | None) -> bool:
+    if not required_scope:
+        return True
+    scopes = set(auth_context.oauth_scopes or [])
+    return required_scope in scopes
+
+
+def authorize_operation(auth_context: Any | None, operation: str) -> None:
+    """Authorize an operation for Doris OAuth. Legacy auth methods pass through."""
+    if auth_context is None:
+        return
+
+    if auth_context.auth_method != "doris_oauth":
+        return
+
+    policy = resolve_operation_policy(operation, auth_context)
+    if policy.doris_oauth_policy != "allow":
+        raise OperationAuthorizationError(
+            f"Operation is not supported for Doris OAuth: {operation}",
+            status_code=403,
+            error_code=policy.error_code or "UNSUPPORTED_FOR_DORIS_OAUTH",
+            required_scope=policy.required_scope,
+            operation=operation,
+        )
+
+    if not _has_scope(auth_context, policy.required_scope):
+        raise OperationAuthorizationError(
+            f"Missing required scope: {policy.required_scope}",
+            status_code=403,
+            error_code="PERMISSION_DENIED",
+            required_scope=policy.required_scope,
+            operation=operation,
+        )
+
+
+def filter_tools_for_auth_context(auth_context: Any | None, tools: list[Any]) -> list[Any]:
+    """Filter visible tools for Doris OAuth users."""
+    if auth_context is None or auth_context.auth_method != "doris_oauth":
+        return tools
+
+    filtered = []
+    for tool in tools:
+        tool_name = getattr(tool, "name", "")
+        try:
+            authorize_operation(auth_context, f"tool:{tool_name}")
+        except OperationAuthorizationError:
+            continue
+        filtered.append(tool)
+    return filtered

--- a/doris_mcp_server/auth/token_manager.py
+++ b/doris_mcp_server/auth/token_manager.py
@@ -34,7 +34,7 @@ from typing import Dict, List, Optional, Any
 from pathlib import Path
 
 from ..utils.logger import get_logger
-from ..utils.security import SecurityLevel
+from ..utils.security import RESERVED_DORIS_OAUTH_TOKEN_PREFIX, SecurityLevel
 
 
 @dataclass
@@ -114,6 +114,13 @@ class TokenManager:
             self._start_hot_reload()
         
         self.logger.info(f"TokenManager initialized with {len(self._tokens)} tokens, hot reload: {self.enable_hot_reload}")
+
+    def _validate_static_token_prefix(self, token: str):
+        if token.startswith(RESERVED_DORIS_OAUTH_TOKEN_PREFIX):
+            raise ValueError(
+                f"Static tokens cannot use reserved Doris OAuth prefix "
+                f"'{RESERVED_DORIS_OAUTH_TOKEN_PREFIX}'"
+            )
     
     def _initialize_default_tokens(self):
         """Initialize default tokens for basic authentication (configurable via environment)"""
@@ -208,6 +215,7 @@ class TokenManager:
             
             # Hash the token
             raw_token = token_config['token']
+            self._validate_static_token_prefix(raw_token)
             token_hash = self._hash_token(raw_token)
             
             # Store token
@@ -284,6 +292,8 @@ class TokenManager:
                 
                 self._add_token_from_config(token_config)
                 
+            except ValueError:
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to load token {token_id} from environment: {e}")
     
@@ -306,6 +316,8 @@ class TokenManager:
             
             self.logger.info(f"Loaded {len(tokens_list)} tokens from file: {self.token_file_path}")
             
+        except ValueError:
+            raise
         except Exception as e:
             self.logger.error(f"Failed to load tokens from file {self.token_file_path}: {e}")
     
@@ -385,6 +397,7 @@ class TokenManager:
                 raw_token = custom_token
             else:
                 raw_token = self.generate_token()
+            self._validate_static_token_prefix(raw_token)
             
             # Calculate expiration
             expires_at = None

--- a/doris_mcp_server/main.py
+++ b/doris_mcp_server/main.py
@@ -26,6 +26,7 @@ import argparse
 import asyncio
 import json
 import logging
+import sys
 from typing import Any
 
 # MCP version compatibility handling
@@ -209,9 +210,15 @@ if not _import_mcp_with_compatibility():
 from .tools.tools_manager import DorisToolsManager
 from .tools.prompts_manager import DorisPromptsManager
 from .tools.resources_manager import DorisResourcesManager
-from .utils.config import DorisConfig
+from .auth.operation_policy import OperationAuthorizationError, authorize_operation
+from .utils.config import (
+    DorisConfig,
+    _mark_source,
+    get_effective_auth_config,
+    normalize_effective_auth_config,
+)
 from .utils.db import DorisConnectionManager
-from .utils.security import DorisSecurityManager
+from .utils.security import DorisSecurityManager, get_current_auth_context
 import os
 
 # Configure logging - will be properly initialized later
@@ -239,6 +246,7 @@ class DorisServer:
         
         # Set connection manager reference in security manager for database validation
         self.security_manager.connection_manager = self.connection_manager
+        self.security_manager.auth_provider.configure_doris_oauth(self.connection_manager)
 
         # Initialize independent managers
         self.resources_manager = DorisResourcesManager(self.connection_manager)
@@ -332,23 +340,33 @@ class DorisServer:
         async def handle_list_resources() -> list[Resource]:
             """Handle resource list request"""
             try:
+                authorize_operation(get_current_auth_context(), "list_resources")
                 self.logger.info("Handling resource list request")
                 resources = await self.resources_manager.list_resources()
                 self.logger.info(f"Returning {len(resources)} resources")
                 return resources
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to handle resource list request: {e}")
+                if getattr(get_current_auth_context(), "auth_method", "") == "doris_oauth":
+                    raise
                 return []
 
         @self.server.read_resource()
         async def handle_read_resource(uri: str) -> str:
             """Handle resource read request"""
             try:
+                authorize_operation(get_current_auth_context(), "read_resource")
                 self.logger.info(f"Handling resource read request: {uri}")
                 content = await self.resources_manager.read_resource(uri)
                 return content
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to handle resource read request: {e}")
+                if getattr(get_current_auth_context(), "auth_method", "") == "doris_oauth":
+                    raise
                 return json.dumps(
                     {"error": f"Failed to read resource: {str(e)}", "uri": uri},
                     ensure_ascii=False,
@@ -359,10 +377,13 @@ class DorisServer:
         async def handle_list_tools() -> list[Tool]:
             """Handle tool list request"""
             try:
+                authorize_operation(get_current_auth_context(), "list_tools")
                 self.logger.info("Handling tool list request")
                 tools = await self.tools_manager.list_tools()
                 self.logger.info(f"Returning {len(tools)} tools")
                 return tools
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to handle tool list request: {e}")
                 return []
@@ -377,6 +398,8 @@ class DorisServer:
                 result = await self.tools_manager.call_tool(name, arguments)
 
                 return [TextContent(type="text", text=result)]
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to handle tool call request: {e}")
                 error_result = json.dumps(
@@ -395,10 +418,13 @@ class DorisServer:
         async def handle_list_prompts() -> list[Prompt]:
             """Handle prompt list request"""
             try:
+                authorize_operation(get_current_auth_context(), "list_prompts")
                 self.logger.info("Handling prompt list request")
                 prompts = await self.prompts_manager.list_prompts()
                 self.logger.info(f"Returning {len(prompts)} prompts")
                 return prompts
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to handle prompt list request: {e}")
                 return []
@@ -407,9 +433,12 @@ class DorisServer:
         async def handle_get_prompt(name: str, arguments: dict[str, Any]) -> str:
             """Handle prompt get request"""
             try:
+                authorize_operation(get_current_auth_context(), "get_prompt")
                 self.logger.info(f"Handling prompt get request: {name}")
                 result = await self.prompts_manager.get_prompt(name, arguments)
                 return result
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 self.logger.error(f"Failed to handle prompt get request: {e}")
                 error_result = json.dumps(
@@ -507,6 +536,12 @@ class DorisServer:
             if global_pool_created:
                 self.logger.info("Global database connection pool available for HTTP mode")
             else:
+                effective_auth = get_effective_auth_config(self.config)
+                if effective_auth.enable_doris_oauth_auth:
+                    raise RuntimeError(
+                        "Doris OAuth requires the configured service/global Doris account "
+                        "to initialize successfully in Phase 3"
+                    )
                 self.logger.info("HTTP mode running without global database pool, will use token-bound configurations")
 
             # Use Starlette and StreamableHTTPSessionManager according to official example
@@ -569,6 +604,13 @@ class DorisServer:
                 
             async def token_management(request):
                 return await token_handlers.handle_management_page(request)
+
+            doris_oauth_handlers = None
+            if self.security_manager.auth_provider.doris_oauth_provider:
+                from .auth.doris_oauth_handlers import DorisOAuthHandlers
+                doris_oauth_handlers = DorisOAuthHandlers(
+                    self.security_manager.auth_provider.doris_oauth_provider
+                )
             
             # Lifecycle manager - simplified since we manage session_manager externally
             @contextlib.asynccontextmanager
@@ -580,25 +622,64 @@ class DorisServer:
                 finally:
                     self.logger.info("Application is shutting down...")
             
-            # Create ASGI application - use direct session manager as ASGI app
-            starlette_app = Starlette(
-                debug=True,
-                routes=[
-                    Route("/health", health_check, methods=["GET"]),
-                    # OAuth endpoints
+            effective_auth = get_effective_auth_config(self.config)
+            routes = [Route("/health", health_check, methods=["GET"])]
+            if effective_auth.enable_external_oauth_auth:
+                routes.extend([
                     Route("/auth/login", oauth_login, methods=["GET"]),
                     Route("/auth/callback", oauth_callback, methods=["GET"]),
                     Route("/auth/provider", oauth_provider_info, methods=["GET"]),
                     Route("/auth/demo", oauth_demo, methods=["GET"]),
-                    # Token management endpoints
-                    Route("/token/create", token_create, methods=["GET", "POST"]),
-                    Route("/token/revoke", token_revoke, methods=["GET", "DELETE"]),
-                    Route("/token/list", token_list, methods=["GET"]),
-                    Route("/token/stats", token_stats, methods=["GET"]),
-                    Route("/token/cleanup", token_cleanup, methods=["GET", "POST"]),
-                    Route("/token/management", token_management, methods=["GET"]),
-                ],
+                ])
+            if effective_auth.enable_doris_oauth_auth and doris_oauth_handlers:
+                routes.extend(doris_oauth_handlers.routes())
+            routes.extend([
+                Route("/token/create", token_create, methods=["GET", "POST"]),
+                Route("/token/revoke", token_revoke, methods=["GET", "DELETE"]),
+                Route("/token/list", token_list, methods=["GET"]),
+                Route("/token/stats", token_stats, methods=["GET"]),
+                Route("/token/cleanup", token_cleanup, methods=["GET", "POST"]),
+                Route("/token/management", token_management, methods=["GET"]),
+            ])
+
+            # Create ASGI application - use direct session manager as ASGI app
+            starlette_app = Starlette(
+                debug=True,
+                routes=routes,
                 lifespan=lifespan,
+            )
+
+            from .auth.mcp_auth_middleware import MCPAuthASGIMiddleware
+
+            async def authenticated_mcp_downstream(scope, receive, send):
+                """Handle authenticated MCP request after auth context is set."""
+                method = scope.get("method", "UNKNOWN")
+                headers = dict(scope.get("headers", []))
+
+                # Handle Dify compatibility for GET requests
+                if method == "GET":
+                    accept_header = headers.get(b'accept', b'').decode('utf-8')
+
+                    # For other GET requests, try to add application/json to Accept header
+                    if 'text/event-stream' in accept_header and 'application/json' not in accept_header:
+                        self.logger.info("Adding application/json to Accept header for GET request")
+                        new_headers = []
+                        for name, value in scope.get("headers", []):
+                            if name == b'accept':
+                                new_value = value.decode('utf-8') + ', application/json'
+                                new_headers.append((name, new_value.encode('utf-8')))
+                            else:
+                                new_headers.append((name, value))
+                        scope = dict(scope)
+                        scope["headers"] = new_headers
+                        self.logger.info(f"Modified Accept header to: {new_value}")
+
+                await session_manager.handle_request(scope, receive, send)
+
+            mcp_auth_middleware = MCPAuthASGIMiddleware(
+                self.security_manager,
+                authenticated_mcp_downstream,
+                effective_auth,
             )
             
             # Custom ASGI app that handles both /mcp and /mcp/ without redirects
@@ -614,80 +695,26 @@ class DorisServer:
                     self.logger.info(f"Received request for path: {path}")
                     
                     try:
-                        # Handle health check, auth, and token management endpoints  
+                        # Handle health check, auth, OAuth, and token management endpoints.
+                        if effective_auth.enable_doris_oauth_auth and path.startswith("/auth/"):
+                            response = JSONResponse({"error": "external_oauth_disabled"}, status_code=404)
+                            await response(scope, receive, send)
+                            return
+
                         if (path.startswith("/health") or 
                             path.startswith("/auth/") or 
-                            path.startswith("/token/")):
+                            path.startswith("/token/") or
+                            path.startswith("/.well-known/") or
+                            path.startswith("/oauth/") or
+                            path == "/doris-login" or
+                            path.startswith("/api/auth/")):
                             await starlette_app(scope, receive, send)
                             return
                         
                         # Handle MCP requests - both /mcp and /mcp/ go to session manager
                         if path == "/mcp" or path.startswith("/mcp/"):
                             self.logger.info(f"Handling MCP request for path: {path}")
-                            # Log request details for debugging
-                            method = scope.get("method", "UNKNOWN")
-                            headers = dict(scope.get("headers", []))
-                            self.logger.info(f"MCP Request - Method: {method}")
-                            self.logger.info(f"MCP Request - Headers: {headers}")
-                            
-                            # Authentication check for MCP requests
-                            try:
-                                # Extract authentication information
-                                auth_info = await self._extract_auth_info_from_scope(scope, headers)
-
-                                # Authenticate the request
-                                auth_context = await self.security_manager.authenticate_request(auth_info)
-                                self.logger.info(f"MCP request authenticated: token_id={auth_context.token_id}, client_ip={auth_context.client_ip}")
-
-                                # Store auth context in scope for potential use by tools/resources
-                                scope["auth_context"] = auth_context
-
-                                # FIX for Issue #62 Bug 1: Set auth_context in context variable
-                                # This allows tools to access token information for token-bound database configuration
-                                # CRITICAL: Use the global ContextVar from security.py to ensure same instance is used everywhere
-                                try:
-                                    from .utils.security import mcp_auth_context_var
-                                    mcp_auth_context_var.set(auth_context)
-                                    self.logger.debug(f"Set auth_context in context variable with token: {bool(hasattr(auth_context, 'token') and auth_context.token)}")
-                                except Exception as ctx_error:
-                                    self.logger.warning(f"Failed to set auth_context in context variable: {ctx_error}")
-
-                            except Exception as auth_error:
-                                self.logger.error(f"MCP authentication failed: {auth_error}")
-                                # Return 401 Unauthorized
-                                from starlette.responses import JSONResponse
-                                response = JSONResponse(
-                                    {"error": "Authentication required", "message": str(auth_error)},
-                                    status_code=401
-                                )
-                                await response(scope, receive, send)
-                                return
-                            
-                            # Handle Dify compatibility for GET requests
-                            if method == "GET":
-                                accept_header = headers.get(b'accept', b'').decode('utf-8')
-                                user_agent = headers.get(b'user-agent', b'').decode('utf-8')
-                                
-
-                                
-                                # For other GET requests, try to add application/json to Accept header
-                                if 'text/event-stream' in accept_header and 'application/json' not in accept_header:
-                                    self.logger.info("Adding application/json to Accept header for GET request")
-                                    # Modify headers to include both content types
-                                    new_headers = []
-                                    for name, value in scope.get("headers", []):
-                                        if name == b'accept':
-                                            # Add application/json to the accept header
-                                            new_value = value.decode('utf-8') + ', application/json'
-                                            new_headers.append((name, new_value.encode('utf-8')))
-                                        else:
-                                            new_headers.append((name, value))
-                                    # Update scope with modified headers
-                                    scope = dict(scope)
-                                    scope["headers"] = new_headers
-                                    self.logger.info(f"Modified Accept header to: {new_value}")
-                            
-                            await session_manager.handle_request(scope, receive, send)
+                            await mcp_auth_middleware(scope, receive, send)
                             return
                         
                         # 404 for other paths
@@ -854,15 +881,20 @@ def update_configuration(config: DorisConfig):
     # For some arguments, if not specified, environment variables or default configurations will be used as default values
     parser = create_arg_parser()
     args = parser.parse_args()
+    argv = sys.argv[1:]
+
+    def cli_has(*options: str) -> bool:
+        return any(arg == option or arg.startswith(f"{option}=") for arg in argv for option in options)
 
     # Update config values
     # Command line arguments override configuration (if provided)
     # basic
-    if args.transport != _default_config.transport:
+    if cli_has("--transport"):
         config.transport = args.transport
-    if args.host != _default_config.server_host:
+        _mark_source(config, "transport", "cli")
+    if cli_has("--host"):
         config.server_host = args.host
-    if args.port != _default_config.server_port:
+    if cli_has("--port"):
         config.server_port = args.port
     server_name = os.getenv("SERVER_NAME")
     if server_name:
@@ -872,24 +904,25 @@ def update_configuration(config: DorisConfig):
         config.server_version = server_version
  
     # database
-    if args.doris_host != _default_config.database.host:  # If not default value, use command line argument
+    if cli_has("--doris-host", "--db-host"):
         config.database.host = args.doris_host
-    if args.doris_port != _default_config.database.port:
+    if cli_has("--doris-port", "--db-port"):
         config.database.port = args.doris_port
-    if args.doris_user != _default_config.database.user:
+    if cli_has("--doris-user", "--db-user"):
         config.database.user = args.doris_user
-    if args.doris_password:  # Use password if provided
+    if cli_has("--doris-password", "--db-password"):
         config.database.password = args.doris_password
-    if args.doris_database != _default_config.database.database:
+    if cli_has("--doris-database", "--db-name"):
         config.database.database = args.doris_database
 
     # logging
-    if args.log_level != _default_config.logging.level:
+    if cli_has("--log-level"):
         config.logging.level = args.log_level
     
     # workers (add to config for HTTP mode)
-    if hasattr(args, 'workers'):
+    if hasattr(args, 'workers') and cli_has("--workers"):
         config.workers = args.workers
+        _mark_source(config, "workers", "cli")
 
 
 async def main():
@@ -917,6 +950,19 @@ async def main():
     logger.info(f"Transport: {config.transport}")
     logger.info(f"Log Level: {config.logging.level}")
 
+    try:
+        effective_auth = normalize_effective_auth_config(
+            config, requested_workers=getattr(config, "workers", 1)
+        )
+    except Exception as auth_config_error:
+        logger.error(f"Invalid authentication configuration: {auth_config_error}")
+        return 1
+
+    if effective_auth.auth_config_warnings:
+        for warning in effective_auth.auth_config_warnings:
+            logger.warning(warning)
+    config.workers = effective_auth.effective_workers
+
     # Create server instance
     server = DorisServer(config)
 
@@ -924,13 +970,7 @@ async def main():
         if config.transport == "stdio":
             await server.start_stdio()
         elif config.transport == "http":
-            # Get workers configuration with auto-detection support
-            workers = getattr(config, 'workers', 1)
-            if workers == 0:
-                import multiprocessing
-                workers = multiprocessing.cpu_count()
-                logger.info(f"Auto-detected {workers} CPU cores for worker processes")
-            
+            workers = getattr(config, 'workers', effective_auth.effective_workers)
             await server.start_http(config.server_host, config.server_port, workers)
         else:
             logger.error(f"Unsupported transport protocol: {config.transport}")

--- a/doris_mcp_server/multiworker_app.py
+++ b/doris_mcp_server/multiworker_app.py
@@ -217,9 +217,10 @@ from starlette.responses import JSONResponse, Response
 from .tools.tools_manager import DorisToolsManager
 from .tools.prompts_manager import DorisPromptsManager
 from .tools.resources_manager import DorisResourcesManager
-from .utils.config import DorisConfig
+from .auth.operation_policy import OperationAuthorizationError, authorize_operation
+from .utils.config import DorisConfig, get_effective_auth_config, normalize_effective_auth_config
 from .utils.db import DorisConnectionManager
-from .utils.security import DorisSecurityManager
+from .utils.security import DorisSecurityManager, get_current_auth_context
 
 # Global variables for worker-specific instances
 _worker_server = None
@@ -228,6 +229,8 @@ _worker_connection_manager = None
 _worker_security_manager = None
 _worker_session_manager_context = None
 _worker_initialized = False
+_worker_effective_auth = None
+_doris_oauth_handlers = None
 
 def get_mcp_capabilities():
     """Get MCP capabilities for worker - use the same logic as main.py"""
@@ -259,7 +262,7 @@ def get_mcp_capabilities():
 
 async def initialize_worker():
     """Initialize MCP server and managers for this worker process"""
-    global _worker_server, _worker_session_manager, _worker_connection_manager, _worker_security_manager, _worker_session_manager_context, _worker_initialized, _oauth_handlers, _token_handlers
+    global _worker_server, _worker_session_manager, _worker_connection_manager, _worker_security_manager, _worker_session_manager_context, _worker_initialized, _oauth_handlers, _token_handlers, _worker_effective_auth, _doris_oauth_handlers
     
     if _worker_initialized:
         return
@@ -273,6 +276,9 @@ async def initialize_worker():
         
         # Create configuration
         config = DorisConfig.from_env()
+        _worker_effective_auth = normalize_effective_auth_config(
+            config, requested_workers=getattr(config, "workers", 1)
+        )
         
         # Initialize enhanced logging system
         from .utils.config import ConfigManager
@@ -292,6 +298,7 @@ async def initialize_worker():
         
         # Set connection manager reference in security manager for database validation
         _worker_security_manager.connection_manager = _worker_connection_manager
+        _worker_security_manager.auth_provider.configure_doris_oauth(_worker_connection_manager)
         
         await _worker_connection_manager.initialize()
         
@@ -308,23 +315,33 @@ async def initialize_worker():
         async def handle_list_resources() -> list[Resource]:
             """Handle resource list request"""
             try:
+                authorize_operation(get_current_auth_context(), "list_resources")
                 logger.info("Handling resource list request in worker")
                 resources = await resources_manager.list_resources()
                 logger.info(f"Returning {len(resources)} resources from worker")
                 return resources
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 logger.error(f"Failed to handle resource list request in worker: {e}")
+                if getattr(get_current_auth_context(), "auth_method", "") == "doris_oauth":
+                    raise
                 return []
 
         @_worker_server.read_resource()
         async def handle_read_resource(uri: str) -> str:
             """Handle resource read request"""
             try:
+                authorize_operation(get_current_auth_context(), "read_resource")
                 logger.info(f"Handling resource read request in worker: {uri}")
                 content = await resources_manager.read_resource(uri)
                 return content
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 logger.error(f"Failed to handle resource read request in worker: {e}")
+                if getattr(get_current_auth_context(), "auth_method", "") == "doris_oauth":
+                    raise
                 return json.dumps(
                     {"error": f"Failed to read resource: {str(e)}", "uri": uri},
                     ensure_ascii=False,
@@ -335,10 +352,13 @@ async def initialize_worker():
         async def handle_list_tools() -> list[Tool]:
             """Handle tool list request"""
             try:
+                authorize_operation(get_current_auth_context(), "list_tools")
                 logger.info("Handling tool list request in worker")
                 tools = await tools_manager.list_tools()
                 logger.info(f"Returning {len(tools)} tools from worker")
                 return tools
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 logger.error(f"Failed to handle tool list request in worker: {e}")
                 return []
@@ -350,6 +370,8 @@ async def initialize_worker():
                 logger.info(f"Handling tool call request in worker: {name}")
                 result = await tools_manager.call_tool(name, arguments)
                 return [TextContent(type="text", text=result)]
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 logger.error(f"Failed to handle tool call request in worker: {e}")
                 error_result = json.dumps(
@@ -367,10 +389,13 @@ async def initialize_worker():
         async def handle_list_prompts() -> list[Prompt]:
             """Handle prompt list request"""
             try:
+                authorize_operation(get_current_auth_context(), "list_prompts")
                 logger.info("Handling prompt list request in worker")
                 prompts = await prompts_manager.list_prompts()
                 logger.info(f"Returning {len(prompts)} prompts from worker")
                 return prompts
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 logger.error(f"Failed to handle prompt list request in worker: {e}")
                 return []
@@ -379,9 +404,12 @@ async def initialize_worker():
         async def handle_get_prompt(name: str, arguments: dict[str, Any]) -> str:
             """Handle prompt get request"""
             try:
+                authorize_operation(get_current_auth_context(), "get_prompt")
                 logger.info(f"Handling prompt get request in worker: {name}")
                 result = await prompts_manager.get_prompt(name, arguments)
                 return result
+            except OperationAuthorizationError:
+                raise
             except Exception as e:
                 logger.error(f"Failed to handle prompt get request in worker: {e}")
                 error_result = json.dumps(
@@ -413,6 +441,11 @@ async def initialize_worker():
         from .auth.token_handlers import TokenHandlers
         _oauth_handlers = OAuthHandlers(_worker_security_manager)
         _token_handlers = TokenHandlers(_worker_security_manager, config)
+        if _worker_effective_auth.enable_doris_oauth_auth:
+            from .auth.doris_oauth_handlers import DorisOAuthHandlers
+            _doris_oauth_handlers = DorisOAuthHandlers(
+                _worker_security_manager.auth_provider.doris_oauth_provider
+            )
         
         _worker_initialized = True
         logger.info(f"Worker {os.getpid()} MCP initialization completed successfully")
@@ -504,6 +537,64 @@ async def token_management(request):
         return HTMLResponse("<h1>Token handlers not initialized</h1>")
     return await _token_handlers.handle_management_page(request)
 
+
+async def doris_oauth_unavailable(request):
+    return JSONResponse({"error": "doris_oauth_not_initialized"}, status_code=503)
+
+
+async def doris_oauth_protected_resource_metadata(request):
+    if not _doris_oauth_handlers:
+        return await doris_oauth_unavailable(request)
+    return await _doris_oauth_handlers.protected_resource_metadata(request)
+
+
+async def doris_oauth_authorization_server_metadata(request):
+    if not _doris_oauth_handlers:
+        return await doris_oauth_unavailable(request)
+    return await _doris_oauth_handlers.authorization_server_metadata(request)
+
+
+async def doris_oauth_register(request):
+    if not _doris_oauth_handlers:
+        return await doris_oauth_unavailable(request)
+    return await _doris_oauth_handlers.register(request)
+
+
+async def doris_oauth_authorize(request):
+    if not _doris_oauth_handlers:
+        return await doris_oauth_unavailable(request)
+    return await _doris_oauth_handlers.authorize(request)
+
+
+async def doris_oauth_token(request):
+    if not _doris_oauth_handlers:
+        return await doris_oauth_unavailable(request)
+    return await _doris_oauth_handlers.token(request)
+
+
+async def doris_oauth_revoke(request):
+    if not _doris_oauth_handlers:
+        return await doris_oauth_unavailable(request)
+    return await _doris_oauth_handlers.revoke(request)
+
+
+async def doris_oauth_login(request):
+    if not _doris_oauth_handlers:
+        return await doris_oauth_unavailable(request)
+    return await _doris_oauth_handlers.login(request)
+
+
+async def doris_oauth_api_token(request):
+    if not _doris_oauth_handlers:
+        return await doris_oauth_unavailable(request)
+    return await _doris_oauth_handlers.api_token(request)
+
+
+async def doris_oauth_api_refresh(request):
+    if not _doris_oauth_handlers:
+        return await doris_oauth_unavailable(request)
+    return await _doris_oauth_handlers.api_refresh(request)
+
 async def root_info(request):
     """Root endpoint"""
     return JSONResponse({
@@ -589,8 +680,19 @@ async def mcp_asgi_app(scope, receive, send):
     method = scope.get('method', 'UNKNOWN')
     logger.debug(f"Worker {os.getpid()} handling MCP request: {method} {path}")
     
-    # Handle the request directly without nested run context
-    await _worker_session_manager.handle_request(scope, receive, send)
+    from .auth.mcp_auth_middleware import MCPAuthASGIMiddleware
+
+    async def downstream(authenticated_scope, authenticated_receive, authenticated_send):
+        await _worker_session_manager.handle_request(
+            authenticated_scope, authenticated_receive, authenticated_send
+        )
+
+    middleware = MCPAuthASGIMiddleware(
+        _worker_security_manager,
+        downstream,
+        _worker_effective_auth or get_effective_auth_config(_worker_security_manager.config),
+    )
+    await middleware(scope, receive, send)
 
 # Create Starlette app with basic routes
 basic_app = Starlette(
@@ -603,6 +705,16 @@ basic_app = Starlette(
         Route("/auth/callback", oauth_callback, methods=["GET"]),
         Route("/auth/provider", oauth_provider_info, methods=["GET"]),
         Route("/auth/demo", oauth_demo, methods=["GET"]),
+        # Doris OAuth endpoints are explicit to avoid top-level silent 404s.
+        Route("/.well-known/oauth-protected-resource", doris_oauth_protected_resource_metadata, methods=["GET"]),
+        Route("/.well-known/oauth-authorization-server", doris_oauth_authorization_server_metadata, methods=["GET"]),
+        Route("/oauth/register", doris_oauth_register, methods=["POST"]),
+        Route("/oauth/authorize", doris_oauth_authorize, methods=["GET"]),
+        Route("/oauth/token", doris_oauth_token, methods=["POST"]),
+        Route("/oauth/revoke", doris_oauth_revoke, methods=["POST"]),
+        Route("/doris-login", doris_oauth_login, methods=["GET", "POST"]),
+        Route("/api/auth/token", doris_oauth_api_token, methods=["POST"]),
+        Route("/api/auth/refresh", doris_oauth_api_refresh, methods=["POST"]),
         # Token management endpoints
         Route("/token/create", token_create, methods=["GET", "POST"]),
         Route("/token/revoke", token_revoke, methods=["GET", "DELETE"]),
@@ -622,6 +734,16 @@ async def app(scope, receive, send):
     if path == "/mcp" or path.startswith('/mcp/'):
         # Handle MCP requests with session manager
         await mcp_asgi_app(scope, receive, send)
+    elif path.startswith("/auth/") and _worker_effective_auth and not _worker_effective_auth.enable_external_oauth_auth:
+        response = JSONResponse({"error": "external_oauth_disabled"}, status_code=404)
+        await response(scope, receive, send)
+    elif (
+        path.startswith("/.well-known/")
+        or path.startswith("/oauth/")
+        or path == "/doris-login"
+        or path.startswith("/api/auth/")
+    ):
+        await basic_app(scope, receive, send)
     else:
         # Handle other requests with basic Starlette app (includes auth endpoints)
         await basic_app(scope, receive, send)

--- a/doris_mcp_server/tools/resources_manager.py
+++ b/doris_mcp_server/tools/resources_manager.py
@@ -20,8 +20,10 @@ Provides standardized abstraction and access interface for database metadata
 """
 
 import json
+from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any
+from urllib.parse import quote, unquote
 
 from mcp.types import Resource
 
@@ -39,31 +41,43 @@ class TableMetadata:
         row_count: int = 0,
         columns: list[dict] = None,
         create_time: datetime = None,
+        database: str | None = None,
     ):
         self.name = name
         self.comment = comment
         self.row_count = row_count
         self.columns = columns or []
         self.create_time = create_time
+        self.database = database
 
 
 class ViewMetadata:
     """Data view metadata"""
 
-    def __init__(self, name: str, comment: str = None, definition: str = None):
+    def __init__(
+        self,
+        name: str,
+        comment: str = None,
+        definition: str = None,
+        database: str | None = None,
+    ):
         self.name = name
         self.comment = comment
         self.definition = definition
+        self.database = database
 
 
 class MetadataCache:
     """Metadata cache manager"""
 
-    def __init__(self, ttl_seconds: int = 300):
+    def __init__(self, ttl_seconds: int = 300, enabled: bool = False):
         self.cache = {}
         self.ttl = ttl_seconds
+        self.enabled = enabled
 
     async def get(self, key: str) -> Any | None:
+        if not self.enabled:
+            return None
         if key in self.cache:
             data, timestamp = self.cache[key]
             if datetime.now().timestamp() - timestamp < self.ttl:
@@ -73,7 +87,27 @@ class MetadataCache:
         return None
 
     async def set(self, key: str, value: Any):
+        if not self.enabled:
+            return
         self.cache[key] = (value, datetime.now().timestamp())
+
+
+class DorisOAuthResourceError(RuntimeError):
+    """Structured resources metadata failure for Doris OAuth requests."""
+
+    def __init__(self, message: str, *, error_code: str, status_code: int):
+        super().__init__(message)
+        self.error_code = error_code
+        self.status_code = status_code
+
+
+EXCLUDED_RESOURCE_DATABASES = {
+    "information_schema",
+    "mysql",
+    "performance_schema",
+    "sys",
+    "doris_metadata",
+}
 
 
 class DorisResourcesManager:
@@ -81,19 +115,115 @@ class DorisResourcesManager:
 
     def __init__(self, connection_manager: DorisConnectionManager):
         self.connection_manager = connection_manager
-        self.metadata_cache = MetadataCache()
+        # Resource metadata cache is disabled until it is identity-aware.
+        # Static token-bound DB and Doris OAuth can route to different Doris
+        # users; global cache keys would leak metadata across identities.
+        self.metadata_cache = MetadataCache(enabled=False)
+
+    def _is_doris_oauth_context(self) -> bool:
+        return getattr(get_auth_context(), "auth_method", "") == "doris_oauth"
+
+    def _schema_filter(self, column_name: str, db_name: str | None) -> tuple[str, tuple]:
+        if db_name:
+            return f"{column_name} = %s", (db_name,)
+        return f"{column_name} = DATABASE()", ()
+
+    def _first_row_value(self, row: Any) -> Any:
+        if isinstance(row, dict):
+            return next(iter(row.values()), None)
+        if isinstance(row, (list, tuple)):
+            return row[0] if row else None
+        return row
+
+    def _visible_resource_database(self, db_name: str | None) -> bool:
+        return bool(db_name) and str(db_name).lower() not in EXCLUDED_RESOURCE_DATABASES
+
+    def _resource_uri_segment(self, value: Any) -> str:
+        return quote(str(value), safe="")
+
+    def _decode_resource_uri_segment(self, value: str) -> str:
+        return unquote(value)
+
+    def _stats_resource_uri(self, db_name: str) -> str:
+        segment = self._resource_uri_segment(db_name)
+        if segment == "database":
+            return f"doris://stats/database/{segment}"
+        return f"doris://stats/{segment}"
+
+    def _resource_error_from_exception(self, exc: Exception) -> DorisOAuthResourceError:
+        error_code = getattr(exc, "error_code", None)
+        status_code = getattr(exc, "status_code", None)
+        message = str(exc) or exc.__class__.__name__
+        if error_code:
+            return DorisOAuthResourceError(
+                message,
+                error_code=str(error_code),
+                status_code=int(status_code or 500),
+            )
+
+        mysql_error_code = None
+        if getattr(exc, "args", None):
+            try:
+                mysql_error_code = int(exc.args[0])
+            except (TypeError, ValueError):
+                mysql_error_code = None
+        if mysql_error_code in {1044, 1045, 1049, 1142, 1227}:
+            return DorisOAuthResourceError(
+                message,
+                error_code="DORIS_OAUTH_METADATA_PERMISSION_DENIED",
+                status_code=403,
+            )
+
+        lowered = message.lower()
+        permission_markers = ("permission denied", "access denied", "not authorized", "privilege")
+        if any(marker in lowered for marker in permission_markers):
+            return DorisOAuthResourceError(
+                message,
+                error_code="DORIS_OAUTH_METADATA_PERMISSION_DENIED",
+                status_code=403,
+            )
+        return DorisOAuthResourceError(
+            message,
+            error_code="DORIS_OAUTH_METADATA_BACKEND_ERROR",
+            status_code=502,
+        )
+
+    def _reraise_if_doris_oauth_resource_error(self, exc: Exception) -> None:
+        if isinstance(exc, DorisOAuthResourceError):
+            raise exc
+        if self._is_doris_oauth_context():
+            raise self._resource_error_from_exception(exc) from exc
+
+    @asynccontextmanager
+    async def _connection_context(self, session_id: str = "system"):
+        manager_context = getattr(self.connection_manager, "get_connection_context", None)
+        if manager_context:
+            async with manager_context(session_id) as connection:
+                yield connection
+            return
+
+        connection = await self.connection_manager.get_connection(session_id)
+        try:
+            yield connection
+        finally:
+            release = getattr(self.connection_manager, "release_connection", None)
+            if release:
+                await release(session_id, connection)
 
     async def list_resources(self) -> list[Resource]:
         """List all available database resources"""
         resources = []
 
         try:
+            if self._is_doris_oauth_context():
+                return await self._list_doris_oauth_resources()
+
             # Get metadata for all tables
             tables = await self._get_table_metadata()
             for table in tables:
                 resources.append(
                     Resource(
-                        uri=f"doris://table/{table.name}",
+                        uri=f"doris://table/{self._resource_uri_segment(table.name)}",
                         name=f"Data Table: {table.name}",
                         description=f"{table.comment or 'Data table'} (rows: {table.row_count:,})",
                         mimeType="application/json",
@@ -105,7 +235,7 @@ class DorisResourcesManager:
             for view in views:
                 resources.append(
                     Resource(
-                        uri=f"doris://view/{view.name}",
+                        uri=f"doris://view/{self._resource_uri_segment(view.name)}",
                         name=f"Data View: {view.name}",
                         description=f"{view.comment or 'Data view'}",
                         mimeType="application/json",
@@ -123,25 +253,71 @@ class DorisResourcesManager:
             )
 
         except Exception as e:
+            self._reraise_if_doris_oauth_resource_error(e)
             print(f"Failed to get resource list: {e}")
 
+        return resources
+
+    async def _list_doris_oauth_resources(self) -> list[Resource]:
+        """List database-qualified resources visible to the routed Doris user."""
+        resources: list[Resource] = []
+        async with self._connection_context("system") as connection:
+            databases = await self._get_visible_databases(connection)
+            for db_name in databases:
+                tables = await self._get_table_metadata_for_database(connection, db_name)
+                for table in tables:
+                    resources.append(
+                        Resource(
+                            uri=(
+                                f"doris://table/{self._resource_uri_segment(db_name)}/"
+                                f"{self._resource_uri_segment(table.name)}"
+                            ),
+                            name=f"Data Table: {db_name}.{table.name}",
+                            description=f"{table.comment or 'Data table'} (rows: {table.row_count:,})",
+                            mimeType="application/json",
+                        )
+                    )
+
+                views = await self._get_view_metadata_for_database(connection, db_name)
+                for view in views:
+                    resources.append(
+                        Resource(
+                            uri=(
+                                f"doris://view/{self._resource_uri_segment(db_name)}/"
+                                f"{self._resource_uri_segment(view.name)}"
+                            ),
+                            name=f"Data View: {db_name}.{view.name}",
+                            description=f"{view.comment or 'Data view'}",
+                            mimeType="application/json",
+                        )
+                    )
+
+                resources.append(
+                    Resource(
+                        uri=self._stats_resource_uri(db_name),
+                        name=f"Database Statistics: {db_name}",
+                        description=f"Overall database statistics for {db_name}",
+                        mimeType="application/json",
+                    )
+                )
         return resources
 
     async def read_resource(self, uri: str) -> str:
         """Read detailed information of specific resource"""
         try:
-            resource_type, resource_name = self._parse_resource_uri(uri)
+            resource_type, resource_name, db_name = self._parse_resource_uri(uri)
 
             if resource_type == "table":
-                return await self._get_table_schema(resource_name)
+                return await self._get_table_schema(resource_name, db_name)
             elif resource_type == "view":
-                return await self._get_view_definition(resource_name)
+                return await self._get_view_definition(resource_name, db_name)
             elif resource_type == "stats" and resource_name == "database":
-                return await self._get_database_stats()
+                return await self._get_database_stats(db_name)
             else:
                 raise ValueError(f"Unsupported resource type: {resource_type}")
 
         except Exception as e:
+            self._reraise_if_doris_oauth_resource_error(e)
             return json.dumps(
                 {"error": f"Failed to read resource: {str(e)}", "uri": uri},
                 ensure_ascii=False,
@@ -155,9 +331,28 @@ class DorisResourcesManager:
         if cached:
             return cached
 
-        connection = await self.connection_manager.get_connection("system")
+        async with self._connection_context("system") as connection:
+            tables = await self._get_table_metadata_for_database(connection)
 
-        # Query basic table information
+        await self.metadata_cache.set(cache_key, tables)
+        return tables
+
+    async def _get_visible_databases(self, connection) -> list[str]:
+        """Get databases visible to the current routed Doris user."""
+        auth_context = get_auth_context()
+        result = await connection.execute("SHOW DATABASES", auth_context=auth_context)
+        databases: list[str] = []
+        for row in result.data:
+            db_name = self._first_row_value(row)
+            if self._visible_resource_database(db_name):
+                databases.append(str(db_name))
+        return databases
+
+    async def _get_table_metadata_for_database(
+        self, connection, db_name: str | None = None
+    ) -> list[TableMetadata]:
+        """Get table metadata for a specific database or the current database."""
+        schema_filter, schema_params = self._schema_filter("table_schema", db_name)
         tables_query = """
         SELECT
             table_name,
@@ -165,18 +360,21 @@ class DorisResourcesManager:
             table_rows as row_count,
             create_time
         FROM information_schema.tables
-        WHERE table_schema = DATABASE()
+        WHERE {schema_filter}
         AND table_type = 'BASE TABLE'
         ORDER BY table_name
-        """
+        """.format(schema_filter=schema_filter)
 
         auth_context = get_auth_context()
-        result = await connection.execute(tables_query, auth_context=auth_context)
+        result = await connection.execute(
+            tables_query,
+            params=schema_params or None,
+            auth_context=auth_context,
+        )
         tables = []
 
         for row in result.data:
-            # Get column information for the table
-            columns = await self._get_table_columns(connection, row["table_name"])
+            columns = await self._get_table_columns(connection, row["table_name"], db_name)
 
             table = TableMetadata(
                 name=row["table_name"],
@@ -184,14 +382,17 @@ class DorisResourcesManager:
                 row_count=row.get("row_count", 0),
                 columns=columns,
                 create_time=row.get("create_time"),
+                database=db_name,
             )
             tables.append(table)
 
-        await self.metadata_cache.set(cache_key, tables)
         return tables
 
-    async def _get_table_columns(self, connection, table_name: str) -> list[dict]:
+    async def _get_table_columns(
+        self, connection, table_name: str, db_name: str | None = None
+    ) -> list[dict]:
         """Get column information for table"""
+        schema_filter, schema_params = self._schema_filter("table_schema", db_name)
         columns_query = """
         SELECT
             column_name,
@@ -201,13 +402,17 @@ class DorisResourcesManager:
             column_comment,
             column_key
         FROM information_schema.columns
-        WHERE table_schema = DATABASE()
+        WHERE {schema_filter}
         AND table_name = %s
         ORDER BY ordinal_position
-        """
+        """.format(schema_filter=schema_filter)
 
         auth_context = get_auth_context()
-        result = await connection.execute(columns_query, params=(table_name,), auth_context=auth_context)
+        result = await connection.execute(
+            columns_query,
+            params=(*schema_params, table_name),
+            auth_context=auth_context,
+        )
         return [dict(row) for row in result.data]
 
     async def _get_view_metadata(self) -> list[ViewMetadata]:
@@ -217,20 +422,33 @@ class DorisResourcesManager:
         if cached:
             return cached
 
-        connection = await self.connection_manager.get_connection("system")
+        async with self._connection_context("system") as connection:
+            views = await self._get_view_metadata_for_database(connection)
 
+        await self.metadata_cache.set(cache_key, views)
+        return views
+
+    async def _get_view_metadata_for_database(
+        self, connection, db_name: str | None = None
+    ) -> list[ViewMetadata]:
+        """Get view metadata for a specific database or the current database."""
+        schema_filter, schema_params = self._schema_filter("table_schema", db_name)
         views_query = """
         SELECT
             table_name,
             table_comment,
             view_definition
         FROM information_schema.views
-        WHERE table_schema = DATABASE()
+        WHERE {schema_filter}
         ORDER BY table_name
-        """
+        """.format(schema_filter=schema_filter)
 
         auth_context = get_auth_context()
-        result = await connection.execute(views_query, auth_context=auth_context)
+        result = await connection.execute(
+            views_query,
+            params=schema_params or None,
+            auth_context=auth_context,
+        )
         views = []
 
         for row in result.data:
@@ -238,16 +456,15 @@ class DorisResourcesManager:
                 name=row["table_name"],
                 comment=row.get("table_comment"),
                 definition=row.get("view_definition"),
+                database=db_name,
             )
             views.append(view)
 
-        await self.metadata_cache.set(cache_key, views)
         return views
 
-    async def _get_table_schema(self, table_name: str) -> str:
+    async def _get_table_schema(self, table_name: str, db_name: str | None = None) -> str:
         """Get detailed structure information of table"""
-        connection = await self.connection_manager.get_connection("system")
-
+        schema_filter, schema_params = self._schema_filter("table_schema", db_name)
         # Get basic table information
         table_info_query = """
         SELECT
@@ -257,24 +474,31 @@ class DorisResourcesManager:
             create_time,
             engine
         FROM information_schema.tables
-        WHERE table_schema = DATABASE()
+        WHERE {schema_filter}
         AND table_name = %s
-        """
+        """.format(schema_filter=schema_filter)
 
-        auth_context = get_auth_context()
-        table_result = await connection.execute(table_info_query, params=(table_name,), auth_context=auth_context)
-        if not table_result.data:
-            raise ValueError(f"Table {table_name} does not exist")
+        async with self._connection_context("system") as connection:
+            auth_context = get_auth_context()
+            table_result = await connection.execute(
+                table_info_query,
+                params=(*schema_params, table_name),
+                auth_context=auth_context,
+            )
+            if not table_result.data:
+                qualified_name = f"{db_name}.{table_name}" if db_name else table_name
+                raise ValueError(f"Table {qualified_name} does not exist")
 
-        table_info = table_result.data[0]
+            table_info = table_result.data[0]
 
-        # Get column information
-        columns = await self._get_table_columns(connection, table_name)
+            # Get column information
+            columns = await self._get_table_columns(connection, table_name, db_name)
 
-        # Get index information
-        indexes = await self._get_table_indexes(connection, table_name)
+            # Get index information
+            indexes = await self._get_table_indexes(connection, table_name, db_name)
 
         schema_info = {
+            "database_name": db_name,
             "table_name": table_info["table_name"],
             "comment": table_info.get("table_comment"),
             "row_count": table_info.get("table_rows", 0),
@@ -286,8 +510,11 @@ class DorisResourcesManager:
 
         return json.dumps(schema_info, ensure_ascii=False, indent=2)
 
-    async def _get_table_indexes(self, connection, table_name: str) -> list[dict]:
+    async def _get_table_indexes(
+        self, connection, table_name: str, db_name: str | None = None
+    ) -> list[dict]:
         """Get index information for table"""
+        schema_filter, schema_params = self._schema_filter("table_schema", db_name)
         indexes_query = """
         SELECT
             index_name,
@@ -295,37 +522,47 @@ class DorisResourcesManager:
             index_type,
             non_unique
         FROM information_schema.statistics
-        WHERE table_schema = DATABASE()
+        WHERE {schema_filter}
         AND table_name = %s
         ORDER BY index_name, seq_in_index
-        """
+        """.format(schema_filter=schema_filter)
 
         auth_context = get_auth_context()
-        result = await connection.execute(indexes_query, params=(table_name,), auth_context=auth_context)
+        result = await connection.execute(
+            indexes_query,
+            params=(*schema_params, table_name),
+            auth_context=auth_context,
+        )
         return [dict(row) for row in result.data]
 
-    async def _get_view_definition(self, view_name: str) -> str:
+    async def _get_view_definition(self, view_name: str, db_name: str | None = None) -> str:
         """Get definition information of view"""
-        connection = await self.connection_manager.get_connection("system")
-
+        schema_filter, schema_params = self._schema_filter("table_schema", db_name)
         view_query = """
         SELECT
             table_name,
             table_comment,
             view_definition
         FROM information_schema.views
-        WHERE table_schema = DATABASE()
+        WHERE {schema_filter}
         AND table_name = %s
-        """
+        """.format(schema_filter=schema_filter)
 
-        auth_context = get_auth_context()
-        result = await connection.execute(view_query, params=(view_name,), auth_context=auth_context)
-        if not result.data:
-            raise ValueError(f"View {view_name} does not exist")
+        async with self._connection_context("system") as connection:
+            auth_context = get_auth_context()
+            result = await connection.execute(
+                view_query,
+                params=(*schema_params, view_name),
+                auth_context=auth_context,
+            )
+            if not result.data:
+                qualified_name = f"{db_name}.{view_name}" if db_name else view_name
+                raise ValueError(f"View {qualified_name} does not exist")
 
-        view_info = result.data[0]
+            view_info = result.data[0]
 
         schema_info = {
+            "database_name": db_name,
             "view_name": view_info["table_name"],
             "comment": view_info.get("table_comment"),
             "definition": view_info.get("view_definition"),
@@ -333,36 +570,44 @@ class DorisResourcesManager:
 
         return json.dumps(schema_info, ensure_ascii=False, indent=2)
 
-    async def _get_database_stats(self) -> str:
+    async def _get_database_stats(self, db_name: str | None = None) -> str:
         """Get database statistics"""
-        connection = await self.connection_manager.get_connection("system")
-
+        schema_filter, schema_params = self._schema_filter("table_schema", db_name)
         # Get table statistics
         table_stats_query = """
         SELECT
             COUNT(*) as table_count,
             SUM(table_rows) as total_rows
         FROM information_schema.tables
-        WHERE table_schema = DATABASE()
+        WHERE {schema_filter}
         AND table_type = 'BASE TABLE'
-        """
+        """.format(schema_filter=schema_filter)
 
-        auth_context = get_auth_context()
-        table_result = await connection.execute(table_stats_query, auth_context=auth_context)
-        table_stats = table_result.data[0] if table_result.data else {}
+        async with self._connection_context("system") as connection:
+            auth_context = get_auth_context()
+            table_result = await connection.execute(
+                table_stats_query,
+                params=schema_params or None,
+                auth_context=auth_context,
+            )
+            table_stats = table_result.data[0] if table_result.data else {}
 
-        # Get view statistics
-        view_stats_query = """
-        SELECT COUNT(*) as view_count
-        FROM information_schema.views
-        WHERE table_schema = DATABASE()
-        """
+            # Get view statistics
+            view_stats_query = """
+            SELECT COUNT(*) as view_count
+            FROM information_schema.views
+            WHERE {schema_filter}
+            """.format(schema_filter=schema_filter)
 
-        view_result = await connection.execute(view_stats_query, auth_context=auth_context)
-        view_stats = view_result.data[0] if view_result.data else {}
+            view_result = await connection.execute(
+                view_stats_query,
+                params=schema_params or None,
+                auth_context=auth_context,
+            )
+            view_stats = view_result.data[0] if view_result.data else {}
 
         stats_info = {
-            "database_name": "current_database",
+            "database_name": db_name or "current_database",
             "table_count": table_stats.get("table_count", 0),
             "view_count": view_stats.get("view_count", 0),
             "total_rows": table_stats.get("total_rows", 0),
@@ -371,7 +616,7 @@ class DorisResourcesManager:
 
         return json.dumps(stats_info, ensure_ascii=False, indent=2)
 
-    def _parse_resource_uri(self, uri: str) -> tuple:
+    def _parse_resource_uri(self, uri: str) -> tuple[str, str, str | None]:
         """Parse resource URI"""
         if not uri.startswith("doris://"):
             raise ValueError("Invalid resource URI format")
@@ -382,4 +627,22 @@ class DorisResourcesManager:
         if len(parts) < 2:
             raise ValueError("Incomplete resource URI format")
 
-        return parts[0], parts[1]
+        resource_type = parts[0]
+        if resource_type in {"table", "view"}:
+            if len(parts) >= 3:
+                return (
+                    resource_type,
+                    self._decode_resource_uri_segment(parts[2]),
+                    self._decode_resource_uri_segment(parts[1]),
+                )
+            return resource_type, self._decode_resource_uri_segment(parts[1]), None
+
+        if resource_type == "stats":
+            if len(parts) >= 3 and parts[1] == "database":
+                return resource_type, "database", self._decode_resource_uri_segment(parts[2])
+            if len(parts) == 2 and parts[1] == "database":
+                return resource_type, "database", None
+            if len(parts) == 2:
+                return resource_type, "database", self._decode_resource_uri_segment(parts[1])
+
+        return resource_type, self._decode_resource_uri_segment(parts[1]), None

--- a/doris_mcp_server/tools/tools_manager.py
+++ b/doris_mcp_server/tools/tools_manager.py
@@ -26,6 +26,11 @@ from typing import Any, Dict, List
 
 from mcp.types import Tool
 
+from ..auth.operation_policy import (
+    OperationAuthorizationError,
+    authorize_operation,
+    filter_tools_for_auth_context,
+)
 from ..utils.db import DorisConnectionManager
 from ..utils.query_executor import DorisQueryExecutor
 from ..utils.analysis_tools import TableAnalyzer, SQLAnalyzer, MemoryTracker
@@ -39,6 +44,7 @@ from ..utils.dependency_analysis_tools import DependencyAnalysisTools
 from ..utils.performance_analytics_tools import PerformanceAnalyticsTools
 from ..utils.adbc_query_tools import DorisADBCQueryTools
 from ..utils.logger import get_logger
+from ..utils.security import get_current_auth_context
 
 logger = get_logger(__name__)
 
@@ -1359,12 +1365,13 @@ No parameters required. Returns connection status, configuration, and diagnostic
             ),
         ]
         
-        return tools
+        return filter_tools_for_auth_context(get_current_auth_context(), tools)
         
     async def call_tool(self, name: str, arguments: Dict[str, Any]) -> str:
         """
         Call the specified query tool (tool routing and scheduling center)
         """
+        authorize_operation(get_current_auth_context(), f"tool:{name}")
         try:
             start_time = time.time()
             
@@ -1449,6 +1456,8 @@ No parameters required. Returns connection status, configuration, and diagnostic
             
             return json.dumps(result, ensure_ascii=False, indent=2)
             
+        except OperationAuthorizationError:
+            raise
         except Exception as e:
             logger.error(f"Tool call failed {name}: {str(e)}")
             error_result = {

--- a/doris_mcp_server/utils/analysis_tools.py
+++ b/doris_mcp_server/utils/analysis_tools.py
@@ -405,15 +405,24 @@ class SQLAnalyzer:
             except Exception:
                 pass
             
-            # Switch database if specified
-            # SECURITY FIX: Validate and quote db_name
+            context_statements = []
+            if catalog_name:
+                try:
+                    validate_identifier(catalog_name, "catalog name")
+                except SQLSecurityError as e:
+                    return {"success": False, "error": f"Invalid catalog name: {e}"}
+                safe_catalog = quote_identifier(catalog_name, "catalog name")
+                context_statements.append(f"USE CATALOG {safe_catalog}")
+
+            # Switch database if specified.
+            # SECURITY FIX: Validate and quote db_name.
             if db_name:
                 try:
                     validate_identifier(db_name, "database name")
                 except SQLSecurityError as e:
                     return {"success": False, "error": f"Invalid database name: {e}"}
                 safe_db = quote_identifier(db_name, "database name")
-                await self.connection_manager.execute_query("explain_session", f"USE {safe_db}", None, auth_context)
+                context_statements.append(f"USE {safe_db}")
             
             # Construct EXPLAIN query
             explain_type = "EXPLAIN VERBOSE" if verbose else "EXPLAIN"
@@ -421,8 +430,43 @@ class SQLAnalyzer:
             
             logger.info(f"Executing explain query: {explain_sql}")
             
-            # Execute explain query
-            result = await self.connection_manager.execute_query("explain_session", explain_sql, None, auth_context)
+            # Execute context switching and explain query on one routed connection
+            # whenever a database/catalog context is requested.
+            if context_statements:
+                connection = None
+                try:
+                    get_connection_for_auth_context = getattr(
+                        self.connection_manager,
+                        "_get_connection_for_auth_context",
+                        None,
+                    )
+                    if callable(get_connection_for_auth_context):
+                        get_effective_auth_context = getattr(
+                            self.connection_manager,
+                            "_get_effective_auth_context",
+                            None,
+                        )
+                        auth_context = (
+                            get_effective_auth_context(auth_context)
+                            if callable(get_effective_auth_context)
+                            else auth_context
+                        )
+                        connection = await get_connection_for_auth_context(
+                            "explain_session",
+                            auth_context,
+                        )
+                    else:
+                        connection = await self.connection_manager.get_connection("explain_session")
+
+                    for context_sql in context_statements:
+                        await connection.execute(context_sql, auth_context=auth_context)
+                    result = await connection.execute(explain_sql, auth_context=auth_context)
+                finally:
+                    release_connection = getattr(self.connection_manager, "release_connection", None)
+                    if connection is not None and callable(release_connection):
+                        await release_connection("explain_session", connection)
+            else:
+                result = await self.connection_manager.execute_query("explain_session", explain_sql, None, auth_context)
             
             # Format explain output
             explain_content = []

--- a/doris_mcp_server/utils/config.py
+++ b/doris_mcp_server/utils/config.py
@@ -23,9 +23,11 @@ Implements configuration loading, validation and management functionality
 import json
 import logging
 import os
+import multiprocessing
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 try:
     from dotenv import load_dotenv
@@ -33,6 +35,153 @@ except ImportError:
     load_dotenv = None
 
 from .logger import get_logger
+
+
+class AuthConfigError(ValueError):
+    """Raised when authentication configuration is inconsistent."""
+
+
+DORIS_OAUTH_METADATA_TOOL_ALLOWLIST_DEFAULT = [
+    "get_db_list",
+    "get_db_table_list",
+    "get_table_schema",
+    "get_table_comment",
+    "get_table_column_comments",
+    "get_table_indexes",
+    "get_catalog_list",
+]
+DORIS_OAUTH_METADATA_TOOL_SET = frozenset(DORIS_OAUTH_METADATA_TOOL_ALLOWLIST_DEFAULT)
+DORIS_OAUTH_QUERY_TOOL_SET = frozenset({"exec_query"})
+DORIS_OAUTH_EXPLAIN_TOOL_SET = frozenset({"get_sql_explain"})
+
+
+@dataclass(frozen=True)
+class ConfigValue:
+    """Configuration value with source metadata."""
+
+    value: Any
+    source: str = "default"
+    explicit: bool = False
+
+
+@dataclass(frozen=True)
+class AuthConfigInputs:
+    """Authentication-related config inputs before normalization."""
+
+    enable_token_auth: ConfigValue
+    enable_jwt_auth: ConfigValue
+    enable_external_oauth_auth: ConfigValue
+    oauth_enabled: ConfigValue
+    enable_doris_oauth_auth: ConfigValue
+    legacy_auth_type: ConfigValue
+    transport: ConfigValue
+    workers: ConfigValue
+
+
+@dataclass(frozen=True)
+class EffectiveAuthConfig:
+    """Normalized authentication configuration used by runtime code."""
+
+    enable_token_auth: bool
+    enable_jwt_auth: bool
+    enable_external_oauth_auth: bool
+    enable_doris_oauth_auth: bool
+    auth_methods: tuple[str, ...]
+    oauth_discovery_mode: str
+    transport: str
+    requested_workers: int
+    effective_workers: int
+    legacy_auth_type: str
+    auth_config_warnings: tuple[str, ...] = ()
+    doris_oauth_base_url: str = ""
+    source_summary: dict[str, str] = field(default_factory=dict)
+
+
+def _str_to_bool(value: Any) -> bool:
+    """Convert common config values to bool."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or str(value).strip() == "":
+        return default
+    return int(value)
+
+
+def _env_optional_int(name: str, default: int | None) -> int | None:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    value = str(value).strip()
+    if value == "":
+        return None
+    return int(value)
+
+
+def _env_csv(name: str, default: list[str]) -> list[str]:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _coerce_csv_config(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return [str(part).strip() for part in value if str(part).strip()]
+
+
+def _validate_doris_oauth_metadata_tool_allowlist(tools: Any) -> list[str]:
+    """Validate the Phase 4 metadata-only Doris OAuth tool allowlist."""
+    normalized = []
+    seen = set()
+    invalid = []
+    for tool in _coerce_csv_config(tools):
+        tool_name = str(tool).strip()
+        if not tool_name:
+            continue
+        if tool_name not in DORIS_OAUTH_METADATA_TOOL_SET:
+            invalid.append(tool_name)
+            continue
+        if tool_name not in seen:
+            normalized.append(tool_name)
+            seen.add(tool_name)
+
+    if invalid:
+        invalid_list = ", ".join(sorted(set(invalid)))
+        raise AuthConfigError(
+            "DORIS_OAUTH_DB_TOOL_ALLOWLIST can only contain Phase 4 metadata tools; "
+            f"invalid entries: {invalid_list}"
+        )
+    return normalized
+
+
+def _is_loopback_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return (parsed.hostname or "").lower() in {"127.0.0.1", "localhost", "::1"}
+
+
+def _ensure_source_maps(config: Any) -> None:
+    if not hasattr(config, "_explicit_sources"):
+        config._explicit_sources = {}
+
+
+def _mark_source(config: Any, field_name: str, source: str) -> None:
+    _ensure_source_maps(config)
+    config._explicit_sources[field_name] = source
+
+
+def _config_value(config: Any, field_name: str, value: Any) -> ConfigValue:
+    _ensure_source_maps(config)
+    source = config._explicit_sources.get(field_name, "default")
+    return ConfigValue(value=value, source=source, explicit=source != "default")
 
 
 @dataclass
@@ -81,6 +230,47 @@ class SecurityConfig:
     enable_token_auth: bool = False  # Enable token-based authentication (default: disabled)
     enable_jwt_auth: bool = False    # Enable JWT authentication (default: disabled)
     enable_oauth_auth: bool = False  # Enable OAuth 2.0/OIDC authentication (default: disabled)
+    enable_doris_oauth_auth: bool = False  # Enable Doris-backed OAuth (default: disabled)
+    doris_oauth_base_url: str = ""  # Public base URL for future Doris OAuth metadata
+    doris_oauth_db_tools_enabled: bool = False
+    doris_oauth_db_tool_allowlist: list[str] = field(
+        default_factory=lambda: list(DORIS_OAUTH_METADATA_TOOL_ALLOWLIST_DEFAULT)
+    )
+    doris_oauth_query_tools_enabled: bool = False
+    doris_oauth_query_tool_allowlist: list[str] = field(default_factory=lambda: ["exec_query"])
+    doris_oauth_explain_tools_enabled: bool = False
+    doris_oauth_explain_tool_allowlist: list[str] = field(default_factory=lambda: ["get_sql_explain"])
+    doris_oauth_access_token_expire_seconds: int = 900
+    doris_oauth_refresh_token_expire_seconds: int = 86400
+    doris_oauth_auth_code_expire_seconds: int = 300
+    doris_oauth_gc_interval_seconds: int = 60
+    doris_oauth_idle_timeout_seconds: int | None = None
+    doris_oauth_login_page_title: str = "Doris MCP Login"
+    doris_oauth_allowed_redirect_uris: list[str] = field(default_factory=list)
+    doris_oauth_clients_file: str = ""
+    doris_oauth_dynamic_client_registration_mode: str = "auto"
+    enable_doris_oauth_production_dcr: bool = False
+    enable_doris_oauth_production_wildcard_redirects: bool = False
+    doris_oauth_allow_insecure_http: bool = False
+    doris_oauth_trust_proxy_headers: bool = False
+    doris_oauth_trusted_proxy_cidrs: list[str] = field(default_factory=list)
+    doris_oauth_rate_limit_window_seconds: int = 300
+    doris_oauth_login_rate_limit_per_ip: int = 20
+    doris_oauth_login_rate_limit_per_user: int = 10
+    doris_oauth_login_rate_limit_per_client: int = 30
+    doris_oauth_login_rate_limit_per_txn: int = 5
+    doris_oauth_dcr_rate_limit_per_ip: int = 30
+    doris_oauth_authorize_rate_limit_per_ip: int = 120
+    doris_oauth_token_rate_limit_per_ip: int = 120
+    doris_oauth_token_rate_limit_per_client: int = 240
+    doris_oauth_revoke_rate_limit_per_ip: int = 120
+    doris_oauth_revoke_rate_limit_per_client: int = 240
+    doris_oauth_api_auth_token_rate_limit_per_ip: int = 20
+    doris_oauth_api_auth_token_rate_limit_per_user: int = 10
+    doris_oauth_api_auth_refresh_rate_limit_per_ip: int = 120
+    doris_oauth_api_auth_refresh_rate_limit_per_client: int = 240
+    doris_oauth_dcr_max_clients: int = 1000
+    doris_oauth_dcr_client_ttl_seconds: int = 86400
     
     # Legacy configuration (kept for backward compatibility)
     auth_type: str = "token"  # jwt, token, basic, oauth (deprecated: use individual switches)
@@ -432,10 +622,146 @@ class DorisConfig:
 
         # Security configuration
         # Independent authentication switches
-        config.security.enable_token_auth = os.getenv("ENABLE_TOKEN_AUTH", str(config.security.enable_token_auth)).lower() == "true"
-        config.security.enable_jwt_auth = os.getenv("ENABLE_JWT_AUTH", str(config.security.enable_jwt_auth)).lower() == "true"
-        config.security.enable_oauth_auth = os.getenv("ENABLE_OAUTH_AUTH", str(config.security.enable_oauth_auth)).lower() == "true"
-        config.security.auth_type = os.getenv("AUTH_TYPE", config.security.auth_type)
+        if "ENABLE_TOKEN_AUTH" in os.environ:
+            config.security.enable_token_auth = _str_to_bool(os.getenv("ENABLE_TOKEN_AUTH"))
+            _mark_source(config, "enable_token_auth", "env")
+        if "ENABLE_JWT_AUTH" in os.environ:
+            config.security.enable_jwt_auth = _str_to_bool(os.getenv("ENABLE_JWT_AUTH"))
+            _mark_source(config, "enable_jwt_auth", "env")
+        if "ENABLE_OAUTH_AUTH" in os.environ:
+            config.security.enable_oauth_auth = _str_to_bool(os.getenv("ENABLE_OAUTH_AUTH"))
+            _mark_source(config, "enable_oauth_auth", "env")
+        if "OAUTH_ENABLED" in os.environ:
+            config.security.oauth_enabled = _str_to_bool(os.getenv("OAUTH_ENABLED"))
+            _mark_source(config, "oauth_enabled", "env")
+        if "ENABLE_DORIS_OAUTH_AUTH" in os.environ:
+            config.security.enable_doris_oauth_auth = _str_to_bool(os.getenv("ENABLE_DORIS_OAUTH_AUTH"))
+            _mark_source(config, "enable_doris_oauth_auth", "env")
+        if "DORIS_OAUTH_BASE_URL" in os.environ:
+            config.security.doris_oauth_base_url = os.getenv("DORIS_OAUTH_BASE_URL", "").strip()
+            _mark_source(config, "doris_oauth_base_url", "env")
+        if "DORIS_OAUTH_DB_TOOLS_ENABLED" in os.environ:
+            config.security.doris_oauth_db_tools_enabled = _str_to_bool(os.getenv("DORIS_OAUTH_DB_TOOLS_ENABLED"))
+            _mark_source(config, "doris_oauth_db_tools_enabled", "env")
+        if "DORIS_OAUTH_DB_TOOL_ALLOWLIST" in os.environ:
+            config.security.doris_oauth_db_tool_allowlist = _env_csv(
+                "DORIS_OAUTH_DB_TOOL_ALLOWLIST",
+                config.security.doris_oauth_db_tool_allowlist,
+            )
+            _mark_source(config, "doris_oauth_db_tool_allowlist", "env")
+        if "DORIS_OAUTH_QUERY_TOOLS_ENABLED" in os.environ:
+            config.security.doris_oauth_query_tools_enabled = _str_to_bool(
+                os.getenv("DORIS_OAUTH_QUERY_TOOLS_ENABLED")
+            )
+            _mark_source(config, "doris_oauth_query_tools_enabled", "env")
+        if "DORIS_OAUTH_QUERY_TOOL_ALLOWLIST" in os.environ:
+            config.security.doris_oauth_query_tool_allowlist = _env_csv(
+                "DORIS_OAUTH_QUERY_TOOL_ALLOWLIST",
+                config.security.doris_oauth_query_tool_allowlist,
+            )
+            _mark_source(config, "doris_oauth_query_tool_allowlist", "env")
+        if "DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED" in os.environ:
+            config.security.doris_oauth_explain_tools_enabled = _str_to_bool(
+                os.getenv("DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED")
+            )
+            _mark_source(config, "doris_oauth_explain_tools_enabled", "env")
+        if "DORIS_OAUTH_EXPLAIN_TOOL_ALLOWLIST" in os.environ:
+            config.security.doris_oauth_explain_tool_allowlist = _env_csv(
+                "DORIS_OAUTH_EXPLAIN_TOOL_ALLOWLIST",
+                config.security.doris_oauth_explain_tool_allowlist,
+            )
+            _mark_source(config, "doris_oauth_explain_tool_allowlist", "env")
+        config.security.doris_oauth_access_token_expire_seconds = _env_int(
+            "DORIS_OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS",
+            config.security.doris_oauth_access_token_expire_seconds,
+        )
+        config.security.doris_oauth_refresh_token_expire_seconds = _env_int(
+            "DORIS_OAUTH_REFRESH_TOKEN_EXPIRE_SECONDS",
+            config.security.doris_oauth_refresh_token_expire_seconds,
+        )
+        config.security.doris_oauth_auth_code_expire_seconds = _env_int(
+            "DORIS_OAUTH_AUTH_CODE_EXPIRE_SECONDS",
+            config.security.doris_oauth_auth_code_expire_seconds,
+        )
+        config.security.doris_oauth_gc_interval_seconds = _env_int(
+            "DORIS_OAUTH_GC_INTERVAL_SECONDS",
+            config.security.doris_oauth_gc_interval_seconds,
+        )
+        config.security.doris_oauth_idle_timeout_seconds = _env_optional_int(
+            "DORIS_OAUTH_IDLE_TIMEOUT_SECONDS",
+            config.security.doris_oauth_idle_timeout_seconds,
+        )
+        config.security.doris_oauth_login_page_title = os.getenv(
+            "DORIS_OAUTH_LOGIN_PAGE_TITLE",
+            config.security.doris_oauth_login_page_title,
+        )
+        config.security.doris_oauth_allowed_redirect_uris = _env_csv(
+            "DORIS_OAUTH_ALLOWED_REDIRECT_URIS",
+            config.security.doris_oauth_allowed_redirect_uris,
+        )
+        config.security.doris_oauth_clients_file = os.getenv(
+            "DORIS_OAUTH_CLIENTS_FILE",
+            config.security.doris_oauth_clients_file,
+        )
+        config.security.doris_oauth_dynamic_client_registration_mode = os.getenv(
+            "DORIS_OAUTH_DYNAMIC_CLIENT_REGISTRATION_MODE",
+            config.security.doris_oauth_dynamic_client_registration_mode,
+        )
+        config.security.enable_doris_oauth_production_dcr = _str_to_bool(
+            os.getenv(
+                "ENABLE_DORIS_OAUTH_PRODUCTION_DCR",
+                config.security.enable_doris_oauth_production_dcr,
+            )
+        )
+        config.security.enable_doris_oauth_production_wildcard_redirects = _str_to_bool(
+            os.getenv(
+                "ENABLE_DORIS_OAUTH_PRODUCTION_WILDCARD_REDIRECTS",
+                config.security.enable_doris_oauth_production_wildcard_redirects,
+            )
+        )
+        config.security.doris_oauth_allow_insecure_http = _str_to_bool(
+            os.getenv(
+                "DORIS_OAUTH_ALLOW_INSECURE_HTTP",
+                config.security.doris_oauth_allow_insecure_http,
+            )
+        )
+        config.security.doris_oauth_trust_proxy_headers = _str_to_bool(
+            os.getenv(
+                "DORIS_OAUTH_TRUST_PROXY_HEADERS",
+                config.security.doris_oauth_trust_proxy_headers,
+            )
+        )
+        config.security.doris_oauth_trusted_proxy_cidrs = _env_csv(
+            "DORIS_OAUTH_TRUSTED_PROXY_CIDRS",
+            config.security.doris_oauth_trusted_proxy_cidrs,
+        )
+        for env_name, field_name in {
+            "DORIS_OAUTH_RATE_LIMIT_WINDOW_SECONDS": "doris_oauth_rate_limit_window_seconds",
+            "DORIS_OAUTH_LOGIN_RATE_LIMIT_PER_IP": "doris_oauth_login_rate_limit_per_ip",
+            "DORIS_OAUTH_LOGIN_RATE_LIMIT_PER_USER": "doris_oauth_login_rate_limit_per_user",
+            "DORIS_OAUTH_LOGIN_RATE_LIMIT_PER_CLIENT": "doris_oauth_login_rate_limit_per_client",
+            "DORIS_OAUTH_LOGIN_RATE_LIMIT_PER_TXN": "doris_oauth_login_rate_limit_per_txn",
+            "DORIS_OAUTH_DCR_RATE_LIMIT_PER_IP": "doris_oauth_dcr_rate_limit_per_ip",
+            "DORIS_OAUTH_AUTHORIZE_RATE_LIMIT_PER_IP": "doris_oauth_authorize_rate_limit_per_ip",
+            "DORIS_OAUTH_TOKEN_RATE_LIMIT_PER_IP": "doris_oauth_token_rate_limit_per_ip",
+            "DORIS_OAUTH_TOKEN_RATE_LIMIT_PER_CLIENT": "doris_oauth_token_rate_limit_per_client",
+            "DORIS_OAUTH_REVOKE_RATE_LIMIT_PER_IP": "doris_oauth_revoke_rate_limit_per_ip",
+            "DORIS_OAUTH_REVOKE_RATE_LIMIT_PER_CLIENT": "doris_oauth_revoke_rate_limit_per_client",
+            "DORIS_OAUTH_API_AUTH_TOKEN_RATE_LIMIT_PER_IP": "doris_oauth_api_auth_token_rate_limit_per_ip",
+            "DORIS_OAUTH_API_AUTH_TOKEN_RATE_LIMIT_PER_USER": "doris_oauth_api_auth_token_rate_limit_per_user",
+            "DORIS_OAUTH_API_AUTH_REFRESH_RATE_LIMIT_PER_IP": "doris_oauth_api_auth_refresh_rate_limit_per_ip",
+            "DORIS_OAUTH_API_AUTH_REFRESH_RATE_LIMIT_PER_CLIENT": "doris_oauth_api_auth_refresh_rate_limit_per_client",
+            "DORIS_OAUTH_DCR_MAX_CLIENTS": "doris_oauth_dcr_max_clients",
+            "DORIS_OAUTH_DCR_CLIENT_TTL_SECONDS": "doris_oauth_dcr_client_ttl_seconds",
+        }.items():
+            setattr(config.security, field_name, _env_int(env_name, getattr(config.security, field_name)))
+        config.security.doris_oauth_rate_limit_window_seconds = _env_int(
+            "DORIS_OAUTH_LOGIN_RATE_LIMIT_WINDOW_SECONDS",
+            config.security.doris_oauth_rate_limit_window_seconds,
+        )
+        if "AUTH_TYPE" in os.environ:
+            config.security.auth_type = os.getenv("AUTH_TYPE", config.security.auth_type)
+            _mark_source(config, "auth_type", "env")
         config.security.token_secret = os.getenv("TOKEN_SECRET", config.security.token_secret)
         config.security.token_expiry = int(
             os.getenv("TOKEN_EXPIRY", str(config.security.token_expiry))
@@ -593,6 +919,12 @@ class DorisConfig:
         # Server configuration
         config.server_name = os.getenv("SERVER_NAME", config.server_name)
         config.server_version = os.getenv("SERVER_VERSION", config.server_version)
+        if "TRANSPORT" in os.environ:
+            config.transport = os.getenv("TRANSPORT", config.transport)
+            _mark_source(config, "transport", "env")
+        if "WORKERS" in os.environ:
+            config.workers = int(os.getenv("WORKERS", "1"))
+            _mark_source(config, "workers", "env")
         server_port = os.getenv("SERVER_PORT", "").strip()
         if server_port and server_port.isdigit():
             config.server_port = int(server_port)
@@ -606,9 +938,10 @@ class DorisConfig:
         config = cls()
 
         # Update basic configuration
-        for key in ["server_name", "server_version", "server_port", "temp_files_dir"]:
+        for key in ["server_name", "server_version", "server_port", "temp_files_dir", "transport", "workers"]:
             if key in config_data:
                 setattr(config, key, config_data[key])
+                _mark_source(config, key, "config_file")
 
         # Update database configuration
         if "database" in config_data:
@@ -623,6 +956,8 @@ class DorisConfig:
             for key, value in sec_config.items():
                 if hasattr(config.security, key):
                     setattr(config.security, key, value)
+                    source_key = "auth_type" if key == "auth_type" else key
+                    _mark_source(config, source_key, "config_file")
 
         # Update performance configuration
         if "performance" in config_data:
@@ -691,6 +1026,34 @@ class DorisConfig:
             },
             "security": {
                 "auth_type": self.security.auth_type,
+                "enable_token_auth": self.security.enable_token_auth,
+                "enable_jwt_auth": self.security.enable_jwt_auth,
+                "enable_oauth_auth": self.security.enable_oauth_auth,
+                "oauth_enabled": self.security.oauth_enabled,
+                "enable_doris_oauth_auth": self.security.enable_doris_oauth_auth,
+                "doris_oauth_base_url": self.security.doris_oauth_base_url,
+                "doris_oauth_db_tools_enabled": self.security.doris_oauth_db_tools_enabled,
+                "doris_oauth_db_tool_allowlist": self.security.doris_oauth_db_tool_allowlist,
+                "doris_oauth_query_tools_enabled": self.security.doris_oauth_query_tools_enabled,
+                "doris_oauth_query_tool_allowlist": self.security.doris_oauth_query_tool_allowlist,
+                "doris_oauth_explain_tools_enabled": self.security.doris_oauth_explain_tools_enabled,
+                "doris_oauth_explain_tool_allowlist": self.security.doris_oauth_explain_tool_allowlist,
+                "doris_oauth_access_token_expire_seconds": self.security.doris_oauth_access_token_expire_seconds,
+                "doris_oauth_refresh_token_expire_seconds": self.security.doris_oauth_refresh_token_expire_seconds,
+                "doris_oauth_auth_code_expire_seconds": self.security.doris_oauth_auth_code_expire_seconds,
+                "doris_oauth_gc_interval_seconds": self.security.doris_oauth_gc_interval_seconds,
+                "doris_oauth_idle_timeout_seconds": self.security.doris_oauth_idle_timeout_seconds,
+                "doris_oauth_login_page_title": self.security.doris_oauth_login_page_title,
+                "doris_oauth_allowed_redirect_uris": self.security.doris_oauth_allowed_redirect_uris,
+                "doris_oauth_clients_file": self.security.doris_oauth_clients_file,
+                "doris_oauth_dynamic_client_registration_mode": self.security.doris_oauth_dynamic_client_registration_mode,
+                "enable_doris_oauth_production_dcr": self.security.enable_doris_oauth_production_dcr,
+                "enable_doris_oauth_production_wildcard_redirects": self.security.enable_doris_oauth_production_wildcard_redirects,
+                "doris_oauth_allow_insecure_http": self.security.doris_oauth_allow_insecure_http,
+                "doris_oauth_trust_proxy_headers": self.security.doris_oauth_trust_proxy_headers,
+                "doris_oauth_trusted_proxy_cidrs": self.security.doris_oauth_trusted_proxy_cidrs,
+                "doris_oauth_dcr_max_clients": self.security.doris_oauth_dcr_max_clients,
+                "doris_oauth_dcr_client_ttl_seconds": self.security.doris_oauth_dcr_client_ttl_seconds,
                 "token_secret": "***",  # Hide secret key
                 "token_expiry": self.security.token_expiry,
                 "enable_security_check": self.security.enable_security_check,
@@ -788,8 +1151,8 @@ class DorisConfig:
             errors.append("Maximum connections must be greater than 0")
 
         # Validate security configuration
-        if self.security.auth_type not in ["token", "basic", "oauth"]:
-            errors.append("Authentication type must be one of token, basic, or oauth")
+        if self.security.auth_type not in ["token", "basic", "oauth", "jwt"]:
+            errors.append("Authentication type must be one of token, basic, oauth, or jwt")
 
         if self.security.token_expiry <= 0:
             errors.append("Token expiry time must be greater than 0")
@@ -898,6 +1261,231 @@ class DorisConfig:
                 "alerts_enabled": self.monitoring.enable_alerts,
             },
         }
+
+
+def build_auth_config_inputs(config: DorisConfig, requested_workers: int | None = None) -> AuthConfigInputs:
+    """Build source-aware auth inputs from a DorisConfig."""
+    workers_value = requested_workers
+    if workers_value is None:
+        workers_value = getattr(config, "workers", 1)
+    explicit_sources = getattr(config, "_explicit_sources", {})
+    workers_source = explicit_sources.get("workers", "default")
+    transport_source = explicit_sources.get("transport", "default")
+
+    return AuthConfigInputs(
+        enable_token_auth=_config_value(config, "enable_token_auth", config.security.enable_token_auth),
+        enable_jwt_auth=_config_value(config, "enable_jwt_auth", config.security.enable_jwt_auth),
+        enable_external_oauth_auth=_config_value(config, "enable_oauth_auth", config.security.enable_oauth_auth),
+        oauth_enabled=_config_value(config, "oauth_enabled", config.security.oauth_enabled),
+        enable_doris_oauth_auth=_config_value(
+            config, "enable_doris_oauth_auth", config.security.enable_doris_oauth_auth
+        ),
+        legacy_auth_type=_config_value(config, "auth_type", config.security.auth_type),
+        transport=ConfigValue(config.transport, transport_source, transport_source != "default"),
+        workers=ConfigValue(workers_value, workers_source, workers_source != "default"),
+    )
+
+
+def normalize_effective_auth_config(
+    config: DorisConfig,
+    requested_workers: int | None = None,
+) -> EffectiveAuthConfig:
+    """Normalize authentication configuration and attach it to the config."""
+    inputs = build_auth_config_inputs(config, requested_workers=requested_workers)
+    warnings: list[str] = []
+
+    auth_type = str(inputs.legacy_auth_type.value or "").strip().lower()
+    if auth_type and auth_type not in {"token", "basic", "oauth", "jwt"}:
+        raise AuthConfigError(f"Unsupported AUTH_TYPE: {auth_type}")
+
+    modern_auth_explicit = any(
+        [
+            inputs.enable_token_auth.explicit,
+            inputs.enable_jwt_auth.explicit,
+            inputs.enable_external_oauth_auth.explicit,
+            inputs.oauth_enabled.explicit,
+            inputs.enable_doris_oauth_auth.explicit,
+        ]
+    )
+
+    enable_token_auth = _str_to_bool(inputs.enable_token_auth.value)
+    enable_jwt_auth = _str_to_bool(inputs.enable_jwt_auth.value)
+    enable_external_oauth_auth = _str_to_bool(inputs.enable_external_oauth_auth.value)
+    enable_doris_oauth_auth = _str_to_bool(inputs.enable_doris_oauth_auth.value)
+
+    config.security.doris_oauth_db_tool_allowlist = _validate_doris_oauth_metadata_tool_allowlist(
+        config.security.doris_oauth_db_tool_allowlist
+    )
+    query_allowlist = _coerce_csv_config(config.security.doris_oauth_query_tool_allowlist)
+    invalid_query_tools = set(query_allowlist) - DORIS_OAUTH_QUERY_TOOL_SET
+    if invalid_query_tools:
+        invalid_list = ", ".join(sorted(invalid_query_tools))
+        raise AuthConfigError(
+            "DORIS_OAUTH_QUERY_TOOL_ALLOWLIST can only contain exec_query; "
+            f"invalid entries: {invalid_list}"
+        )
+    config.security.doris_oauth_query_tool_allowlist = list(dict.fromkeys(query_allowlist))
+
+    explain_allowlist = _coerce_csv_config(config.security.doris_oauth_explain_tool_allowlist)
+    invalid_explain_tools = set(explain_allowlist) - DORIS_OAUTH_EXPLAIN_TOOL_SET
+    if invalid_explain_tools:
+        invalid_list = ", ".join(sorted(invalid_explain_tools))
+        raise AuthConfigError(
+            "DORIS_OAUTH_EXPLAIN_TOOL_ALLOWLIST can only contain get_sql_explain; "
+            f"invalid entries: {invalid_list}"
+        )
+    config.security.doris_oauth_explain_tool_allowlist = list(dict.fromkeys(explain_allowlist))
+
+    if inputs.enable_external_oauth_auth.explicit and inputs.oauth_enabled.explicit:
+        if _str_to_bool(inputs.enable_external_oauth_auth.value) != _str_to_bool(inputs.oauth_enabled.value):
+            raise AuthConfigError("ENABLE_OAUTH_AUTH and oauth_enabled/OAUTH_ENABLED explicitly conflict")
+
+    if inputs.oauth_enabled.explicit:
+        enable_external_oauth_auth = _str_to_bool(inputs.oauth_enabled.value)
+
+    if not modern_auth_explicit and inputs.legacy_auth_type.explicit:
+        if auth_type == "token":
+            enable_token_auth = True
+            warnings.append("AUTH_TYPE=token is deprecated; use ENABLE_TOKEN_AUTH=true")
+        elif auth_type == "jwt":
+            enable_jwt_auth = True
+            warnings.append("AUTH_TYPE=jwt is deprecated; use ENABLE_JWT_AUTH=true")
+        elif auth_type == "oauth":
+            enable_external_oauth_auth = True
+            warnings.append("AUTH_TYPE=oauth is deprecated; use ENABLE_OAUTH_AUTH=true")
+        elif auth_type == "basic":
+            warnings.append("AUTH_TYPE=basic is legacy; no HTTP basic verifier is enabled by default")
+    elif inputs.legacy_auth_type.explicit:
+        if auth_type == "oauth" and enable_doris_oauth_auth:
+            raise AuthConfigError("AUTH_TYPE=oauth conflicts with ENABLE_DORIS_OAUTH_AUTH=true")
+        warnings.append("AUTH_TYPE is deprecated and ignored because explicit auth switches are set")
+
+    if enable_doris_oauth_auth and enable_external_oauth_auth:
+        raise AuthConfigError("Doris OAuth and external OAuth cannot be enabled together")
+
+    transport = str(inputs.transport.value or "stdio")
+    requested = int(inputs.workers.value if inputs.workers.value is not None else 1)
+    effective_workers = multiprocessing.cpu_count() if requested == 0 else requested
+
+    if enable_doris_oauth_auth and transport == "stdio":
+        raise AuthConfigError("Doris OAuth requires HTTP transport")
+    if enable_doris_oauth_auth and effective_workers > 1:
+        raise AuthConfigError("Doris OAuth initial implementation requires a single worker")
+    if enable_doris_oauth_auth and not config.database.host:
+        raise AuthConfigError("DORIS_HOST is required when Doris OAuth is enabled")
+    if enable_doris_oauth_auth and not config.database.user:
+        raise AuthConfigError("DORIS_USER service account is required when Doris OAuth is enabled")
+    if enable_doris_oauth_auth:
+        base_url = config.security.doris_oauth_base_url.rstrip("/")
+        if not base_url:
+            raise AuthConfigError("DORIS_OAUTH_BASE_URL is required when Doris OAuth is enabled")
+        parsed_base_url = urlparse(base_url)
+        if not parsed_base_url.scheme or not parsed_base_url.netloc:
+            raise AuthConfigError("DORIS_OAUTH_BASE_URL must be an absolute URL")
+        if parsed_base_url.scheme == "http" and not _is_loopback_url(base_url):
+            if not config.security.doris_oauth_allow_insecure_http:
+                raise AuthConfigError("Non-loopback Doris OAuth base URL must use HTTPS")
+        elif parsed_base_url.scheme not in {"http", "https"}:
+            raise AuthConfigError("DORIS_OAUTH_BASE_URL must use HTTP or HTTPS")
+
+        mode = config.security.doris_oauth_dynamic_client_registration_mode
+        if mode not in {"auto", "disabled", "enabled"}:
+            raise AuthConfigError("DORIS_OAUTH_DYNAMIC_CLIENT_REGISTRATION_MODE must be auto, disabled, or enabled")
+        if mode == "enabled" and not _is_loopback_url(base_url):
+            if not config.security.enable_doris_oauth_production_dcr:
+                raise AuthConfigError("Production Doris OAuth DCR requires ENABLE_DORIS_OAUTH_PRODUCTION_DCR=true")
+        if config.security.doris_oauth_trust_proxy_headers and not config.security.doris_oauth_trusted_proxy_cidrs:
+            raise AuthConfigError("Trusted proxy CIDRs are required when Doris OAuth proxy headers are trusted")
+
+        ttl_limits = {
+            "doris_oauth_access_token_expire_seconds": 86400,
+            "doris_oauth_refresh_token_expire_seconds": 30 * 86400,
+            "doris_oauth_auth_code_expire_seconds": 1800,
+            "doris_oauth_gc_interval_seconds": 3600,
+            "doris_oauth_dcr_client_ttl_seconds": 30 * 86400,
+        }
+        for field_name, upper_bound in ttl_limits.items():
+            value = getattr(config.security, field_name)
+            if int(value) <= 0 or int(value) > upper_bound:
+                raise AuthConfigError(f"{field_name} must be between 1 and {upper_bound}")
+        idle_timeout = config.security.doris_oauth_idle_timeout_seconds
+        if idle_timeout is not None and (int(idle_timeout) <= 0 or int(idle_timeout) > 7 * 86400):
+            raise AuthConfigError("doris_oauth_idle_timeout_seconds must be between 1 and 604800")
+        for field_name in (
+            "doris_oauth_rate_limit_window_seconds",
+            "doris_oauth_login_rate_limit_per_ip",
+            "doris_oauth_login_rate_limit_per_user",
+            "doris_oauth_login_rate_limit_per_client",
+            "doris_oauth_login_rate_limit_per_txn",
+            "doris_oauth_dcr_rate_limit_per_ip",
+            "doris_oauth_authorize_rate_limit_per_ip",
+            "doris_oauth_token_rate_limit_per_ip",
+            "doris_oauth_token_rate_limit_per_client",
+            "doris_oauth_revoke_rate_limit_per_ip",
+            "doris_oauth_revoke_rate_limit_per_client",
+            "doris_oauth_api_auth_token_rate_limit_per_ip",
+            "doris_oauth_api_auth_token_rate_limit_per_user",
+            "doris_oauth_api_auth_refresh_rate_limit_per_ip",
+            "doris_oauth_api_auth_refresh_rate_limit_per_client",
+            "doris_oauth_dcr_max_clients",
+        ):
+            if int(getattr(config.security, field_name)) <= 0:
+                raise AuthConfigError(f"{field_name} must be greater than 0")
+
+    methods: list[str] = []
+    if enable_doris_oauth_auth:
+        methods.append("doris_oauth")
+    if enable_token_auth:
+        methods.append("token")
+    if enable_jwt_auth:
+        methods.append("jwt")
+    if enable_external_oauth_auth:
+        methods.append("external_oauth")
+
+    if enable_doris_oauth_auth:
+        discovery_mode = "doris_oauth"
+    elif enable_external_oauth_auth:
+        discovery_mode = "external_oauth"
+    else:
+        discovery_mode = "none"
+
+    source_summary = {
+        "enable_token_auth": inputs.enable_token_auth.source,
+        "enable_jwt_auth": inputs.enable_jwt_auth.source,
+        "enable_oauth_auth": inputs.enable_external_oauth_auth.source,
+        "oauth_enabled": inputs.oauth_enabled.source,
+        "enable_doris_oauth_auth": inputs.enable_doris_oauth_auth.source,
+        "auth_type": inputs.legacy_auth_type.source,
+        "transport": inputs.transport.source,
+        "workers": inputs.workers.source,
+    }
+
+    effective = EffectiveAuthConfig(
+        enable_token_auth=enable_token_auth,
+        enable_jwt_auth=enable_jwt_auth,
+        enable_external_oauth_auth=enable_external_oauth_auth,
+        enable_doris_oauth_auth=enable_doris_oauth_auth,
+        auth_methods=tuple(methods),
+        oauth_discovery_mode=discovery_mode,
+        doris_oauth_base_url=config.security.doris_oauth_base_url.rstrip("/"),
+        transport=transport,
+        requested_workers=requested,
+        effective_workers=effective_workers,
+        legacy_auth_type=auth_type,
+        auth_config_warnings=tuple(warnings),
+        source_summary=source_summary,
+    )
+    config.effective_auth = effective
+    config._auth_inputs = inputs
+    return effective
+
+
+def get_effective_auth_config(config: DorisConfig) -> EffectiveAuthConfig:
+    """Return previously normalized auth config."""
+    effective = getattr(config, "effective_auth", None)
+    if effective is None:
+        raise AuthConfigError("Effective auth config has not been normalized")
+    return effective
 
 
 class ConfigManager:

--- a/doris_mcp_server/utils/db.py
+++ b/doris_mcp_server/utils/db.py
@@ -23,9 +23,13 @@ Supports asynchronous operations and concurrent connection management, ensuring 
 """
 
 import asyncio
+import hashlib
+import hmac
 import logging
 import re
+import secrets
 import time
+import uuid
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -79,10 +83,57 @@ class QueryResult:
     sql: str
 
 
+@dataclass
+class DorisUserPoolMeta:
+    """Metadata for an active Doris-user-owned pool."""
+
+    user: str
+    pool_key: str
+    owner_id: str
+    created_at: datetime
+    last_used: datetime
+    maxsize: int
+    database: str
+    charset: str
+    credential_fingerprint: str
+    generation: int = 0
+
+
+class DorisUserPoolMissingError(RuntimeError):
+    """Raised when a Doris OAuth request has no local Doris user pool."""
+
+    error_code = "DORIS_OAUTH_POOL_MISSING"
+    status_code = 401
+
+    def __init__(self, message: str = "Doris OAuth user pool is missing"):
+        super().__init__(message)
+
+
+class DorisUserAuthenticationError(RuntimeError):
+    """Raised when Doris username/password authentication fails."""
+
+    error_code = "DORIS_AUTHENTICATION_FAILED"
+    status_code = 401
+
+    def __init__(self, message: str = "Doris user authentication failed"):
+        super().__init__(message)
+
+
 class DorisConnection:
     """Doris database connection wrapper class"""
 
-    def __init__(self, connection: Connection, session_id: str, security_manager=None):
+    def __init__(
+        self,
+        connection: Connection,
+        session_id: str,
+        security_manager=None,
+        *,
+        pool_kind: str = "global",
+        route_key: str = "global",
+        owner_id: str = "global:0",
+        generation: int = 0,
+        owner_pool: Any | None = None,
+    ):
         self.connection = connection
         self.session_id = session_id
         self.created_at = datetime.utcnow()
@@ -90,6 +141,11 @@ class DorisConnection:
         self.query_count = 0
         self.is_healthy = True
         self.security_manager = security_manager
+        self.pool_kind = pool_kind
+        self.route_key = route_key
+        self.owner_id = owner_id
+        self.generation = generation
+        self.owner_pool = owner_pool
         self.logger = get_logger(__name__)
 
     async def execute(self, sql: str, params: tuple | None = None, auth_context=None) -> QueryResult:
@@ -272,6 +328,18 @@ class DorisConnectionManager:
         self.token_configs: Dict[str, dict] = {}  # token_hash -> db_config
         self._token_pool_locks: Dict[str, asyncio.Lock] = {}  # token_hash -> lock
         self._token_pools_lock = asyncio.Lock()  # Lock for managing token_pools dict
+        self._token_pool_owner_ids: Dict[str, str] = {}  # token_hash -> owner id
+        self._token_pool_generations: Dict[str, int] = {}  # token_hash -> physical pool generation
+
+        # Doris OAuth user-owned pool state. Raw Doris passwords are never stored.
+        self.doris_user_pools: Dict[str, Pool] = {}  # normalized Doris user -> active pool
+        self.doris_user_pool_meta: Dict[str, DorisUserPoolMeta] = {}
+        self._retired_doris_user_pools: Dict[str, Pool] = {}  # owner_id -> retired pool
+        self._doris_user_pool_locks: Dict[str, asyncio.Lock] = {}
+        self._doris_user_pools_lock = asyncio.Lock()
+        self._doris_user_pool_secret = secrets.token_bytes(32)
+        self._global_pool_owner_id = "global:0"
+        self._global_pool_generation = 0
 
         # FIX for Issue #58 Problem 1: Disable session caching to prevent connection sharing
         # Session caching causes multiple threads to share the same MySQL connection,
@@ -413,6 +481,354 @@ class DorisConnectionManager:
             if old_config.get(key) != new_config.get(key):
                 return True
         return False
+
+    def _validate_doris_user(self, user: str) -> str:
+        """Validate and normalize a Doris username for pool routing."""
+        if not isinstance(user, str) or not user:
+            raise DorisUserAuthenticationError("Doris user must be a non-empty string")
+        if user != user.strip():
+            raise DorisUserAuthenticationError("Doris user must not contain leading or trailing whitespace")
+        if len(user) > 256:
+            raise DorisUserAuthenticationError("Doris user is too long")
+        if any(ch in user for ch in ("\x00", "\n", "\r")):
+            raise DorisUserAuthenticationError("Doris user contains invalid characters")
+        return user
+
+    def _validate_doris_password(self, password: str) -> None:
+        """Validate a Doris password without logging or storing it."""
+        if not isinstance(password, str) or not password:
+            raise DorisUserAuthenticationError("Doris password must be a non-empty string")
+        if len(password) > 256:
+            raise DorisUserAuthenticationError("Doris password is too long")
+        if any(ch in password for ch in ("\x00", "\n", "\r")):
+            raise DorisUserAuthenticationError("Doris password contains invalid characters")
+
+    def _validate_doris_auth_retries(self, max_retries: int) -> int:
+        if isinstance(max_retries, bool) or not isinstance(max_retries, int) or max_retries < 1:
+            raise DorisUserAuthenticationError("max_retries must be a positive integer")
+        return max_retries
+
+    def _doris_user_route_key(self, user: str) -> str:
+        return f"doris_user:{user}"
+
+    def _credential_fingerprint(self, password: str) -> str:
+        return hmac.new(
+            self._doris_user_pool_secret,
+            password.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def _get_doris_user_pool_maxsize(self) -> int:
+        return max(1, min(5, int(self.maxsize or 1)))
+
+    def _build_doris_user_db_config(self, user: str, password: str) -> dict:
+        return {
+            "host": self.original_db_config["host"],
+            "port": self.original_db_config["port"],
+            "user": user,
+            "password": password,
+            # Per-user pools must not depend on the service/global default DB:
+            # low-privilege Doris RBAC users may lack access to it. Queries can
+            # still use fully qualified names or select a DB later.
+            "database": "information_schema",
+            "charset": self.original_db_config["charset"],
+            "maxsize": self._get_doris_user_pool_maxsize(),
+        }
+
+    async def _get_doris_user_lock(self, user: str) -> asyncio.Lock:
+        async with self._doris_user_pools_lock:
+            lock = self._doris_user_pool_locks.get(user)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._doris_user_pool_locks[user] = lock
+            return lock
+
+    async def _close_pool_safely(self, pool: Pool | None, label: str, timeout: float = 2.0) -> None:
+        """Close a pool without letting one failure block broader cleanup."""
+        if not pool:
+            return
+        try:
+            if getattr(pool, "closed", False) is not True:
+                pool.close()
+            wait_closed = getattr(pool, "wait_closed", None)
+            if wait_closed:
+                try:
+                    await asyncio.wait_for(wait_closed(), timeout=timeout)
+                except asyncio.TimeoutError:
+                    self.logger.warning(f"Timeout waiting for {label} pool to close")
+        except Exception as e:
+            self.logger.warning(f"Error closing {label} pool: {e}")
+
+    async def _force_close_raw_connection(self, raw_connection: Any, reason: str) -> None:
+        """Force-close a raw connection when owner-based release is impossible."""
+        if not raw_connection:
+            return
+        try:
+            if getattr(raw_connection, "closed", False) is True:
+                return
+            ensure_closed = getattr(raw_connection, "ensure_closed", None)
+            if ensure_closed:
+                result = ensure_closed()
+                if asyncio.iscoroutine(result):
+                    await result
+                return
+            close = getattr(raw_connection, "close", None)
+            if close:
+                result = close()
+                if asyncio.iscoroutine(result):
+                    await result
+        except Exception as e:
+            self.logger.debug(f"Error force closing connection after {reason}: {e}")
+
+    async def _close_auth_connection(self, conn: Any) -> None:
+        if not conn:
+            return
+        try:
+            close = getattr(conn, "close", None)
+            if close:
+                result = close()
+                if asyncio.iscoroutine(result):
+                    await result
+                return
+            ensure_closed = getattr(conn, "ensure_closed", None)
+            if ensure_closed:
+                result = ensure_closed()
+                if asyncio.iscoroutine(result):
+                    await result
+        except Exception as e:
+            self.logger.debug(f"Error closing Doris auth connection: {e}")
+
+    def _mark_global_pool_created(self) -> None:
+        self._global_pool_generation += 1
+        self._global_pool_owner_id = f"global:gen:{self._global_pool_generation}:{uuid.uuid4().hex}"
+
+    async def authenticate_doris_user(
+        self,
+        user: str,
+        password: str,
+        *,
+        max_retries: int = 1,
+    ) -> None:
+        """Validate Doris username/password against FE MySQL without creating a pool."""
+        normalized_user = self._validate_doris_user(user)
+        self._validate_doris_password(password)
+        retries = self._validate_doris_auth_retries(max_retries)
+
+        last_error: Exception | None = None
+        for attempt in range(1, retries + 1):
+            conn = None
+            try:
+                conn = await aiomysql.connect(
+                    host=self.original_db_config["host"],
+                    port=self.original_db_config["port"],
+                    user=normalized_user,
+                    password=password,
+                    db="information_schema",
+                    charset=self.charset,
+                    connect_timeout=self.connect_timeout,
+                    autocommit=True,
+                )
+                return
+            except DorisUserAuthenticationError:
+                raise
+            except Exception as e:
+                last_error = e
+                self.logger.warning(
+                    "Doris user authentication failed for %s@%s:%s on attempt %s/%s: %s",
+                    normalized_user,
+                    self.original_db_config["host"],
+                    self.original_db_config["port"],
+                    attempt,
+                    retries,
+                    type(e).__name__,
+                )
+            finally:
+                await self._close_auth_connection(conn)
+
+        raise DorisUserAuthenticationError(
+            f"Doris user authentication failed for {normalized_user}: {type(last_error).__name__}"
+        )
+
+    async def create_or_replace_doris_user_pool(
+        self,
+        user: str,
+        password: str,
+        *,
+        max_retries: int = 1,
+    ) -> None:
+        """Authenticate a Doris user, then create/reuse/soft-replace its pool."""
+        normalized_user = self._validate_doris_user(user)
+        self._validate_doris_password(password)
+        self._validate_doris_auth_retries(max_retries)
+
+        await self.authenticate_doris_user(normalized_user, password, max_retries=max_retries)
+        fingerprint = self._credential_fingerprint(password)
+        lock = await self._get_doris_user_lock(normalized_user)
+        old_pool = None
+        old_owner_id = ""
+
+        async with lock:
+            existing = self.doris_user_pools.get(normalized_user)
+            meta = self.doris_user_pool_meta.get(normalized_user)
+            if (
+                existing
+                and getattr(existing, "closed", False) is not True
+                and meta
+                and meta.credential_fingerprint == fingerprint
+            ):
+                meta.last_used = datetime.utcnow()
+                self.logger.debug("Reusing Doris user pool for %s", normalized_user)
+                return
+
+            db_config = self._build_doris_user_db_config(normalized_user, password)
+            new_pool = await self._create_pool_with_config(db_config)
+
+            old_pool = existing
+            old_meta = meta
+            generation = (old_meta.generation + 1) if old_meta else 1
+            owner_id = f"doris_user:{normalized_user}:gen:{generation}:{uuid.uuid4().hex}"
+            now = datetime.utcnow()
+            new_meta = DorisUserPoolMeta(
+                user=normalized_user,
+                pool_key=self._doris_user_route_key(normalized_user),
+                owner_id=owner_id,
+                created_at=now,
+                last_used=now,
+                maxsize=db_config["maxsize"],
+                database=db_config["database"],
+                charset=db_config["charset"],
+                credential_fingerprint=fingerprint,
+                generation=generation,
+            )
+
+            self.doris_user_pools[normalized_user] = new_pool
+            self.doris_user_pool_meta[normalized_user] = new_meta
+            if old_pool:
+                old_owner_id = old_meta.owner_id if old_meta else f"doris_user:{normalized_user}:retired:{uuid.uuid4().hex}"
+                self._retired_doris_user_pools[old_owner_id] = old_pool
+
+        if old_pool:
+            await self._close_pool_safely(old_pool, f"retired Doris user {old_owner_id}")
+
+    def has_doris_user_pool(self, user: str) -> bool:
+        try:
+            normalized_user = self._validate_doris_user(user)
+        except DorisUserAuthenticationError:
+            return False
+        pool = self.doris_user_pools.get(normalized_user)
+        return bool(pool and getattr(pool, "closed", False) is not True)
+
+    async def get_connection_for_doris_user(self, user: str, session_id: str) -> "DorisConnection":
+        """Acquire a connection from an existing Doris-user pool, fail-closed if absent."""
+        try:
+            normalized_user = self._validate_doris_user(user)
+        except DorisUserAuthenticationError as e:
+            raise DorisUserPoolMissingError(str(e)) from e
+
+        lock = await self._get_doris_user_lock(normalized_user)
+        async with lock:
+            pool = self.doris_user_pools.get(normalized_user)
+            meta = self.doris_user_pool_meta.get(normalized_user)
+            if not pool or getattr(pool, "closed", False) is True or not meta:
+                raise DorisUserPoolMissingError(f"Doris user pool missing for {normalized_user}")
+
+            raw_conn = await asyncio.wait_for(pool.acquire(), timeout=self.connect_timeout)
+            meta.last_used = datetime.utcnow()
+            return DorisConnection(
+                raw_conn,
+                session_id,
+                self.security_manager,
+                pool_kind="doris_user",
+                route_key=meta.pool_key,
+                owner_id=meta.owner_id,
+                generation=meta.generation,
+                owner_pool=pool,
+            )
+
+    async def release_connection_for_doris_user(self, user: str, connection: "DorisConnection") -> None:
+        """Release a Doris-user connection to its captured owner pool."""
+        try:
+            normalized_user = self._validate_doris_user(user)
+            expected_route_key = self._doris_user_route_key(normalized_user)
+        except DorisUserAuthenticationError:
+            expected_route_key = ""
+
+        if connection and (
+            getattr(connection, "pool_kind", "") != "doris_user"
+            or getattr(connection, "route_key", "") != expected_route_key
+        ):
+            self.logger.warning(
+                "Doris user connection route mismatch on release: expected=%s actual=%s kind=%s",
+                expected_route_key,
+                getattr(connection, "route_key", ""),
+                getattr(connection, "pool_kind", ""),
+            )
+        await self.release_routed_connection(connection)
+
+    async def evict_doris_user_pool(self, user: str) -> None:
+        """Remove and close a Doris-user pool if it exists."""
+        try:
+            normalized_user = self._validate_doris_user(user)
+        except DorisUserAuthenticationError:
+            return
+
+        lock = await self._get_doris_user_lock(normalized_user)
+        pool = None
+        owner_id = ""
+        async with lock:
+            pool = self.doris_user_pools.pop(normalized_user, None)
+            meta = self.doris_user_pool_meta.pop(normalized_user, None)
+            owner_id = meta.owner_id if meta else self._doris_user_route_key(normalized_user)
+            if pool and meta:
+                self._retired_doris_user_pools[meta.owner_id] = pool
+
+        await self._close_pool_safely(pool, f"evicted Doris user {owner_id}")
+
+    async def cleanup_idle_doris_user_pools(
+        self,
+        active_users: set[str] | None = None,
+        max_idle_time: int | None = None,
+    ) -> None:
+        """Close Doris-user pools that are not in active_users and are optionally idle."""
+        active_users = active_users or set()
+        normalized_active_users = {u for u in active_users if isinstance(u, str)}
+        now = datetime.utcnow()
+        users_to_remove: list[str] = []
+
+        async with self._doris_user_pools_lock:
+            for user, pool in list(self.doris_user_pools.items()):
+                meta = self.doris_user_pool_meta.get(user)
+                if user in normalized_active_users:
+                    continue
+                if max_idle_time is not None and meta:
+                    idle_seconds = (now - meta.last_used).total_seconds()
+                    if idle_seconds < max_idle_time:
+                        continue
+                if pool:
+                    users_to_remove.append(user)
+
+        for user in users_to_remove:
+            await self.evict_doris_user_pool(user)
+
+    async def close_all_doris_user_pools(self) -> None:
+        """Close all active and retired Doris-user pools for shutdown."""
+        async with self._doris_user_pools_lock:
+            pools_by_owner: list[tuple[str, Pool]] = []
+            for user, pool in list(self.doris_user_pools.items()):
+                meta = self.doris_user_pool_meta.get(user)
+                pools_by_owner.append((meta.owner_id if meta else self._doris_user_route_key(user), pool))
+            pools_by_owner.extend(list(self._retired_doris_user_pools.items()))
+            self.doris_user_pools.clear()
+            self.doris_user_pool_meta.clear()
+            self._retired_doris_user_pools.clear()
+            self._doris_user_pool_locks.clear()
+
+        seen_pool_ids: set[int] = set()
+        for owner_id, pool in pools_by_owner:
+            if not pool or id(pool) in seen_pool_ids:
+                continue
+            seen_pool_ids.add(id(pool))
+            await self._close_pool_safely(pool, f"Doris user {owner_id}")
     
     async def get_pool_for_token(self, token: str) -> tuple[Pool, dict]:
         """Get or create a dedicated connection pool for a specific token
@@ -454,6 +870,7 @@ class DorisConnectionManager:
                         except Exception as e:
                             self.logger.warning(f"Error closing old pool during hot reload: {e}")
                     self.token_configs.pop(token_hash, None)
+                    self._token_pool_owner_ids.pop(token_hash, None)
                 # Continue to slow path to create new pool
             elif pool and not pool.closed:
                 return pool, cached_config
@@ -503,6 +920,11 @@ class DorisConnectionManager:
             # Store pool and config
             self.token_pools[token_hash] = pool
             self.token_configs[token_hash] = db_config
+            token_generation = self._token_pool_generations.get(token_hash, 0) + 1
+            self._token_pool_generations[token_hash] = token_generation
+            self._token_pool_owner_ids[token_hash] = (
+                f"static_token:{token_hash}:gen:{token_generation}:{uuid.uuid4().hex}"
+            )
             
             # Create lock for this token if not exists
             if token_hash not in self._token_pool_locks:
@@ -535,7 +957,7 @@ class DorisConnectionManager:
                     db=db_config['database'],
                     charset=charset,
                     minsize=0,  # Don't pre-create connections
-                    maxsize=self.maxsize,
+                    maxsize=db_config.get('maxsize', self.maxsize),
                     connect_timeout=self.connect_timeout,
                     autocommit=True,
                     pool_recycle=self.pool_recycle
@@ -572,7 +994,17 @@ class DorisConnectionManager:
             self.logger.debug(f"Session {session_id}: Acquired connection from token pool "
                             f"(user: {db_config['user']}@{db_config['host']})")
             
-            return DorisConnection(connection, session_id, self.security_manager)
+            token_hash = self._get_token_hash(token)
+            return DorisConnection(
+                connection,
+                session_id,
+                self.security_manager,
+                pool_kind="static_token",
+                route_key=f"static_token:{token_hash}",
+                owner_id=self._token_pool_owner_ids.get(token_hash, f"static_token:{token_hash}:0"),
+                generation=self._token_pool_generations.get(token_hash, 0),
+                owner_pool=pool,
+            )
             
         except Exception as e:
             self.logger.error(f"Session {session_id}: Failed to acquire connection from token pool: {e}")
@@ -586,14 +1018,19 @@ class DorisConnectionManager:
             connection: DorisConnection wrapper to release
         """
         token_hash = self._get_token_hash(token)
-        
-        if token_hash in self.token_pools:
-            pool = self.token_pools[token_hash]
-            if pool and not pool.closed:
-                try:
-                    pool.release(connection.connection)
-                except Exception as e:
-                    self.logger.warning(f"Failed to release connection to token pool: {e}")
+        expected_route_key = f"static_token:{token_hash}"
+
+        if connection and (
+            getattr(connection, "pool_kind", "") != "static_token"
+            or getattr(connection, "route_key", "") != expected_route_key
+        ):
+            self.logger.warning(
+                "Static token connection route mismatch on release: expected=%s actual=%s kind=%s",
+                expected_route_key,
+                getattr(connection, "route_key", ""),
+                getattr(connection, "pool_kind", ""),
+            )
+        await self.release_routed_connection(connection)
     
     async def cleanup_token_pools(self, max_idle_time: int = 3600):
         """Clean up idle token connection pools
@@ -620,6 +1057,8 @@ class DorisConnectionManager:
                         await pool.wait_closed()
                     self.token_configs.pop(token_hash, None)
                     self._token_pool_locks.pop(token_hash, None)
+                    self._token_pool_owner_ids.pop(token_hash, None)
+                    self._token_pool_generations.pop(token_hash, None)
                     self.logger.info(f"Cleaned up idle token pool (hash: {token_hash[:8]}...)")
                 except Exception as e:
                     self.logger.warning(f"Error cleaning up token pool: {e}")
@@ -646,12 +1085,16 @@ class DorisConnectionManager:
                     self.token_pools.clear()
                     self.token_configs.clear()
                     self._token_pool_locks.clear()
+                    self._token_pool_owner_ids.clear()
+                    self._token_pool_generations.clear()
         except asyncio.TimeoutError:
             self.logger.warning("Timeout acquiring lock for token pool cleanup, forcing clear")
             # Force clear without lock
             self.token_pools.clear()
             self.token_configs.clear()
             self._token_pool_locks.clear()
+            self._token_pool_owner_ids.clear()
+            self._token_pool_generations.clear()
 
     async def configure_for_token(self, token: str) -> tuple[bool, str]:
         """Configure connection manager for token with new priority logic
@@ -773,6 +1216,7 @@ class DorisConnectionManager:
                 connect_timeout=self.connect_timeout,
                 autocommit=True
             )
+            self._mark_global_pool_created()
             
             # Store the current config for comparison later
             self._last_pool_config = {
@@ -915,6 +1359,7 @@ class DorisConnectionManager:
                 connect_timeout=self.connect_timeout,
                 autocommit=True
             )
+            self._mark_global_pool_created()
             
             # Test initial connection
             if not await self._test_pool_health():
@@ -1130,6 +1575,7 @@ class DorisConnectionManager:
             connect_timeout=self.connect_timeout,
             autocommit=True
         )
+        self._mark_global_pool_created()
         
         # Test pool health
         if not await self._test_pool_health():
@@ -1334,6 +1780,7 @@ class DorisConnectionManager:
                             ),
                             timeout=10.0
                         )
+                        self._mark_global_pool_created()
                         
                         # Test recovered pool with timeout
                         if await asyncio.wait_for(self._test_pool_health(), timeout=5.0):
@@ -1381,31 +1828,49 @@ class DorisConnectionManager:
             if not self.pool_recovering:  # Only recover if not already in progress
                 await self._recover_pool()
 
-    async def get_connection(self, session_id: str) -> DorisConnection:
-        """🔧 FIX: Simplified connection acquisition without double locking
-        
-        Uses only semaphore to prevent too many concurrent acquisitions.
-        If the connection is successfully obtained, it will be added to the connection pool cache.
-        
-        🔧 FIX for token isolation: Now automatically checks for auth_context from ContextVar
-        and uses token-specific connection pool if available.
-        """
-        # 🔧 FIX: Check for auth_context from global ContextVar
-        # This ensures all tools using get_connection respect token-bound database configuration
-        auth_context = None
+    def _get_effective_auth_context(self, auth_context=None):
+        if auth_context is not None:
+            return auth_context
         try:
             from .security import mcp_auth_context_var
-            auth_context = mcp_auth_context_var.get()
+            return mcp_auth_context_var.get()
         except Exception as e:
-            self.logger.debug(f"get_connection: Could not get auth_context: {e}")
-        
-        if auth_context and hasattr(auth_context, 'token') and auth_context.token:
-            # Use token-specific connection pool
-            # SECURITY: Do NOT catch exceptions here - if token pool fails, don't fallback to global pool
-            # This prevents privilege escalation
+            self.logger.debug(f"Could not get auth_context: {e}")
+            return None
+
+    async def _get_connection_for_auth_context(self, session_id: str, auth_context=None) -> DorisConnection:
+        """Resolve the request route with Doris OAuth fail-closed priority."""
+        if auth_context and getattr(auth_context, "auth_method", "") == "doris_oauth":
+            doris_user = getattr(auth_context, "doris_user", "")
+            if not doris_user:
+                raise DorisUserPoolMissingError("Doris OAuth auth context is missing doris_user")
+            try:
+                normalized_user = self._validate_doris_user(doris_user)
+            except DorisUserAuthenticationError as e:
+                raise DorisUserPoolMissingError(str(e)) from e
+            expected_route_key = self._doris_user_route_key(normalized_user)
+            context_pool_key = getattr(auth_context, "pool_key", "")
+            if context_pool_key and context_pool_key != expected_route_key:
+                raise DorisUserPoolMissingError("Doris OAuth pool key does not match doris_user")
+            self.logger.debug("get_connection: Using Doris user pool for session %s", session_id)
+            return await self.get_connection_for_doris_user(normalized_user, session_id)
+
+        if auth_context and getattr(auth_context, "token", ""):
+            # SECURITY: Do not catch token pool errors here; token-bound requests must not fall back.
             self.logger.debug(f"get_connection: Using token-specific pool for session {session_id}")
             return await self.get_connection_for_token(auth_context.token, session_id)
-        
+
+        return await self._get_global_connection(session_id)
+
+    async def get_connection(self, session_id: str) -> DorisConnection:
+        """Acquire a connection using Doris OAuth -> static token -> global priority."""
+        return await self._get_connection_for_auth_context(
+            session_id,
+            self._get_effective_auth_context(),
+        )
+
+    async def _get_global_connection(self, session_id: str) -> DorisConnection:
+        """Acquire a connection from the global pool."""
         cached_conn = self.session_cache.get(session_id)
         if cached_conn:
             return cached_conn
@@ -1470,7 +1935,16 @@ class DorisConnectionManager:
                         raise RuntimeError("Connection acquisition timed out")
                 
                 # Wrap in DorisConnection
-                doris_conn = DorisConnection(raw_conn, session_id, self.security_manager)
+                doris_conn = DorisConnection(
+                    raw_conn,
+                    session_id,
+                    self.security_manager,
+                    pool_kind="global",
+                    route_key="global",
+                    owner_id=self._global_pool_owner_id,
+                    generation=self._global_pool_generation,
+                    owner_pool=self.pool,
+                )
                 
                 # Basic validation - check if connection is open
                 if raw_conn.closed:
@@ -1490,6 +1964,38 @@ class DorisConnectionManager:
                 self.logger.error(f"Failed to get connection for session {session_id}: {e}")
                 raise
 
+    async def release_routed_connection(self, connection: DorisConnection | None) -> None:
+        """Release a DorisConnection to the exact pool captured at acquire time."""
+        if not connection or not getattr(connection, "connection", None):
+            return
+
+        raw_connection = connection.connection
+        owner_pool = getattr(connection, "owner_pool", None)
+        if owner_pool is None:
+            self.logger.warning(
+                "Connection %s has no captured owner pool; force closing raw connection",
+                getattr(connection, "session_id", ""),
+            )
+            await self._force_close_raw_connection(raw_connection, "missing owner pool")
+            return
+
+        try:
+            owner_pool.release(raw_connection)
+            self.logger.debug(
+                "Released %s connection for route=%s owner=%s",
+                getattr(connection, "pool_kind", ""),
+                getattr(connection, "route_key", ""),
+                getattr(connection, "owner_id", ""),
+            )
+        except Exception as release_error:
+            self.logger.warning(
+                "Connection release failed for route=%s owner=%s: %s; force closing",
+                getattr(connection, "route_key", ""),
+                getattr(connection, "owner_id", ""),
+                release_error,
+            )
+            await self._force_close_raw_connection(raw_connection, "owner pool release failure")
+
     async def release_connection(self, session_id: str, connection: DorisConnection):
         """🔧 FIX: Release connection back to pool with proper error handling"""
         cached_conn = self.session_cache.get(session_id)
@@ -1501,6 +2007,14 @@ class DorisConnectionManager:
 
         if not connection or not connection.connection:
             self.logger.debug(f"No connection to release for session {session_id}")
+            return
+
+        if getattr(connection, "owner_pool", None) is not None:
+            await self.release_routed_connection(connection)
+            return
+
+        if getattr(connection, "pool_kind", "global") != "global":
+            await self.release_routed_connection(connection)
             return
             
         try:
@@ -1552,6 +2066,9 @@ class DorisConnectionManager:
                 except asyncio.CancelledError:
                     pass
 
+            # Close Doris OAuth user pools before legacy token/global pools.
+            await self.close_all_doris_user_pools()
+
             # 🔧 FIX: Close all per-token connection pools
             await self.close_all_token_pools()
 
@@ -1590,46 +2107,15 @@ class DorisConnectionManager:
     async def execute_query(
         self, session_id: str, sql: str, params: tuple | None = None, auth_context=None
     ) -> QueryResult:
-        """Execute query - Enhanced Strategy with per-token connection pool isolation
-
-        FIX for multi-tenant concurrency: Each token now uses its own dedicated connection pool
-        to prevent configuration conflicts between concurrent requests from different tokens.
-        """
+        """Execute query using the same routed acquire/release contract as get_connection()."""
         connection = None
-        token = None
+        effective_auth_context = self._get_effective_auth_context(auth_context)
         
         try:
-            # Check if we have a token for per-token pool isolation
-            if auth_context and hasattr(auth_context, 'token') and auth_context.token:
-                token = auth_context.token
-                
-                try:
-                    # 🔧 FIX: Use dedicated connection pool for this token
-                    # This prevents concurrent requests from different tokens interfering
-                    connection = await self.get_connection_for_token(token, session_id)
-                    
-                    # Get the config for logging
-                    token_hash = self._get_token_hash(token)
-                    if token_hash in self.token_configs:
-                        db_config = self.token_configs[token_hash]
-                        self.logger.info(f"Session {session_id}: Using dedicated pool for {db_config['user']}@{db_config['host']}")
-                    
-                except Exception as token_pool_error:
-                    # SECURITY: If token should have pool but creation fails, don't fallback
-                    # This prevents privilege escalation (using high-privilege default user)
-                    self.logger.error(f"Session {session_id}: Token pool error: {token_pool_error}")
-                    raise RuntimeError(
-                        f"Failed to get connection for authenticated token. "
-                        f"This is a security measure to prevent using default high-privilege credentials. "
-                        f"Error: {token_pool_error}"
-                    )
-            else:
-                # No token - use global pool (backward compatibility)
-                self.logger.debug(f"Session {session_id}: No token, using global connection pool")
-                connection = await self.get_connection(session_id)
+            connection = await self._get_connection_for_auth_context(session_id, effective_auth_context)
 
             # Execute query
-            result = await connection.execute(sql, params, auth_context)
+            result = await connection.execute(sql, params, effective_auth_context)
 
             return result
 
@@ -1637,12 +2123,8 @@ class DorisConnectionManager:
             self.logger.error(f"Query execution failed for session {session_id}: {e}")
             raise
         finally:
-            # Always release connection back to the appropriate pool
             if connection:
-                if token:
-                    await self.release_connection_for_token(token, connection)
-                else:
-                    await self.release_connection(session_id, connection)
+                await self.release_connection(session_id, connection)
 
     @asynccontextmanager
     async def get_connection_context(self, session_id: str):

--- a/doris_mcp_server/utils/query_executor.py
+++ b/doris_mcp_server/utils/query_executor.py
@@ -28,7 +28,7 @@ import time
 import os
 import uuid
 import traceback
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, date
 from typing import Any, Dict
 from decimal import Decimal
@@ -37,7 +37,12 @@ import sqlparse
 
 from .db import DorisConnectionManager, QueryResult, get_first_sql_keyword
 from .logger import get_logger
-from .sql_security_utils import get_auth_context
+from .sql_security_utils import (
+    SQLSecurityError,
+    get_auth_context,
+    quote_identifier,
+    validate_identifier,
+)
 
 
 @dataclass
@@ -391,6 +396,18 @@ class DorisQueryExecutor:
         self.metrics.concurrent_queries += 1
 
         try:
+            effective_auth_context = auth_context or get_auth_context()
+            if (
+                query_request.cache_enabled
+                and getattr(effective_auth_context, "auth_method", "") == "doris_oauth"
+            ):
+                self.logger.warning(
+                    "Doris OAuth query cache disabled for session %s",
+                    query_request.session_id,
+                )
+                query_request = replace(query_request, cache_enabled=False)
+                auth_context = effective_auth_context
+
             # Check cache first
             if query_request.cache_enabled:
                 cached_result = await self.query_cache.get(
@@ -543,6 +560,138 @@ class DorisQueryExecutor:
 
         return query_results
 
+    def _build_context_statements(
+        self, db_name: str | None = None, catalog_name: str | None = None
+    ) -> list[str]:
+        """Build validated Doris context switching statements."""
+        statements: list[str] = []
+        if catalog_name:
+            validate_identifier(catalog_name, "catalog name")
+            safe_catalog = quote_identifier(catalog_name, "catalog name")
+            statements.append(f"USE CATALOG {safe_catalog}")
+        if db_name:
+            validate_identifier(db_name, "database name")
+            safe_db = quote_identifier(db_name, "database name")
+            statements.append(f"USE {safe_db}")
+        return statements
+
+    async def _acquire_routed_connection(self, session_id: str, auth_context=None):
+        """Acquire a routed connection, preserving an explicit auth context."""
+        get_connection_for_auth_context = getattr(
+            self.connection_manager,
+            "_get_connection_for_auth_context",
+            None,
+        )
+        if callable(get_connection_for_auth_context):
+            get_effective_auth_context = getattr(
+                self.connection_manager,
+                "_get_effective_auth_context",
+                None,
+            )
+            effective_auth_context = (
+                get_effective_auth_context(auth_context)
+                if callable(get_effective_auth_context)
+                else auth_context
+            )
+            return await get_connection_for_auth_context(
+                session_id,
+                effective_auth_context,
+            )
+        return await self.connection_manager.get_connection(session_id)
+
+    async def _release_routed_connection(self, session_id: str, connection) -> None:
+        release_connection = getattr(self.connection_manager, "release_connection", None)
+        if callable(release_connection):
+            await release_connection(session_id, connection)
+
+    def _query_result_payload(self, result: QueryResult) -> dict[str, Any]:
+        return {
+            "data": [self._serialize_row_data(data) for data in result.data],
+            "row_count": result.row_count,
+            "execution_time": result.execution_time,
+            "metadata": {
+                "columns": result.metadata.get("columns", []),
+                "query": result.sql,
+            },
+        }
+
+    async def _execute_sql_with_context_for_mcp(
+        self,
+        sql: str,
+        *,
+        db_name: str | None = None,
+        catalog_name: str | None = None,
+        limit: int = 1000,
+        timeout: int = 30,
+        session_id: str = "mcp_session",
+        user_id: str = "mcp_user",
+        auth_context=None,
+    ) -> Dict[str, Any]:
+        """Execute optional catalog/db context and target SQL on one routed connection."""
+        try:
+            context_statements = self._build_context_statements(db_name, catalog_name)
+        except SQLSecurityError as exc:
+            return {
+                "success": False,
+                "error": str(exc),
+                "error_type": "invalid_context",
+                "data": None,
+            }
+
+        target_statements = [s.strip() for s in sqlparse.split(sql) if s.strip()]
+        if not target_statements:
+            return {
+                "success": False,
+                "error": "SQL query is required",
+                "data": None,
+            }
+
+        if len(target_statements) == 1:
+            target_sql = target_statements[0]
+            if get_first_sql_keyword(target_sql) == "SELECT" and "LIMIT" not in target_sql.upper():
+                target_sql = target_sql.rstrip(";")
+                target_sql = f"{target_sql} LIMIT {limit}"
+            target_statements = [target_sql]
+
+        connection = None
+        try:
+            connection = await self._acquire_routed_connection(session_id, auth_context)
+            for context_sql in context_statements:
+                if timeout:
+                    await asyncio.wait_for(
+                        connection.execute(context_sql, auth_context=auth_context),
+                        timeout=timeout,
+                    )
+                else:
+                    await connection.execute(context_sql, auth_context=auth_context)
+
+            query_results: list[QueryResult] = []
+            for statement in target_statements:
+                if timeout:
+                    result = await asyncio.wait_for(
+                        connection.execute(statement, auth_context=auth_context),
+                        timeout=timeout,
+                    )
+                else:
+                    result = await connection.execute(statement, auth_context=auth_context)
+                query_results.append(result)
+
+            if len(query_results) == 1:
+                payload = self._query_result_payload(query_results[0])
+                return {
+                    "success": True,
+                    **payload,
+                }
+
+            return {
+                "success": True,
+                "multiple_results": True,
+                "results": [self._query_result_payload(result) for result in query_results],
+            }
+        finally:
+            if connection is not None:
+                await self._release_routed_connection(session_id, connection)
+
     async def explain_query(self, sql: str, session_id: str) -> dict[str, Any]:
         """Get query execution plan"""
         explain_sql = f"EXPLAIN {sql}"
@@ -599,6 +748,8 @@ class DorisQueryExecutor:
         timeout: int = 30,
         session_id: str = "mcp_session",
         user_id: str = "mcp_user",
+        db_name: str | None = None,
+        catalog_name: str | None = None,
         auth_context = None  # FIX for Issue #62 Bug 1: Accept auth_context with token
     ) -> Dict[str, Any]:
         """Execute SQL query for MCP interface - unified method
@@ -685,15 +836,18 @@ class DorisQueryExecutor:
                 else:
                     self.logger.warning("Security configuration not found, proceeding without validation")
 
-                # Add LIMIT if not present and it's a SELECT query.
-                # get_first_sql_keyword skips leading comments so `-- note\nSELECT ...`
-                # still gets the LIMIT cap (sql.startswith would silently bypass it).
-                sql_upper = sql.upper()
-                if get_first_sql_keyword(sql) == "SELECT" and "LIMIT" not in sql_upper:
-                    if sql.endswith(";"):
-                        sql = sql[:-1]
-                    sql = f"{sql} LIMIT {limit}"
-                
+                if db_name or catalog_name:
+                    return await self._execute_sql_with_context_for_mcp(
+                        sql,
+                        db_name=db_name,
+                        catalog_name=catalog_name,
+                        limit=limit,
+                        timeout=timeout,
+                        session_id=session_id,
+                        user_id=user_id,
+                        auth_context=auth_context,
+                    )
+
                 all_statements = [
                     s.strip()
                     for s in sqlparse.split(sql)
@@ -703,6 +857,16 @@ class DorisQueryExecutor:
                     return await self.execute_batch_sqls_for_mcp(sqls=all_statements, timeout=timeout,
                                                                  session_id=session_id, user_id=user_id,
                                                                  auth_context=auth_context)
+
+                # Add LIMIT if not present and it's a single SELECT query.
+                # Split first so a multi-statement SQL block is not turned into
+                # an extra synthetic statement such as a trailing "LIMIT 100".
+                sql_upper = sql.upper()
+                if get_first_sql_keyword(sql) == "SELECT" and "LIMIT" not in sql_upper:
+                    if sql.endswith(";"):
+                        sql = sql[:-1]
+                    sql = f"{sql} LIMIT {limit}"
+
                 # Create query request
                 query_request = QueryRequest(
                     sql=sql,
@@ -974,6 +1138,8 @@ async def execute_sql_query(sql: str, connection_manager: DorisConnectionManager
         session_id = kwargs.get("session_id", "mcp_session")
         user_id = kwargs.get("user_id", "mcp_user")
         auth_context = kwargs.get("auth_context", None)  # FIX: Extract auth_context
+        db_name = kwargs.get("db_name", None)
+        catalog_name = kwargs.get("catalog_name", None)
 
         # The execute_sql_for_mcp method now includes security validation
         result = await executor.execute_sql_for_mcp(
@@ -982,6 +1148,8 @@ async def execute_sql_query(sql: str, connection_manager: DorisConnectionManager
             timeout=timeout,
             session_id=session_id,
             user_id=user_id,
+            db_name=db_name,
+            catalog_name=catalog_name,
             auth_context=auth_context  # FIX: Pass auth_context with token
         )
 

--- a/doris_mcp_server/utils/schema_extractor.py
+++ b/doris_mcp_server/utils/schema_extractor.py
@@ -48,6 +48,16 @@ MULTI_DATABASE_NAMES=os.getenv("MULTI_DATABASE_NAMES","")
 # Import local modules
 from .db import DorisConnectionManager
 
+
+class DorisOAuthMetadataError(RuntimeError):
+    """Structured metadata failure for Doris OAuth MCP tool responses."""
+
+    def __init__(self, message: str, *, error_code: str, status_code: int):
+        super().__init__(message)
+        self.error_code = error_code
+        self.status_code = status_code
+
+
 class MetadataExtractor:
     """Apache Doris Metadata Extractor"""
     
@@ -89,6 +99,112 @@ class MetadataExtractor:
         
         # Session ID for database queries
         self._session_id = f"metadata_extractor_{uuid.uuid4().hex[:8]}"
+
+    def _current_auth_context(self):
+        try:
+            from .security import mcp_auth_context_var
+            return mcp_auth_context_var.get()
+        except Exception:
+            return None
+
+    def _is_doris_oauth_context(self, auth_context=None) -> bool:
+        context = auth_context if auth_context is not None else self._current_auth_context()
+        return getattr(context, "auth_method", "") == "doris_oauth"
+
+    def _metadata_error_from_exception(self, exc: Exception) -> DorisOAuthMetadataError:
+        error_code = getattr(exc, "error_code", None)
+        status_code = getattr(exc, "status_code", None)
+        message = str(exc) or exc.__class__.__name__
+        if error_code:
+            return DorisOAuthMetadataError(
+                message,
+                error_code=str(error_code),
+                status_code=int(status_code or 500),
+            )
+
+        mysql_error_code = None
+        if getattr(exc, "args", None):
+            try:
+                mysql_error_code = int(exc.args[0])
+            except (TypeError, ValueError):
+                mysql_error_code = None
+        if mysql_error_code in {1044, 1045, 1049, 1142, 1227}:
+            return DorisOAuthMetadataError(
+                message,
+                error_code="DORIS_OAUTH_METADATA_PERMISSION_DENIED",
+                status_code=403,
+            )
+
+        lowered = message.lower()
+        if any(marker in lowered for marker in ("permission denied", "access denied", "not authorized", "privilege")):
+            return DorisOAuthMetadataError(
+                message,
+                error_code="DORIS_OAUTH_METADATA_PERMISSION_DENIED",
+                status_code=403,
+            )
+        return DorisOAuthMetadataError(
+            message,
+            error_code="DORIS_OAUTH_METADATA_BACKEND_ERROR",
+            status_code=502,
+        )
+
+    def _reraise_if_doris_oauth_metadata_error(self, exc: Exception) -> None:
+        if isinstance(exc, DorisOAuthMetadataError):
+            raise exc
+        if self._is_doris_oauth_context():
+            raise self._metadata_error_from_exception(exc) from exc
+
+    def _doris_oauth_table_not_visible_error(
+        self,
+        table_name: str,
+        db_name: str | None = None,
+        catalog_name: str | None = None,
+    ) -> DorisOAuthMetadataError:
+        qualified_name = ".".join(
+            part
+            for part in (
+                catalog_name or self.catalog_name,
+                db_name or self.db_name,
+                table_name,
+            )
+            if part
+        )
+        return DorisOAuthMetadataError(
+            f"Doris OAuth metadata table is not visible or does not exist: {qualified_name or table_name}",
+            error_code="DORIS_OAUTH_METADATA_NOT_VISIBLE",
+            status_code=404,
+        )
+
+    def _raise_if_doris_oauth_table_not_visible(
+        self,
+        table_name: str,
+        db_name: str | None = None,
+        catalog_name: str | None = None,
+    ) -> None:
+        if self._is_doris_oauth_context():
+            raise self._doris_oauth_table_not_visible_error(table_name, db_name, catalog_name)
+
+    async def _ensure_table_visible_for_doris_oauth_metadata(
+        self,
+        table_name: str,
+        db_name: str | None = None,
+        catalog_name: str | None = None,
+    ) -> None:
+        if not self._is_doris_oauth_context():
+            return
+
+        effective_db = db_name or self.db_name
+        effective_catalog = catalog_name or self.catalog_name
+        query = f"""
+        SELECT 1 AS TABLE_VISIBLE
+        FROM information_schema.tables
+        WHERE TABLE_SCHEMA = '{effective_db}'
+          AND TABLE_NAME = '{table_name}'
+        LIMIT 1
+        """
+        result = await self._execute_query_with_catalog_async(query, effective_db, effective_catalog)
+        if not result or not result[0]:
+            raise self._doris_oauth_table_not_visible_error(table_name, effective_db, effective_catalog)
         
     def _load_excluded_databases(self) -> List[str]:
         """
@@ -1192,17 +1308,9 @@ class MetadataExtractor:
         Returns:
             Query result data (list of dictionaries or pandas DataFrame)
         """
+        auth_context = self._current_auth_context()
         try:
             if self.connection_manager:
-                # FIX: Get auth_context from global ContextVar for token-bound database configuration
-                # This ensures all query methods use the correct user's connection pool
-                auth_context = None
-                try:
-                    from .security import mcp_auth_context_var
-                    auth_context = mcp_auth_context_var.get()
-                except Exception:
-                    pass
-                
                 # Use the injected connection manager directly (async)
                 result = await self.connection_manager.execute_query(self._session_id, query, None, auth_context)
                 
@@ -1222,6 +1330,12 @@ class MetadataExtractor:
                 else:
                     return data
             else:
+                if self._is_doris_oauth_context(auth_context):
+                    raise DorisOAuthMetadataError(
+                        "Doris OAuth metadata connection manager is unavailable",
+                        error_code="DORIS_OAUTH_POOL_MISSING",
+                        status_code=401,
+                    )
                 # Fallback: Return empty result
                 logger.warning("No connection manager provided, returning empty result")
                 if return_dataframe:
@@ -1231,6 +1345,8 @@ class MetadataExtractor:
                     return []
         except Exception as e:
             logger.error(f"Error executing query: {str(e)}")
+            if self._is_doris_oauth_context(auth_context):
+                raise self._metadata_error_from_exception(e) from e
             # Return empty result instead of raising exception to prevent cascade failures
             if return_dataframe:
                 import pandas as pd
@@ -1272,6 +1388,7 @@ class MetadataExtractor:
             result = await self._execute_query_async(query, db_name)
             
             if not result:
+                self._raise_if_doris_oauth_table_not_visible(table_name, effective_db, effective_catalog)
                 return []
             
             # Process results
@@ -1292,6 +1409,7 @@ class MetadataExtractor:
             
         except Exception as e:
             logger.error(f"Failed to get table schema: {e}")
+            self._reraise_if_doris_oauth_metadata_error(e)
             return []
 
     async def get_all_databases_async(self, catalog_name: str = None) -> List[str]:
@@ -1329,6 +1447,7 @@ class MetadataExtractor:
             
         except Exception as e:
             logger.error(f"Failed to get database list: {e}")
+            self._reraise_if_doris_oauth_metadata_error(e)
             return []
 
     async def get_database_tables_async(self, db_name: str = None, catalog_name: str = None) -> List[str]:
@@ -1373,6 +1492,7 @@ class MetadataExtractor:
             
         except Exception as e:
             logger.error(f"Failed to get table list: {e}")
+            self._reraise_if_doris_oauth_metadata_error(e)
             return []
 
     async def get_catalog_list_async(self) -> List[str]:
@@ -1404,6 +1524,7 @@ class MetadataExtractor:
             
         except Exception as e:
             logger.error(f"Failed to get catalog list: {e}")
+            self._reraise_if_doris_oauth_metadata_error(e)
             return []
 
     async def get_table_comment_async(self, table_name: str, db_name: str = None, catalog_name: str = None) -> str:
@@ -1433,10 +1554,12 @@ class MetadataExtractor:
 
             result = await self._execute_query_with_catalog_async(query, effective_db, effective_catalog)
             if not result or not result[0]:
+                self._raise_if_doris_oauth_table_not_visible(table_name, effective_db, effective_catalog)
                 return ""
             return result[0].get("TABLE_COMMENT", "") or ""
         except Exception as e:
             logger.error(f"Failed to get table comment asynchronously: {e}")
+            self._reraise_if_doris_oauth_metadata_error(e)
             return ""
 
     async def get_column_comments_async(self, table_name: str, db_name: str = None, catalog_name: str = None) -> Dict[str, str]:
@@ -1468,14 +1591,22 @@ class MetadataExtractor:
             """
 
             rows = await self._execute_query_with_catalog_async(query, effective_db, effective_catalog)
+            if not rows:
+                await self._ensure_table_visible_for_doris_oauth_metadata(
+                    table_name,
+                    effective_db,
+                    effective_catalog,
+                )
+                return {}
             comments: Dict[str, str] = {}
-            for col in rows or []:
+            for col in rows:
                 name = col.get("COLUMN_NAME", "")
                 if name:
                     comments[name] = col.get("COLUMN_COMMENT", "") or ""
             return comments
         except Exception as e:
             logger.error(f"Failed to get column comments asynchronously: {e}")
+            self._reraise_if_doris_oauth_metadata_error(e)
             return {}
 
     async def get_table_indexes_async(self, table_name: str, db_name: str = None, catalog_name: str = None) -> List[Dict[str, Any]]:
@@ -1532,10 +1663,17 @@ class MetadataExtractor:
                         continue
                 if current_index is not None:
                     indexes.append(current_index)
+            else:
+                await self._ensure_table_visible_for_doris_oauth_metadata(
+                    table_name,
+                    effective_db,
+                    effective_catalog,
+                )
 
             return indexes
         except Exception as e:
             logger.error(f"Error getting index information asynchronously: {str(e)}")
+            self._reraise_if_doris_oauth_metadata_error(e)
             return []
 
     async def get_recent_audit_logs_async(self, days: int = 7, limit: int = 100):
@@ -1564,7 +1702,15 @@ class MetadataExtractor:
 
     # ==================== Business layer methods (original metadata_tools.py functionality) ====================
     
-    def _format_response(self, success: bool, result: Any = None, error: str = None, message: str = "") -> Dict[str, Any]:
+    def _format_response(
+        self,
+        success: bool,
+        result: Any = None,
+        error: str = None,
+        message: str = "",
+        error_code: str | None = None,
+        status_code: int | None = None,
+    ) -> Dict[str, Any]:
         """Format response result"""
         response_data = {
             "success": success,
@@ -1576,8 +1722,21 @@ class MetadataExtractor:
         elif not success:
             response_data["error"] = error or "Unknown error"
             response_data["message"] = message or "Operation failed"
+            if error_code:
+                response_data["error_code"] = error_code
+            if status_code:
+                response_data["status_code"] = status_code
         
         return response_data
+
+    def _format_metadata_error_response(self, exc: Exception, message: str) -> Dict[str, Any]:
+        return self._format_response(
+            success=False,
+            error=str(exc),
+            message=message,
+            error_code=getattr(exc, "error_code", None),
+            status_code=getattr(exc, "status_code", None),
+        )
 
     async def exec_query_for_mcp(
         self,
@@ -1600,56 +1759,30 @@ class MetadataExtractor:
             if not sql:
                 return self._format_response(success=False, error="No SQL statement provided", message="Please provide SQL statement to execute")
 
-            # FIX for Issue #62 Bug 3: Build context switching SQL if db_name or catalog_name is specified
-            # SECURITY FIX: Validate catalog_name and db_name to prevent SQL injection
-            final_sql = sql
-            if catalog_name or db_name:
-                context_statements = []
+            # SECURITY FIX: Validate catalog_name and db_name to prevent SQL injection.
+            # The query executor performs context switching and the target SQL on
+            # the same routed connection when either context parameter is supplied.
+            if catalog_name:
+                try:
+                    validate_identifier(catalog_name, "catalog name")
+                except SQLSecurityError as e:
+                    logger.warning(f"Invalid catalog name rejected: {e}")
+                    return self._format_response(
+                        success=False,
+                        error=f"Invalid catalog name: {catalog_name}",
+                        message="Catalog name contains invalid characters",
+                    )
 
-                # Validate and sanitize catalog_name
-                if catalog_name:
-                    try:
-                        validate_identifier(catalog_name, "catalog name")
-                    except SQLSecurityError as e:
-                        logger.warning(f"Invalid catalog name rejected: {e}")
-                        return self._format_response(
-                            success=False, 
-                            error=f"Invalid catalog name: {catalog_name}", 
-                            message="Catalog name contains invalid characters"
-                        )
-                    # Use quote_identifier to safely escape the catalog name
-                    safe_catalog = quote_identifier(catalog_name, "catalog name")
-                    context_statements.append(f"USE CATALOG {safe_catalog}")
-                    logger.debug(f"Switching to catalog: {catalog_name}")
-
-                # Validate and sanitize db_name
-                if db_name:
-                    try:
-                        validate_identifier(db_name, "database name")
-                    except SQLSecurityError as e:
-                        logger.warning(f"Invalid database name rejected: {e}")
-                        return self._format_response(
-                            success=False, 
-                            error=f"Invalid database name: {db_name}", 
-                            message="Database name contains invalid characters"
-                        )
-                    # Use quote_identifier to safely escape the database name
-                    safe_db = quote_identifier(db_name, "database name")
-                    if catalog_name:
-                        safe_catalog = quote_identifier(catalog_name, "catalog name")
-                        context_statements.append(f"USE {safe_catalog}.{safe_db}")
-                    else:
-                        context_statements.append(f"USE {safe_db}")
-                    logger.debug(f"Switching to database: {db_name}")
-
-                # Combine context switching with original SQL
-                if context_statements:
-                    # Remove trailing semicolon from context statements if present
-                    context_sql = "; ".join(context_statements)
-                    # Ensure original SQL doesn't start with semicolon
-                    sql_clean = sql.lstrip(";").strip()
-                    final_sql = f"{context_sql}; {sql_clean}"
-                    logger.debug(f"Modified SQL with context switching: {final_sql[:200]}...")
+            if db_name:
+                try:
+                    validate_identifier(db_name, "database name")
+                except SQLSecurityError as e:
+                    logger.warning(f"Invalid database name rejected: {e}")
+                    return self._format_response(
+                        success=False,
+                        error=f"Invalid database name: {db_name}",
+                        message="Database name contains invalid characters",
+                    )
 
             # FIX: Try to get auth_context from context variable (set by HTTP middleware)
             # This allows token-bound database configuration to work
@@ -1675,10 +1808,12 @@ class MetadataExtractor:
 
             # Call execute_sql_query to execute query with auth_context
             exec_result = await execute_sql_query(
-                sql=final_sql,  # Use modified SQL with context switching
+                sql=sql,
                 connection_manager=self.connection_manager,
                 limit=max_rows,
                 timeout=timeout,
+                db_name=db_name,
+                catalog_name=catalog_name,
                 auth_context=auth_context  # FIX: Pass auth_context with token
             )
 
@@ -1743,7 +1878,7 @@ class MetadataExtractor:
             return self._format_response(success=True, result=schema)
         except Exception as e:
             logger.error(f"Failed to get table schema: {str(e)}", exc_info=True)
-            return self._format_response(success=False, error=str(e), message="Error occurred while getting table schema")
+            return self._format_metadata_error_response(e, "Error occurred while getting table schema")
 
     async def get_db_table_list_for_mcp(
         self, 
@@ -1779,7 +1914,7 @@ class MetadataExtractor:
             return self._format_response(success=True, result=tables)
         except Exception as e:
             logger.error(f"Failed to get database table list: {str(e)}", exc_info=True)
-            return self._format_response(success=False, error=str(e), message="Error occurred while getting database table list")
+            return self._format_metadata_error_response(e, "Error occurred while getting database table list")
 
     async def get_db_list_for_mcp(self, catalog_name: str = None) -> Dict[str, Any]:
         """Get list of all database names on server - MCP interface"""
@@ -1790,7 +1925,7 @@ class MetadataExtractor:
             return self._format_response(success=True, result=databases)
         except Exception as e:
             logger.error(f"Failed to get database list: {str(e)}", exc_info=True)
-            return self._format_response(success=False, error=str(e), message="Error occurred while getting database list")
+            return self._format_metadata_error_response(e, "Error occurred while getting database list")
 
     async def get_table_comment_for_mcp(
         self, 
@@ -1839,7 +1974,7 @@ class MetadataExtractor:
             return self._format_response(success=True, result=comment)
         except Exception as e:
             logger.error(f"Failed to get table comment: {str(e)}", exc_info=True)
-            return self._format_response(success=False, error=str(e), message="Error occurred while getting table comment")
+            return self._format_metadata_error_response(e, "Error occurred while getting table comment")
 
     async def get_table_column_comments_for_mcp(
         self, 
@@ -1888,7 +2023,7 @@ class MetadataExtractor:
             return self._format_response(success=True, result=comments)
         except Exception as e:
             logger.error(f"Failed to get table column comments: {str(e)}", exc_info=True)
-            return self._format_response(success=False, error=str(e), message="Error occurred while getting table column comments")
+            return self._format_metadata_error_response(e, "Error occurred while getting table column comments")
 
     async def get_table_indexes_for_mcp(
         self, 
@@ -1937,7 +2072,7 @@ class MetadataExtractor:
             return self._format_response(success=True, result=indexes)
         except Exception as e:
             logger.error(f"Failed to get table indexes: {str(e)}", exc_info=True)
-            return self._format_response(success=False, error=str(e), message="Error occurred while getting table indexes")
+            return self._format_metadata_error_response(e, "Error occurred while getting table indexes")
 
     def _serialize_datetime_objects(self, data):
         """Serialize datetime objects to JSON compatible format"""
@@ -1989,7 +2124,7 @@ class MetadataExtractor:
             return self._format_response(success=True, result=catalogs, message="Successfully retrieved catalog list")
         except Exception as e:
             logger.error(f"Failed to get catalog list: {str(e)}", exc_info=True)
-            return self._format_response(success=False, error=str(e), message="Error occurred while getting catalog list")
+            return self._format_metadata_error_response(e, "Error occurred while getting catalog list")
 
 
 # ==================== Compatibility aliases ====================

--- a/doris_mcp_server/utils/security.py
+++ b/doris_mcp_server/utils/security.py
@@ -22,7 +22,7 @@ Implements enterprise-level authentication, authorization, SQL security validati
 
 import logging
 import re
-from contextvars import ContextVar
+from contextvars import ContextVar, Token as ContextToken
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -33,11 +33,16 @@ from sqlparse.sql import Statement
 from sqlparse.tokens import Keyword, Name
 
 from .logger import get_logger
-from .config import DatabaseConfig
+from .config import (
+    DatabaseConfig,
+    get_effective_auth_config,
+)
 
 # Global ContextVar for auth_context - must be a single instance shared across all modules
 # This allows token-bound database configuration to work correctly in concurrent requests
 mcp_auth_context_var: ContextVar['AuthContext'] = ContextVar('mcp_auth_context', default=None)
+
+RESERVED_DORIS_OAUTH_TOKEN_PREFIX = "doa_"
 
 
 class SecurityLevel(Enum):
@@ -63,6 +68,32 @@ class AuthContext:
     login_time: datetime = field(default_factory=datetime.utcnow)
     last_activity: datetime | None = None
     token: str = ""  # Raw token for token-bound database configuration
+    auth_method: str = ""  # anonymous, token, jwt, external_oauth, doris_oauth
+    doris_user: str = ""
+    oauth_client_id: str = ""
+    oauth_scopes: list[str] = field(default_factory=list)
+    oauth_token_id: str = ""
+    pool_key: str = ""
+
+
+def get_current_auth_context() -> AuthContext | None:
+    """Return the current request auth context."""
+    return mcp_auth_context_var.get()
+
+
+def set_current_auth_context(auth_context: AuthContext) -> ContextToken:
+    """Set auth context and return the ContextVar token for reset."""
+    return mcp_auth_context_var.set(auth_context)
+
+
+def clear_current_auth_context() -> ContextToken:
+    """Force-clear auth context and return the ContextVar token."""
+    return mcp_auth_context_var.set(None)
+
+
+def reset_auth_context(token: ContextToken) -> None:
+    """Reset auth context using the token returned by set_current_auth_context."""
+    mcp_auth_context_var.reset(token)
 
 
 @dataclass
@@ -129,6 +160,9 @@ class DorisSecurityManager:
         except Exception as e:
             self.logger.error(f"Failed to initialize DorisSecurityManager: {e}")
             raise
+
+    def _get_effective_auth_config(self):
+        return get_effective_auth_config(self.config)
 
     async def shutdown(self):
         """Shutdown security manager components"""
@@ -226,16 +260,20 @@ class DorisSecurityManager:
     async def authenticate_request(self, auth_info: dict[str, Any]) -> AuthContext:
         """Validate request authentication information
         
-        Tries authentication methods in order: Token -> JWT -> OAuth
+        Tries authentication methods in normalized effective config order.
         Any one method succeeding allows access
         If all methods are disabled, returns anonymous context
         """
-        # Check if any authentication method is enabled
-        if not (self.config.security.enable_token_auth or 
-                self.config.security.enable_jwt_auth or 
-                self.config.security.enable_oauth_auth):
+        effective_auth = self._get_effective_auth_config()
+        bearer_token = str(auth_info.get("token") or "")
+        authorization = str(auth_info.get("authorization") or "")
+        if not bearer_token and authorization.startswith("Bearer "):
+            bearer_token = authorization[7:]
+
+        if not effective_auth.auth_methods:
+            if auth_info.get("type"):
+                return await self.auth_provider.authenticate(auth_info)
             self.logger.debug("All authentication methods are disabled")
-            # Return anonymous context when no authentication is enabled
             return AuthContext(
                 token_id="anonymous",
                 user_id="anonymous",
@@ -243,35 +281,28 @@ class DorisSecurityManager:
                 permissions=["read"],
                 security_level=SecurityLevel.PUBLIC,
                 client_ip=auth_info.get("client_ip", "unknown"),
-                session_id="anonymous_session"
+                session_id="anonymous_session",
+                auth_method="anonymous",
+                pool_key="global",
             )
         
-        # Try authentication methods in order of preference
         last_error = None
-        
-        # 1. Try Token authentication first (most common)
-        if self.config.security.enable_token_auth:
+
+        for auth_method in effective_auth.auth_methods:
             try:
-                return await self.auth_provider.authenticate_token(auth_info)
+                if auth_method == "doris_oauth":
+                    return await self.auth_provider.authenticate_doris_oauth(auth_info)
+                if auth_method == "token":
+                    return await self.auth_provider.authenticate_token(auth_info)
+                if auth_method == "jwt":
+                    return await self.auth_provider.authenticate_jwt(auth_info)
+                if auth_method == "external_oauth":
+                    return await self.auth_provider.authenticate_oauth(auth_info)
             except Exception as e:
-                self.logger.debug(f"Token authentication failed: {e}")
+                self.logger.debug(f"{auth_method} authentication failed: {e}")
                 last_error = e
-        
-        # 2. Try JWT authentication
-        if self.config.security.enable_jwt_auth:
-            try:
-                return await self.auth_provider.authenticate_jwt(auth_info)
-            except Exception as e:
-                self.logger.debug(f"JWT authentication failed: {e}")
-                last_error = e
-        
-        # 3. Try OAuth authentication
-        if self.config.security.enable_oauth_auth:
-            try:
-                return await self.auth_provider.authenticate_oauth(auth_info)
-            except Exception as e:
-                self.logger.debug(f"OAuth authentication failed: {e}")
-                last_error = e
+                if auth_method == "doris_oauth" and bearer_token.startswith(RESERVED_DORIS_OAUTH_TOKEN_PREFIX):
+                    raise
         
         # All enabled authentication methods failed
         error_message = f"Authentication failed: {str(last_error)}" if last_error else "No authentication method succeeded"
@@ -453,26 +484,32 @@ class AuthenticationProvider:
         self.session_cache = {}
         self.jwt_manager = None
         self.oauth_provider = None
+        self.doris_oauth_provider = None
         self.token_manager = None
         self.security_manager = security_manager
+        self.effective_auth = get_effective_auth_config(config)
         
         # Initialize authentication providers based on individual switches
         auth_methods_enabled = []
         
         # Initialize Token manager if enabled
-        if config.security.enable_token_auth:
+        if self.effective_auth.enable_token_auth:
             self._initialize_token_manager()
             auth_methods_enabled.append("Token")
             
         # Initialize JWT manager if enabled
-        if config.security.enable_jwt_auth:
+        if self.effective_auth.enable_jwt_auth:
             self._initialize_jwt_manager()
             auth_methods_enabled.append("JWT")
             
         # Initialize OAuth provider if enabled
-        if config.security.enable_oauth_auth or (hasattr(config.security, 'oauth_enabled') and config.security.oauth_enabled):
+        if self.effective_auth.enable_external_oauth_auth:
             self._initialize_oauth_provider()
             auth_methods_enabled.append("OAuth")
+
+        if self.effective_auth.enable_doris_oauth_auth:
+            self._initialize_doris_oauth_provider()
+            auth_methods_enabled.append("Doris OAuth")
             
         if auth_methods_enabled:
             self.logger.info(f"Authentication enabled with methods: {', '.join(auth_methods_enabled)}")
@@ -518,6 +555,24 @@ class AuthenticationProvider:
             self.logger.error(f"Failed to initialize OAuth provider: {e}")
             raise
 
+    def _initialize_doris_oauth_provider(self):
+        """Initialize Doris-backed OAuth provider shell."""
+        try:
+            from ..auth.doris_oauth_provider import DorisOAuthProvider
+            self.doris_oauth_provider = DorisOAuthProvider(self.config)
+            self.logger.info("Doris OAuth provider initialized")
+        except ImportError as e:
+            self.logger.error(f"Failed to import Doris OAuth provider: {e}")
+            raise
+        except Exception as e:
+            self.logger.error(f"Failed to initialize Doris OAuth provider: {e}")
+            raise
+
+    def configure_doris_oauth(self, connection_manager) -> None:
+        """Inject the Phase 2 connection manager after it is created."""
+        if self.doris_oauth_provider:
+            self.doris_oauth_provider.configure_connection_manager(connection_manager)
+
     async def initialize(self):
         """Initialize authentication provider asynchronously"""
         if self.jwt_manager:
@@ -550,23 +605,64 @@ class AuthenticationProvider:
             await self.oauth_provider.shutdown()
             self.logger.info("OAuth authentication provider shutdown completed")
 
+        if self.doris_oauth_provider:
+            await self.doris_oauth_provider.shutdown()
+            self.logger.info("Doris OAuth authentication provider shutdown completed")
+
+    async def authenticate(self, auth_info: dict[str, Any]) -> AuthContext:
+        """Legacy direct authentication entrypoint.
+
+        Runtime HTTP auth goes through DorisSecurityManager.authenticate_request()
+        and EffectiveAuthConfig. This method is kept for existing direct callers
+        that pass an explicit auth_info["type"].
+        """
+        auth_type = str(auth_info.get("type") or "").strip().lower()
+        if auth_type == "token":
+            if self.effective_auth.enable_token_auth and self.token_manager:
+                return await self.authenticate_token(auth_info)
+            return await self._authenticate_legacy_token(auth_info)
+        if auth_type == "basic":
+            return await self._authenticate_basic(auth_info)
+        if auth_type == "jwt":
+            return await self.authenticate_jwt(auth_info)
+        if auth_type == "oauth":
+            return await self.authenticate_oauth(auth_info)
+        if auth_type == "doris_oauth":
+            return await self.authenticate_doris_oauth(auth_info)
+        raise ValueError(f"Unsupported authentication type: {auth_type or '<missing>'}")
+
     async def authenticate_token(self, auth_info: dict[str, Any]) -> AuthContext:
         """Perform token authentication"""
-        if not self.config.security.enable_token_auth:
+        if not self.effective_auth.enable_token_auth:
             raise ValueError("Token authentication is not enabled")
         return await self._authenticate_token(auth_info)
     
     async def authenticate_jwt(self, auth_info: dict[str, Any]) -> AuthContext:
         """Perform JWT authentication"""
-        if not self.config.security.enable_jwt_auth:
+        if not self.effective_auth.enable_jwt_auth:
             raise ValueError("JWT authentication is not enabled")
         return await self._authenticate_jwt(auth_info)
     
     async def authenticate_oauth(self, auth_info: dict[str, Any]) -> AuthContext:
         """Perform OAuth authentication"""
-        if not self.config.security.enable_oauth_auth:
+        if not self.effective_auth.enable_external_oauth_auth:
             raise ValueError("OAuth authentication is not enabled")
         return await self._authenticate_oauth(auth_info)
+
+    async def authenticate_doris_oauth(self, auth_info: dict[str, Any]) -> AuthContext:
+        """Authenticate a Doris OAuth doa_ access token."""
+        if not self.effective_auth.enable_doris_oauth_auth:
+            raise ValueError("Doris OAuth authentication is not enabled")
+        token = auth_info.get("token")
+        if not token:
+            authorization = auth_info.get("authorization")
+            if authorization and authorization.startswith("Bearer "):
+                token = authorization[7:]
+        if not token or not token.startswith("doa_"):
+            raise ValueError("Missing Doris OAuth access token")
+        if not self.doris_oauth_provider:
+            raise ValueError("Doris OAuth provider is not initialized")
+        return await self.doris_oauth_provider.authenticate_access_token(auth_info)
 
     async def _authenticate_jwt(self, auth_info: dict[str, Any]) -> AuthContext:
         """JWT authentication"""
@@ -601,10 +697,18 @@ class AuthenticationProvider:
         # Handle different OAuth authentication scenarios
         if "access_token" in auth_info:
             # Direct OAuth access token authentication
-            return await self.oauth_provider.authenticate_with_token(auth_info["access_token"])
+            auth_context = await self.oauth_provider.authenticate_with_token(auth_info["access_token"])
+            auth_context.auth_method = "external_oauth"
+            auth_context.token = ""
+            auth_context.pool_key = "global"
+            return auth_context
         elif "code" in auth_info and "state" in auth_info:
             # OAuth callback authentication
-            return await self.oauth_provider.handle_callback(auth_info["code"], auth_info["state"])
+            auth_context = await self.oauth_provider.handle_callback(auth_info["code"], auth_info["state"])
+            auth_context.auth_method = "external_oauth"
+            auth_context.token = ""
+            auth_context.pool_key = "global"
+            return auth_context
         else:
             raise ValueError("OAuth authentication requires either access_token or code+state")
 
@@ -648,12 +752,42 @@ class AuthenticationProvider:
                 session_id=auth_info.get("session_id", f"session_{token_info.token_id}"),
                 login_time=datetime.utcnow(),
                 last_activity=token_info.last_used,
-                token=token  # Store raw token for token-bound database configuration
+                token=token,  # Store raw token for token-bound database configuration
+                auth_method="token",
+                pool_key=f"static_token:{token_info.token_id}",
             )
             
         except Exception as e:
             self.logger.error(f"Token authentication failed: {e}")
             raise ValueError(f"Token authentication failed: {str(e)}")
+
+    async def _authenticate_legacy_token(self, auth_info: dict[str, Any]) -> AuthContext:
+        """Token authentication for legacy direct callers without TokenManager."""
+        token = auth_info.get("token")
+        if not token:
+            authorization = auth_info.get("authorization")
+            if authorization and authorization.startswith("Bearer "):
+                token = authorization[7:]
+            elif authorization and authorization.startswith("Token "):
+                token = authorization[6:]
+
+        if not token:
+            raise ValueError("Missing authentication token")
+
+        user_info = await self._validate_token(token)
+        return AuthContext(
+            token_id=token,
+            user_id=user_info["user_id"],
+            roles=user_info["roles"],
+            permissions=user_info["permissions"],
+            security_level=user_info["security_level"],
+            client_ip=auth_info.get("client_ip", "unknown"),
+            session_id=auth_info.get("session_id", f"session_{user_info['user_id']}"),
+            login_time=datetime.utcnow(),
+            auth_method="token",
+            token=token,
+            pool_key=f"static_token:{token}",
+        )
 
     async def _authenticate_basic(self, auth_info: dict[str, Any]) -> AuthContext:
         """Basic authentication (username password)"""
@@ -673,6 +807,8 @@ class AuthenticationProvider:
             session_id=auth_info.get("session_id", "default"),
             login_time=datetime.utcnow(),
             security_level=SecurityLevel(user_info.get("security_level", "internal")),
+            auth_method="basic",
+            pool_key="global",
         )
 
     async def _validate_token(self, token: str) -> dict[str, Any]:
@@ -977,6 +1113,10 @@ class SQLSecurityValidator:
             # UNION-based injection (but allow legitimate UNION queries)
             # Only flag if UNION is followed by suspicious patterns like SELECT with WHERE 1=1
             r"UNION\s+(ALL\s+)?SELECT\s+.*\s+(WHERE|AND|OR)\s+\d+\s*=\s*\d+",
+            r"UNION\s+(ALL\s+)?SELECT\s+.*\b(PASSWORD|SECRET|TOKEN|CREDENTIAL|ADMIN)\b",
+
+            # Boolean tautology injection. BETWEEN clauses are cleaned below before this is applied.
+            r"\b(OR|AND)\s+\d+\s*=\s*\d+\b",
 
             # Boolean-based blind injection with comments (true injection pattern)
             r"(WHERE|AND|OR)\s+\d+\s*=\s*\d+\s*(--|#|/\*)",
@@ -1068,9 +1208,16 @@ class SQLSecurityValidator:
                 elif token.ttype in (Comment.Single, Comment.Multi):
                     # Comments are generally OK, but check for suspicious injection patterns
                     comment_value = str(token).lower()
-                    # Check if comment contains dangerous SQL keywords
-                    dangerous_in_comments = ['drop', 'delete', 'insert', 'update', 'union', 'exec', 'execute']
-                    if any(keyword in comment_value for keyword in dangerous_in_comments):
+                    comment_body = re.sub(r"^(--|#|/\*)\s*", "", comment_value).strip()
+                    truncation_pattern = (
+                        r"^(and|or|union|select|drop|delete|insert|update|exec|execute)\b"
+                    )
+                    sensitive_pattern = (
+                        r"\b(admin|credential|password|secret|token)\b"
+                    )
+                    if re.search(truncation_pattern, comment_body) or re.search(
+                        sensitive_pattern, comment_body
+                    ):
                         self.logger.warning(f"Suspicious SQL keyword in comment: {token}")
                         return True
                     # Normal comments are OK

--- a/doris_mcp_server/utils/sql_security_utils.py
+++ b/doris_mcp_server/utils/sql_security_utils.py
@@ -22,16 +22,16 @@ to prevent SQL injection attacks.
 """
 
 import re
-from contextvars import ContextVar
 from typing import Optional, Tuple, List, Any
 
 from .logger import get_logger
+from .security import (
+    get_current_auth_context,
+    mcp_auth_context_var as auth_context_var,
+    set_current_auth_context,
+)
 
 logger = get_logger(__name__)
-
-# Context variable for auth_context (set by HTTP middleware)
-auth_context_var: ContextVar = ContextVar('mcp_auth_context', default=None)
-
 
 class SQLSecurityError(Exception):
     """Exception raised for SQL security validation failures"""
@@ -269,7 +269,7 @@ class SQLSecurityUtils:
             The auth_context object, or None if not available
         """
         try:
-            auth_context = auth_context_var.get()
+            auth_context = get_current_auth_context()
             if auth_context:
                 logger.debug(f"Retrieved auth_context from context variable")
             return auth_context
@@ -287,7 +287,7 @@ class SQLSecurityUtils:
         Args:
             auth_context: The auth_context object to set
         """
-        auth_context_var.set(auth_context)
+        set_current_auth_context(auth_context)
         logger.debug("Set auth_context in context variable")
 
 
@@ -298,4 +298,3 @@ build_table_reference = SQLSecurityUtils.build_table_reference
 build_column_reference = SQLSecurityUtils.build_column_reference
 get_auth_context = SQLSecurityUtils.get_auth_context
 set_auth_context = SQLSecurityUtils.set_auth_context
-

--- a/test/auth/test_doris_oauth_routes.py
+++ b/test/auth/test_doris_oauth_routes.py
@@ -1,0 +1,846 @@
+import asyncio
+import base64
+import hashlib
+import re
+import time
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+from starlette.applications import Starlette
+
+from doris_mcp_server.auth.doris_oauth_handlers import DorisOAuthHandlers
+from doris_mcp_server.auth.doris_oauth_provider import DorisOAuthProvider
+from doris_mcp_server.auth.doris_oauth_types import ProtectedResourceAuthError, TokenEndpointError
+from doris_mcp_server.utils.config import DorisConfig, _mark_source, normalize_effective_auth_config
+
+
+FULL_DORIS_OAUTH_SCOPE_SET = tuple(
+    sorted(
+        {
+            "tool:list",
+            "resource:list",
+            "resource:read",
+            "tool:call:get_db_list",
+            "tool:call:get_db_table_list",
+            "tool:call:get_table_schema",
+            "tool:call:get_table_comment",
+            "tool:call:get_table_column_comments",
+            "tool:call:get_table_indexes",
+            "tool:call:get_catalog_list",
+            "tool:call:exec_query",
+            "tool:call:get_sql_explain",
+        }
+    )
+)
+
+
+class FakeConnectionManager:
+    def __init__(self):
+        self.pools = {}
+        self.create_calls = []
+        self.cleanup_calls = []
+        self.global_acquire_calls = 0
+
+    async def create_or_replace_doris_user_pool(self, username, password):
+        self.create_calls.append((username, password))
+        if password == "bad":
+            raise RuntimeError("invalid credentials")
+        self.pools[username] = True
+
+    def has_doris_user_pool(self, username):
+        return self.pools.get(username, False)
+
+    async def cleanup_idle_doris_user_pools(self, active_users):
+        self.cleanup_calls.append(set(active_users))
+
+
+def _pkce(verifier="verifier-123"):
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("="), verifier
+
+
+def _config(
+    *,
+    db_tools_enabled=False,
+    allowlist=None,
+    query_tools_enabled=False,
+    explain_tools_enabled=False,
+):
+    config = DorisConfig()
+    config.transport = "http"
+    _mark_source(config, "transport", "test")
+    config.security.enable_doris_oauth_auth = True
+    _mark_source(config, "enable_doris_oauth_auth", "test")
+    config.security.doris_oauth_base_url = "http://localhost:3000"
+    config.security.doris_oauth_db_tools_enabled = db_tools_enabled
+    if allowlist is not None:
+        config.security.doris_oauth_db_tool_allowlist = list(allowlist)
+    config.security.doris_oauth_query_tools_enabled = query_tools_enabled
+    config.security.doris_oauth_explain_tools_enabled = explain_tools_enabled
+    config.security.doris_oauth_access_token_expire_seconds = 900
+    config.security.doris_oauth_refresh_token_expire_seconds = 86400
+    normalize_effective_auth_config(config, requested_workers=1)
+    return config
+
+
+def _provider_app(config=None):
+    cm = FakeConnectionManager()
+    provider = DorisOAuthProvider(config or _config())
+    provider.configure_connection_manager(cm)
+    return provider, cm, Starlette(routes=DorisOAuthHandlers(provider).routes())
+
+
+async def _client(app):
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://localhost:3000", follow_redirects=False)
+
+
+@pytest.mark.asyncio
+async def test_register_omitted_and_blank_scope_allow_safe_client_scope_set():
+    _provider, _cm, app = _provider_app()
+    async with await _client(app) as client:
+        response = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7777/callback"]},
+        )
+        assert response.status_code == 201
+        assert response.json()["scope"] == "resource:list resource:read tool:list"
+
+        response = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7778/callback"], "scope": ""},
+        )
+        assert response.status_code == 201
+        assert response.json()["scope"] == "resource:list resource:read tool:list"
+
+
+@pytest.mark.asyncio
+async def test_register_omitted_scope_client_allowlist_includes_safe_metadata_when_db_gate_true():
+    config = _config(db_tools_enabled=True, allowlist=["get_db_list"])
+    _provider, _cm, app = _provider_app(config)
+    async with await _client(app) as client:
+        response = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7777/callback"]},
+        )
+
+    assert response.status_code == 201
+    assert response.json()["scope"] == "resource:list resource:read tool:call:get_db_list tool:list"
+
+
+@pytest.mark.asyncio
+async def test_register_explicit_unknown_or_forbidden_scope_is_invalid_scope():
+    _provider, _cm, app = _provider_app()
+    async with await _client(app) as client:
+        response = await client.post(
+            "/oauth/register",
+            json={
+                "redirect_uris": ["http://localhost:7777/callback"],
+                "scope": "tool:list scope:admin unknown",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_scope"
+
+
+@pytest.mark.asyncio
+async def test_register_metadata_scope_requires_db_gate():
+    _provider, _cm, app = _provider_app()
+    async with await _client(app) as client:
+        response = await client.post(
+            "/oauth/register",
+            json={
+                "redirect_uris": ["http://localhost:7777/callback"],
+                "scope": "tool:list tool:call:get_db_list",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_scope"
+
+
+@pytest.mark.asyncio
+async def test_register_metadata_scope_allowed_when_db_gate_true_and_explicit():
+    config = _config(db_tools_enabled=True, allowlist=["get_db_list"])
+    _provider, _cm, app = _provider_app(config)
+    async with await _client(app) as client:
+        response = await client.post(
+            "/oauth/register",
+            json={
+                "redirect_uris": ["http://localhost:7777/callback"],
+                "scope": "tool:list tool:call:get_db_list",
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.json()["scope"] == "tool:call:get_db_list tool:list"
+
+
+@pytest.mark.asyncio
+async def test_register_resource_scopes_allowed_explicitly_without_metadata_gate():
+    _provider, _cm, app = _provider_app()
+    async with await _client(app) as client:
+        metadata = await client.get("/.well-known/oauth-protected-resource")
+        response = await client.post(
+            "/oauth/register",
+            json={
+                "redirect_uris": ["http://localhost:7777/callback"],
+                "scope": "tool:list resource:list resource:read",
+            },
+        )
+
+    assert "resource:list" in metadata.json()["scopes_supported"]
+    assert "resource:read" in metadata.json()["scopes_supported"]
+    assert response.status_code == 201
+    assert response.json()["scope"] == "resource:list resource:read tool:list"
+
+
+@pytest.mark.asyncio
+async def test_authorize_can_request_resource_scopes_after_dcr_omits_scope():
+    provider, _cm, app = _provider_app()
+    async with await _client(app) as client:
+        register = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7777/callback"]},
+        )
+        client_id = register.json()["client_id"]
+        challenge, _verifier = _pkce()
+        authorize = await client.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": "http://localhost:7777/callback",
+                "state": "state-resource",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "scope": "tool:list resource:list resource:read",
+            },
+        )
+
+    assert authorize.status_code == 302
+    assert authorize.headers["location"].startswith("/doris-login?")
+    txn_id = parse_qs(urlparse(authorize.headers["location"]).query)["txn_id"][0]
+    transaction = provider.get_login_transaction(txn_id)
+    assert transaction.candidate_granted_scopes == (
+        "resource:list",
+        "resource:read",
+        "tool:list",
+    )
+
+
+@pytest.mark.parametrize("scope", ["tool:call:exec_query", "tool:call:get_sql_explain"])
+@pytest.mark.asyncio
+async def test_register_query_and_explain_scopes_require_their_own_gates(scope):
+    config = _config(db_tools_enabled=True, allowlist=["get_db_list"])
+    _provider, _cm, app = _provider_app(config)
+    async with await _client(app) as client:
+        response = await client.post(
+            "/oauth/register",
+            json={
+                "redirect_uris": ["http://localhost:7777/callback"],
+                "scope": f"tool:list {scope}",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_scope"
+
+
+@pytest.mark.asyncio
+async def test_register_omitted_scope_client_allowlist_includes_query_and_explain_when_enabled():
+    config = _config(
+        db_tools_enabled=True,
+        allowlist=["get_db_list"],
+        query_tools_enabled=True,
+        explain_tools_enabled=True,
+    )
+    _provider, _cm, app = _provider_app(config)
+    async with await _client(app) as client:
+        response = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7777/callback"]},
+        )
+
+    assert response.status_code == 201
+    assert response.json()["scope"] == (
+        "resource:list resource:read tool:call:exec_query "
+        "tool:call:get_db_list tool:call:get_sql_explain tool:list"
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_short_tool_scope_aliases_are_canonicalized_when_enabled():
+    config = _config(
+        db_tools_enabled=True,
+        allowlist=["get_db_list"],
+        query_tools_enabled=True,
+        explain_tools_enabled=True,
+    )
+    _provider, _cm, app = _provider_app(config)
+    async with await _client(app) as client:
+        response = await client.post(
+            "/oauth/register",
+            json={
+                "redirect_uris": ["http://localhost:7777/callback"],
+                "scope": "tool:list get_db_list exec_query get_sql_explain",
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.json()["scope"] == (
+        "tool:call:exec_query tool:call:get_db_list "
+        "tool:call:get_sql_explain tool:list"
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorize_omitted_scope_grants_configured_server_allowlist():
+    provider, _cm, app = _provider_app(
+        _config(
+            db_tools_enabled=True,
+            allowlist=["get_db_list"],
+            query_tools_enabled=True,
+            explain_tools_enabled=True,
+        )
+    )
+    async with await _client(app) as client:
+        register = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7777/callback"]},
+        )
+        client_id = register.json()["client_id"]
+        challenge, _verifier = _pkce()
+        authorize = await client.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": "http://localhost:7777/callback",
+                "state": "state-default",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+        )
+
+    assert authorize.status_code == 302
+    txn_id = parse_qs(urlparse(authorize.headers["location"]).query)["txn_id"][0]
+    transaction = provider.get_login_transaction(txn_id)
+    assert transaction.candidate_granted_scopes == (
+        "resource:list",
+        "resource:read",
+        "tool:call:exec_query",
+        "tool:call:get_db_list",
+        "tool:call:get_sql_explain",
+        "tool:list",
+    )
+
+
+@pytest.mark.asyncio
+async def test_authorize_short_tool_scope_aliases_are_canonicalized_when_enabled():
+    provider, _cm, app = _provider_app(
+        _config(
+            db_tools_enabled=True,
+            allowlist=["get_db_list"],
+            query_tools_enabled=True,
+            explain_tools_enabled=True,
+        )
+    )
+    async with await _client(app) as client:
+        register = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7777/callback"]},
+        )
+        client_id = register.json()["client_id"]
+        challenge, _verifier = _pkce()
+        authorize = await client.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": "http://localhost:7777/callback",
+                "state": "state-alias",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "scope": "tool:list get_db_list exec_query get_sql_explain",
+            },
+        )
+
+    assert authorize.status_code == 302
+    txn_id = parse_qs(urlparse(authorize.headers["location"]).query)["txn_id"][0]
+    transaction = provider.get_login_transaction(txn_id)
+    assert transaction.requested_scopes == (
+        "tool:list",
+        "tool:call:get_db_list",
+        "tool:call:exec_query",
+        "tool:call:get_sql_explain",
+    )
+    assert transaction.candidate_granted_scopes == (
+        "tool:call:exec_query",
+        "tool:call:get_db_list",
+        "tool:call:get_sql_explain",
+        "tool:list",
+    )
+
+
+@pytest.mark.asyncio
+async def test_expired_dcr_clients_do_not_count_against_capacity():
+    config = _config()
+    config.security.doris_oauth_dcr_max_clients = 1
+    cm = FakeConnectionManager()
+    provider = DorisOAuthProvider(config)
+    provider.configure_connection_manager(cm)
+    provider.store.add_client(
+        client_id="expired-dcr",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uris=("http://localhost:7000/callback",),
+        client_allowed_scopes=("tool:list",),
+        source="dcr",
+        expires_at=time.time() - 1,
+    )
+    app = Starlette(routes=DorisOAuthHandlers(provider).routes())
+
+    async with await _client(app) as client:
+        response = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7777/callback"]},
+        )
+
+    assert response.status_code == 201
+    assert "expired-dcr" not in provider.store.clients_by_id
+
+
+@pytest.mark.asyncio
+async def test_authorize_invalid_redirect_is_direct_400_and_invalid_scope_redirects():
+    provider, _cm, app = _provider_app()
+    client_record = provider.store.add_client(
+        client_id="client-1",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uris=("http://localhost:7777/callback",),
+        client_allowed_scopes=("tool:list",),
+        source="dcr",
+        expires_at=None,
+    )
+    challenge, _verifier = _pkce()
+
+    async with await _client(app) as client:
+        response = await client.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": client_record.client_id,
+                "redirect_uri": "http://localhost:8888/callback",
+                "state": "state-1",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+        )
+        assert response.status_code == 400
+        assert "location" not in response.headers
+
+        response = await client.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": client_record.client_id,
+                "redirect_uri": "http://localhost:7777/callback",
+                "state": "state-2",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "scope": "unknown",
+            },
+        )
+
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert location.startswith("http://localhost:7777/callback")
+    query = parse_qs(urlparse(location).query)
+    assert query["error"] == ["invalid_scope"]
+    assert query["state"] == ["state-2"]
+
+
+@pytest.mark.asyncio
+async def test_full_login_code_exchange_auth_context_and_pool_missing_revocation():
+    provider, cm, app = _provider_app()
+    async with await _client(app) as client:
+        register = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7777/callback"]},
+        )
+        client_id = register.json()["client_id"]
+        challenge, verifier = _pkce()
+        authorize = await client.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": "http://localhost:7777/callback",
+                "state": "state-1",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+        )
+        assert authorize.status_code == 302
+
+        login_get = await client.get(authorize.headers["location"])
+        assert login_get.status_code == 200
+        assert "<title>doris</title>" in login_get.text
+        assert "<h2>doris</h2>" in login_get.text
+        assert "Doris Username" in login_get.text
+        assert "Doris Password" in login_get.text
+        assert "httponly" in login_get.headers["set-cookie"].lower()
+        assert "samesite=lax" in login_get.headers["set-cookie"].lower()
+        assert "path=/doris-login" in login_get.headers["set-cookie"].lower()
+        csrf = re.search(r'name="login_csrf" value="([^"]+)"', login_get.text).group(1)
+        txn_id = re.search(r'name="txn_id" value="([^"]+)"', login_get.text).group(1)
+
+        login_post = await client.post(
+            "/doris-login",
+            data={
+                "txn_id": txn_id,
+                "login_csrf": csrf,
+                "username": "alice",
+                "password": "correct",
+            },
+        )
+        assert cm.create_calls == [("alice", "correct")]
+        code = parse_qs(urlparse(login_post.headers["location"]).query)["code"][0]
+
+        token_response = await client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "code": code,
+                "redirect_uri": "http://localhost:7777/callback",
+                "code_verifier": verifier,
+            },
+        )
+        assert token_response.status_code == 200
+        token_json = token_response.json()
+        assert token_json["access_token"].startswith("doa_")
+        assert token_json["scope"] == "resource:list resource:read tool:list"
+
+    auth_context = await provider.authenticate_access_token({"token": token_json["access_token"]})
+    assert auth_context.auth_method == "doris_oauth"
+    assert auth_context.doris_user == "alice"
+    assert auth_context.oauth_client_id == client_id
+    assert auth_context.oauth_scopes == ["resource:list", "resource:read", "tool:list"]
+    assert auth_context.pool_key == "doris_user:alice"
+    assert auth_context.token == ""
+
+    cm.pools["alice"] = False
+    with pytest.raises(ProtectedResourceAuthError) as exc:
+        await provider.authenticate_access_token({"token": token_json["access_token"]})
+    assert exc.value.error == "login_required"
+    assert exc.value.error_code == "DORIS_OAUTH_POOL_MISSING"
+    assert cm.global_acquire_calls == 0
+
+    cm.pools["alice"] = True
+    with pytest.raises(ProtectedResourceAuthError):
+        await provider.authenticate_access_token({"token": token_json["access_token"]})
+
+
+@pytest.mark.asyncio
+async def test_full_login_without_scope_grants_configured_rbac_capability_envelope():
+    provider, cm, app = _provider_app(
+        _config(
+            db_tools_enabled=True,
+            query_tools_enabled=True,
+            explain_tools_enabled=True,
+        )
+    )
+    async with await _client(app) as client:
+        register = await client.post(
+            "/oauth/register",
+            json={"redirect_uris": ["http://localhost:7777/callback"]},
+        )
+        client_id = register.json()["client_id"]
+        challenge, verifier = _pkce()
+        authorize = await client.get(
+            "/oauth/authorize",
+            params={
+                "response_type": "code",
+                "client_id": client_id,
+                "redirect_uri": "http://localhost:7777/callback",
+                "state": "state-full-default",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+        )
+        assert authorize.status_code == 302
+
+        login_get = await client.get(authorize.headers["location"])
+        csrf = re.search(r'name="login_csrf" value="([^"]+)"', login_get.text).group(1)
+        txn_id = re.search(r'name="txn_id" value="([^"]+)"', login_get.text).group(1)
+
+        login_post = await client.post(
+            "/doris-login",
+            data={
+                "txn_id": txn_id,
+                "login_csrf": csrf,
+                "username": "alice",
+                "password": "correct",
+            },
+        )
+        code = parse_qs(urlparse(login_post.headers["location"]).query)["code"][0]
+
+        token_response = await client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "code": code,
+                "redirect_uri": "http://localhost:7777/callback",
+                "code_verifier": verifier,
+            },
+        )
+
+    assert cm.create_calls == [("alice", "correct")]
+    assert token_response.status_code == 200
+    token_json = token_response.json()
+    assert tuple(token_json["scope"].split()) == FULL_DORIS_OAUTH_SCOPE_SET
+    assert "*" not in token_json["scope"].split()
+    assert "scope:admin" not in token_json["scope"].split()
+    assert "scope:profile:read" not in token_json["scope"].split()
+    assert "scope:monitoring:read" not in token_json["scope"].split()
+    assert "scope:adbc:execute" not in token_json["scope"].split()
+
+    auth_context = await provider.authenticate_access_token({"token": token_json["access_token"]})
+    assert auth_context.auth_method == "doris_oauth"
+    assert auth_context.doris_user == "alice"
+    assert tuple(auth_context.oauth_scopes) == FULL_DORIS_OAUTH_SCOPE_SET
+    assert auth_context.doris_oauth_db_tools_enabled is True
+    assert auth_context.doris_oauth_query_tools_enabled is True
+    assert auth_context.doris_oauth_explain_tools_enabled is True
+    assert auth_context.pool_key == "doris_user:alice"
+    assert auth_context.token == ""
+
+
+@pytest.mark.asyncio
+async def test_token_endpoint_invalid_code_invalid_client_refresh_pool_missing_and_revoke_unknown():
+    provider, cm, app = _provider_app()
+    public_client = provider.store.add_client(
+        client_id="public",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uris=("http://localhost:7777/callback",),
+        client_allowed_scopes=("tool:list",),
+        source="dcr",
+        expires_at=None,
+    )
+    provider.store.add_client(
+        client_id="secret-client",
+        client_secret="dos_secret",
+        token_endpoint_auth_method="client_secret_post",
+        redirect_uris=("http://localhost:7778/callback",),
+        client_allowed_scopes=("tool:list",),
+        source="dcr",
+        expires_at=None,
+    )
+    pair = provider.store.issue_token_pair(
+        client_id=public_client.client_id,
+        doris_user="alice",
+        scopes=("tool:list",),
+        resource=provider.resource,
+        access_ttl_seconds=900,
+        refresh_ttl_seconds=86400,
+    )
+    cm.pools["alice"] = False
+
+    async with await _client(app) as client:
+        invalid_code = await client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "public",
+                "code": "doc_missing",
+                "redirect_uri": "http://localhost:7777/callback",
+                "code_verifier": "verifier",
+            },
+        )
+        invalid_client = await client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "authorization_code",
+                "client_id": "secret-client",
+                "client_secret": "wrong",
+                "code": "doc_missing",
+                "redirect_uri": "http://localhost:7778/callback",
+                "code_verifier": "verifier",
+            },
+        )
+        refresh_missing_pool = await client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": "public",
+                "refresh_token": pair.refresh_token,
+            },
+        )
+        revoke_unknown = await client.post("/oauth/revoke", data={"token": "dor_unknown"})
+        revoke_unknown_bad_client = await client.post(
+            "/oauth/revoke",
+            data={"token": "dor_unknown", "client_id": "secret-client", "client_secret": "wrong"},
+        )
+        api_refresh_unknown = await client.post(
+            "/api/auth/refresh",
+            json={"refresh_token": "dor_unknown"},
+        )
+
+    assert invalid_code.status_code == 400
+    assert invalid_code.json()["error"] == "invalid_grant"
+    assert invalid_client.status_code == 401
+    assert invalid_client.json()["error"] == "invalid_client"
+    assert refresh_missing_pool.status_code == 401
+    assert refresh_missing_pool.json()["error"] == "login_required"
+    assert provider.store.get_refresh_token(pair.refresh_token).revoked_at is not None
+    assert revoke_unknown.status_code == 200
+    assert revoke_unknown_bad_client.status_code == 401
+    assert revoke_unknown_bad_client.json()["error"] == "invalid_client"
+    assert api_refresh_unknown.status_code == 400
+    assert api_refresh_unknown.json()["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_replay_under_lock_only_issues_one_new_pair():
+    provider, cm, _app = _provider_app()
+    provider.store.add_client(
+        client_id="public",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uris=("http://localhost:7777/callback",),
+        client_allowed_scopes=("tool:list",),
+        source="dcr",
+        expires_at=None,
+    )
+    pair = provider.store.issue_token_pair(
+        client_id="public",
+        doris_user="alice",
+        scopes=("tool:list",),
+        resource=provider.resource,
+        access_ttl_seconds=900,
+        refresh_ttl_seconds=86400,
+    )
+    cm.pools["alice"] = True
+    payload = {
+        "grant_type": "refresh_token",
+        "client_id": "public",
+        "refresh_token": pair.refresh_token,
+    }
+
+    await provider._lock.acquire()
+    try:
+        first = asyncio.create_task(provider.refresh_token(dict(payload)))
+        second = asyncio.create_task(provider.refresh_token(dict(payload)))
+        await asyncio.sleep(0)
+    finally:
+        provider._lock.release()
+
+    results = await asyncio.gather(first, second, return_exceptions=True)
+    successes = [result for result in results if isinstance(result, dict)]
+    errors = [result for result in results if isinstance(result, TokenEndpointError)]
+
+    assert len(successes) == 1
+    assert len(errors) == 1
+    assert errors[0].error == "invalid_grant"
+    active_refresh_tokens = [
+        record for record in provider.store.refresh_by_hash.values() if record.revoked_at is None
+    ]
+    assert len(active_refresh_tokens) == 1
+    assert active_refresh_tokens[0].token_id != pair.refresh_record.token_id
+
+
+@pytest.mark.asyncio
+async def test_api_auth_token_defaults_to_configured_server_allowlist_not_wildcard():
+    _provider, cm, app = _provider_app()
+    async with await _client(app) as client:
+        response = await client.post(
+            "/api/auth/token",
+            json={"username": "cli_user", "password": "correct"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["scope"] == "resource:list resource:read tool:list"
+    assert "*" not in response.json()["scope"]
+    assert cm.create_calls == [("cli_user", "correct")]
+
+
+@pytest.mark.asyncio
+async def test_revoke_client_bucket_rate_limit_is_enforced():
+    config = _config()
+    config.security.doris_oauth_revoke_rate_limit_per_client = 1
+    provider = DorisOAuthProvider(config)
+    provider.store.add_client(
+        client_id="public",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uris=("http://localhost:7777/callback",),
+        client_allowed_scopes=("tool:list",),
+        source="dcr",
+        expires_at=None,
+    )
+    app = Starlette(routes=DorisOAuthHandlers(provider).routes())
+
+    async with await _client(app) as client:
+        first = await client.post("/oauth/revoke", data={"token": "dor_unknown", "client_id": "public"})
+        second = await client.post("/oauth/revoke", data={"token": "dor_other", "client_id": "public"})
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+
+
+def test_trusted_proxy_headers_are_used_only_from_trusted_cidrs():
+    config = _config()
+    config.security.doris_oauth_trust_proxy_headers = True
+    config.security.doris_oauth_trusted_proxy_cidrs = ["10.0.0.0/8"]
+    handler = DorisOAuthHandlers(DorisOAuthProvider(config))
+
+    trusted_scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/oauth/register",
+        "headers": [(b"x-forwarded-for", b"203.0.113.7, 10.1.2.3")],
+        "client": ("10.1.2.3", 1234),
+    }
+    untrusted_scope = dict(trusted_scope)
+    untrusted_scope["client"] = ("192.0.2.10", 1234)
+
+    from starlette.requests import Request
+
+    assert handler._client_ip(Request(trusted_scope)) == "203.0.113.7"
+    assert handler._client_ip(Request(untrusted_scope)) == "192.0.2.10"
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_http_startup_fails_when_global_pool_missing(monkeypatch):
+    from doris_mcp_server.main import DorisServer
+
+    server = DorisServer(_config())
+
+    async def skip_security_initialize():
+        return None
+
+    async def missing_global_pool():
+        return False
+
+    monkeypatch.setattr(server.security_manager, "initialize", skip_security_initialize)
+    monkeypatch.setattr(server.connection_manager, "initialize_for_http_mode", missing_global_pool)
+
+    with pytest.raises(RuntimeError, match="service/global Doris account"):
+        await server.start_http(host="127.0.0.1", port=0, workers=1)
+
+
+@pytest.mark.asyncio
+async def test_multiworker_exported_app_explicitly_handles_doris_oauth_paths():
+    from doris_mcp_server import multiworker_app
+
+    transport = httpx.ASGITransport(app=multiworker_app.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://localhost:3000") as client:
+        response = await client.get("/.well-known/oauth-protected-resource")
+
+    assert response.status_code != 404

--- a/test/auth/test_doris_oauth_store.py
+++ b/test/auth/test_doris_oauth_store.py
@@ -1,0 +1,140 @@
+from dataclasses import asdict, is_dataclass
+
+from doris_mcp_server.auth.doris_oauth_store import DorisOAuthStore
+
+
+def _assert_raw_absent(store, raw_values):
+    for raw in raw_values:
+        assert raw
+        for name, value in store.__dict__.items():
+            if name == "_hash_key":
+                continue
+            assert raw not in repr(value)
+            if isinstance(value, dict):
+                for key, item in value.items():
+                    assert raw not in repr(key)
+                    assert raw not in repr(item)
+                    if is_dataclass(item):
+                        assert raw not in repr(asdict(item))
+
+
+def test_store_keeps_tokens_codes_and_client_secret_hash_only():
+    store = DorisOAuthStore()
+    client_secret = "dos_RAW_CLIENT_SECRET_123"
+    store.add_client(
+        client_id="client-1",
+        client_secret=client_secret,
+        token_endpoint_auth_method="client_secret_post",
+        redirect_uris=("http://localhost:7777/callback",),
+        client_allowed_scopes=("tool:list",),
+        source="dcr",
+        expires_at=None,
+        registration_ip="127.0.0.1",
+    )
+    txn_id, _txn = store.create_auth_transaction(
+        client_id="client-1",
+        redirect_uri="http://localhost:7777/callback",
+        state="state-1",
+        code_challenge="challenge",
+        requested_scopes=("tool:list",),
+        candidate_granted_scopes=("tool:list",),
+        resource="http://localhost:3000/mcp",
+        client_ip="127.0.0.1",
+        ttl_seconds=300,
+    )
+    csrf = "dcsrf_RAW_CSRF_123"
+    store.set_transaction_csrf(txn_id, csrf)
+    code, _code_record = store.create_authorization_code(
+        client_id="client-1",
+        doris_user="alice",
+        redirect_uri="http://localhost:7777/callback",
+        scopes=("tool:list",),
+        resource="http://localhost:3000/mcp",
+        code_challenge="challenge",
+        code_challenge_method="S256",
+        ttl_seconds=300,
+    )
+    pair = store.issue_token_pair(
+        client_id="client-1",
+        doris_user="alice",
+        scopes=("tool:list",),
+        resource="http://localhost:3000/mcp",
+        access_ttl_seconds=900,
+        refresh_ttl_seconds=86400,
+    )
+
+    _assert_raw_absent(
+        store,
+        [
+            client_secret,
+            txn_id,
+            csrf,
+            code,
+            pair.access_token,
+            pair.refresh_token,
+        ],
+    )
+
+
+def test_authorization_code_is_single_use():
+    store = DorisOAuthStore()
+    code, _record = store.create_authorization_code(
+        client_id="client-1",
+        doris_user="alice",
+        redirect_uri="http://localhost:7777/callback",
+        scopes=("tool:list",),
+        resource="http://localhost:3000/mcp",
+        code_challenge="challenge",
+        code_challenge_method="S256",
+        ttl_seconds=300,
+    )
+
+    assert store.pop_authorization_code(code) is not None
+    assert store.pop_authorization_code(code) is None
+
+
+def test_refresh_rotation_revokes_old_pair_but_keeps_new_family_active():
+    store = DorisOAuthStore()
+    old_pair = store.issue_token_pair(
+        client_id="client-1",
+        doris_user="alice",
+        scopes=("tool:list",),
+        resource="http://localhost:3000/mcp",
+        access_ttl_seconds=900,
+        refresh_ttl_seconds=86400,
+    )
+    store.revoke_pair_for_refresh_id(old_pair.refresh_record.token_id)
+    new_pair = store.issue_token_pair(
+        client_id="client-1",
+        doris_user="alice",
+        scopes=("tool:list",),
+        resource="http://localhost:3000/mcp",
+        access_ttl_seconds=900,
+        refresh_ttl_seconds=86400,
+        family_id=old_pair.refresh_record.family_id,
+        rotated_from=old_pair.refresh_record.token_id,
+    )
+
+    assert store.get_access_token(old_pair.access_token).revoked_at is not None
+    assert store.get_refresh_token(old_pair.refresh_token).revoked_at is not None
+    assert store.get_access_token(new_pair.access_token).revoked_at is None
+    assert store.get_refresh_token(new_pair.refresh_token).revoked_at is None
+    assert store.active_users() == {"alice"}
+
+
+def test_pool_missing_family_revoke_makes_access_and_refresh_inactive():
+    store = DorisOAuthStore()
+    pair = store.issue_token_pair(
+        client_id="client-1",
+        doris_user="alice",
+        scopes=("tool:list",),
+        resource="http://localhost:3000/mcp",
+        access_ttl_seconds=900,
+        refresh_ttl_seconds=86400,
+    )
+
+    store.revoke_family_by_access_token_id(pair.access_record.token_id)
+
+    assert store.get_access_token(pair.access_token).revoked_at is not None
+    assert store.get_refresh_token(pair.refresh_token).revoked_at is not None
+    assert store.active_users() == set()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,7 +48,7 @@ def event_loop():
 @pytest.fixture
 def test_config():
     """Test configuration fixture"""
-    from doris_mcp_server.utils.config import DorisConfig, DatabaseConfig, SecurityConfig
+    from doris_mcp_server.utils.config import DorisConfig, normalize_effective_auth_config
     
     config = DorisConfig()
     
@@ -68,6 +68,7 @@ def test_config():
     config.security.auth_type = "token"
     config.security.token_secret = "test_secret"
     config.security.token_expiry = 3600
+    normalize_effective_auth_config(config)
     
     return config
 

--- a/test/security/test_auth_context.py
+++ b/test/security/test_auth_context.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+
+import pytest
+
+from doris_mcp_server.auth.auth_middleware import AuthMiddleware
+from doris_mcp_server.utils.security import (
+    AuthContext,
+    get_current_auth_context,
+    reset_auth_context,
+    set_current_auth_context,
+)
+from doris_mcp_server.utils import sql_security_utils
+
+
+def test_sql_security_utils_uses_shared_contextvar():
+    auth_context = AuthContext(user_id="u1", auth_method="token")
+
+    token = set_current_auth_context(auth_context)
+    try:
+        assert sql_security_utils.auth_context_var is not None
+        assert sql_security_utils.get_auth_context() is auth_context
+        assert get_current_auth_context() is auth_context
+    finally:
+        reset_auth_context(token)
+
+    assert get_current_auth_context() is None
+
+
+@pytest.mark.asyncio
+async def test_jwt_auth_context_does_not_store_raw_token():
+    class FakeJWTManager:
+        async def validate_token(self, token, token_type):
+            assert token == "jwt.raw.token"
+            assert token_type == "access"
+            return {
+                "payload": {
+                    "jti": "jwt-id",
+                    "sub": "jwt-user",
+                    "roles": ["reader"],
+                    "permissions": ["read_data"],
+                    "security_level": "internal",
+                    "iat": int(datetime.utcnow().timestamp()),
+                }
+            }
+
+    middleware = AuthMiddleware(FakeJWTManager())
+    auth_context = await middleware.authenticate_request(
+        {"authorization": "Bearer jwt.raw.token"}
+    )
+
+    assert auth_context.auth_method == "jwt"
+    assert auth_context.token == ""
+    assert auth_context.pool_key == "global"
+    assert auth_context.token_id == "jwt-id"

--- a/test/security/test_effective_auth_config.py
+++ b/test/security/test_effective_auth_config.py
@@ -1,0 +1,235 @@
+import pytest
+from pathlib import Path
+
+from doris_mcp_server.auth.doris_oauth_scope_policy import DorisOAuthScopePolicy
+from doris_mcp_server.utils.config import (
+    AuthConfigError,
+    DorisConfig,
+    _mark_source,
+    normalize_effective_auth_config,
+)
+from doris_mcp_server.utils.security import AuthenticationProvider
+
+
+def test_default_auth_methods_remain_disabled():
+    config = DorisConfig()
+
+    effective = normalize_effective_auth_config(config)
+
+    assert effective.auth_methods == ()
+    assert effective.oauth_discovery_mode == "none"
+
+
+def test_runtime_auth_provider_requires_normalized_effective_config():
+    with pytest.raises(AuthConfigError, match="has not been normalized"):
+        AuthenticationProvider(DorisConfig())
+
+
+def test_explicit_oauth_false_conflicts_with_oauth_enabled_true():
+    config = DorisConfig()
+    config.security.oauth_enabled = True
+    _mark_source(config, "oauth_enabled", "config_file")
+    config.security.enable_oauth_auth = False
+    _mark_source(config, "enable_oauth_auth", "env")
+
+    with pytest.raises(AuthConfigError, match="explicitly conflict"):
+        normalize_effective_auth_config(config)
+
+
+def test_legacy_auth_type_only_applies_when_explicit():
+    config = DorisConfig()
+    config.security.auth_type = "token"
+    _mark_source(config, "auth_type", "env")
+
+    effective = normalize_effective_auth_config(config)
+
+    assert effective.enable_token_auth is True
+    assert effective.auth_methods == ("token",)
+
+
+def test_doris_oauth_conflicts_with_external_oauth():
+    config = DorisConfig()
+    config.transport = "http"
+    _mark_source(config, "transport", "env")
+    config.security.enable_doris_oauth_auth = True
+    _mark_source(config, "enable_doris_oauth_auth", "env")
+    config.security.enable_oauth_auth = True
+    _mark_source(config, "enable_oauth_auth", "env")
+
+    with pytest.raises(AuthConfigError, match="cannot be enabled together"):
+        normalize_effective_auth_config(config)
+
+
+def test_doris_oauth_rejects_stdio_transport():
+    config = DorisConfig()
+    config.security.enable_doris_oauth_auth = True
+    _mark_source(config, "enable_doris_oauth_auth", "env")
+
+    with pytest.raises(AuthConfigError, match="requires HTTP transport"):
+        normalize_effective_auth_config(config)
+
+
+def _doris_oauth_http_config(base_url="http://localhost:3000"):
+    config = DorisConfig()
+    config.transport = "http"
+    _mark_source(config, "transport", "env")
+    config.security.enable_doris_oauth_auth = True
+    _mark_source(config, "enable_doris_oauth_auth", "env")
+    config.security.doris_oauth_base_url = base_url
+    return config
+
+
+def test_doris_oauth_requires_base_url():
+    config = _doris_oauth_http_config("")
+
+    with pytest.raises(AuthConfigError, match="DORIS_OAUTH_BASE_URL is required"):
+        normalize_effective_auth_config(config)
+
+
+def test_doris_oauth_rejects_non_loopback_http_base_url_by_default():
+    config = _doris_oauth_http_config("http://mcp.example.test")
+
+    with pytest.raises(AuthConfigError, match="must use HTTPS"):
+        normalize_effective_auth_config(config)
+
+
+def test_doris_oauth_accepts_loopback_http_base_url():
+    config = _doris_oauth_http_config("http://localhost:3000")
+
+    effective = normalize_effective_auth_config(config)
+
+    assert effective.oauth_discovery_mode == "doris_oauth"
+    assert effective.doris_oauth_base_url == "http://localhost:3000"
+
+
+@pytest.mark.parametrize("tool_name", ["exec_query", "get_sql_explain", "get_sql_profile", "not_real"])
+def test_doris_oauth_metadata_tool_allowlist_rejects_non_metadata_tools(tool_name):
+    config = _doris_oauth_http_config("http://localhost:3000")
+    config.security.doris_oauth_db_tool_allowlist = ["get_db_list", tool_name]
+
+    with pytest.raises(AuthConfigError, match="DORIS_OAUTH_DB_TOOL_ALLOWLIST"):
+        normalize_effective_auth_config(config)
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "doris_oauth_query_tools_enabled",
+        "doris_oauth_explain_tools_enabled",
+    ],
+)
+def test_doris_oauth_query_and_explain_flags_are_supported(field_name):
+    config = _doris_oauth_http_config("http://localhost:3000")
+    setattr(config.security, field_name, True)
+
+    normalize_effective_auth_config(config)
+
+
+def _read_env_file(path):
+    values = {}
+    for raw_line in Path(path).read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value.strip().strip('"').strip("'")
+    return values
+
+
+def test_runtime_doris_oauth_smoke_env_matches_rbac_default_scope_model(monkeypatch):
+    env_values = _read_env_file("runtime/doris-oauth-test/.env")
+    for key in (
+        "TRANSPORT",
+        "SERVER_HOST",
+        "SERVER_PORT",
+        "WORKERS",
+        "DORIS_HOST",
+        "DORIS_PORT",
+        "DORIS_USER",
+        "DORIS_PASSWORD",
+        "DORIS_DATABASE",
+        "ENABLE_DORIS_OAUTH_AUTH",
+        "DORIS_OAUTH_BASE_URL",
+        "ENABLE_TOKEN_AUTH",
+        "ENABLE_JWT_AUTH",
+        "ENABLE_OAUTH_AUTH",
+        "OAUTH_ENABLED",
+        "DORIS_OAUTH_DB_TOOLS_ENABLED",
+        "DORIS_OAUTH_DB_TOOL_ALLOWLIST",
+        "DORIS_OAUTH_QUERY_TOOLS_ENABLED",
+        "DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED",
+        "ENABLE_SECURITY_CHECK",
+        "DORIS_OAUTH_DYNAMIC_CLIENT_REGISTRATION_MODE",
+    ):
+        monkeypatch.setenv(key, env_values.get(key, ""))
+    monkeypatch.delenv("AUTH_TYPE", raising=False)
+
+    config = DorisConfig.from_env()
+    effective = normalize_effective_auth_config(config, requested_workers=int(env_values["WORKERS"]))
+    policy = DorisOAuthScopePolicy(config.security)
+
+    assert effective.auth_methods == ("doris_oauth",)
+    assert effective.oauth_discovery_mode == "doris_oauth"
+    assert effective.transport == "http"
+    assert effective.effective_workers == 1
+    assert config.security.enable_security_check is False
+    assert config.security.enable_token_auth is False
+    assert config.security.enable_jwt_auth is False
+    assert config.security.enable_oauth_auth is False
+    assert config.security.oauth_enabled is False
+
+    assert {
+        "tool:list",
+        "resource:list",
+        "resource:read",
+        "tool:call:get_db_list",
+        "tool:call:get_db_table_list",
+        "tool:call:get_table_schema",
+        "tool:call:get_table_comment",
+        "tool:call:get_table_column_comments",
+        "tool:call:get_table_indexes",
+        "tool:call:get_catalog_list",
+        "tool:call:exec_query",
+        "tool:call:get_sql_explain",
+    } <= policy.server_allowed_scopes
+    assert {
+        "*",
+        "scope:admin",
+        "scope:service_account",
+        "scope:profile:read",
+        "scope:monitoring:read",
+        "scope:adbc:execute",
+    }.isdisjoint(policy.server_allowed_scopes)
+
+
+def test_doris_oauth_production_dcr_requires_explicit_flag():
+    config = _doris_oauth_http_config("https://mcp.example.test")
+    config.security.doris_oauth_dynamic_client_registration_mode = "enabled"
+
+    with pytest.raises(AuthConfigError, match="Production Doris OAuth DCR requires"):
+        normalize_effective_auth_config(config)
+
+
+def test_doris_oauth_rejects_invalid_ttl():
+    config = _doris_oauth_http_config("http://localhost:3000")
+    config.security.doris_oauth_access_token_expire_seconds = 86401
+
+    with pytest.raises(AuthConfigError, match="doris_oauth_access_token_expire_seconds"):
+        normalize_effective_auth_config(config)
+
+
+def test_doris_oauth_workers_zero_expands_before_fail_fast(monkeypatch):
+    config = DorisConfig()
+    config.transport = "http"
+    _mark_source(config, "transport", "cli")
+    config.security.enable_doris_oauth_auth = True
+    _mark_source(config, "enable_doris_oauth_auth", "env")
+    config.workers = 0
+    _mark_source(config, "workers", "cli")
+
+    import doris_mcp_server.utils.config as config_module
+
+    monkeypatch.setattr(config_module.multiprocessing, "cpu_count", lambda: 4)
+
+    with pytest.raises(AuthConfigError, match="single worker"):
+        normalize_effective_auth_config(config, requested_workers=0)

--- a/test/security/test_mcp_auth_middleware.py
+++ b/test/security/test_mcp_auth_middleware.py
@@ -1,0 +1,241 @@
+import json
+
+import pytest
+
+import doris_mcp_server.auth.mcp_auth_middleware as middleware_module
+from doris_mcp_server.auth.mcp_auth_middleware import MCPAuthASGIMiddleware
+from doris_mcp_server.auth.operation_policy import OperationAuthorizationError
+from doris_mcp_server.utils.config import EffectiveAuthConfig
+from doris_mcp_server.utils.security import AuthContext, get_current_auth_context
+
+
+def _effective(auth_methods=("token",), discovery_mode="none", base_url=""):
+    return EffectiveAuthConfig(
+        enable_token_auth="token" in auth_methods,
+        enable_jwt_auth="jwt" in auth_methods,
+        enable_external_oauth_auth="external_oauth" in auth_methods,
+        enable_doris_oauth_auth="doris_oauth" in auth_methods,
+        auth_methods=tuple(auth_methods),
+        oauth_discovery_mode=discovery_mode,
+        doris_oauth_base_url=base_url,
+        transport="http",
+        requested_workers=1,
+        effective_workers=1,
+        legacy_auth_type="",
+    )
+
+
+async def _receive():
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+def _send_collector(messages):
+    async def send(message):
+        messages.append(message)
+
+    return send
+
+
+@pytest.mark.asyncio
+async def test_mcp_auth_middleware_sets_scope_and_resets_context():
+    auth_context = AuthContext(token_id="t1", user_id="u1", auth_method="token")
+
+    class SecurityManager:
+        async def authenticate_request(self, auth_info):
+            assert auth_info["token"] == "abc"
+            return auth_context
+
+    async def downstream(scope, receive, send):
+        assert scope["auth_context"] is auth_context
+        assert get_current_auth_context() is auth_context
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    messages = []
+    middleware = MCPAuthASGIMiddleware(SecurityManager(), downstream, _effective())
+    await middleware(
+        {
+            "type": "http",
+            "path": "/mcp",
+            "headers": [(b"authorization", b"Bearer abc")],
+            "client": ("127.0.0.1", 1),
+        },
+        _receive,
+        _send_collector(messages),
+    )
+
+    assert messages[0]["status"] == 200
+    assert get_current_auth_context() is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_auth_middleware_accepts_legacy_query_string_token():
+    auth_context = AuthContext(token_id="t1", user_id="u1", auth_method="token")
+
+    class SecurityManager:
+        async def authenticate_request(self, auth_info):
+            assert auth_info["token"] == "legacy-query-token"
+            assert auth_info["authorization"] == ""
+            return auth_context
+
+    async def downstream(scope, receive, send):
+        assert scope["auth_context"] is auth_context
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    messages = []
+    middleware = MCPAuthASGIMiddleware(SecurityManager(), downstream, _effective())
+    await middleware(
+        {
+            "type": "http",
+            "path": "/mcp",
+            "query_string": b"token=legacy-query-token",
+            "headers": [],
+            "client": ("127.0.0.1", 1),
+        },
+        _receive,
+        _send_collector(messages),
+    )
+
+    assert messages[0]["status"] == 200
+    assert get_current_auth_context() is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_auth_middleware_returns_doris_oauth_challenge_on_401():
+    class SecurityManager:
+        async def authenticate_request(self, auth_info):
+            raise ValueError("missing")
+
+    async def downstream(scope, receive, send):
+        raise AssertionError("downstream must not be called")
+
+    messages = []
+    middleware = MCPAuthASGIMiddleware(
+        SecurityManager(),
+        downstream,
+        _effective(
+            auth_methods=("doris_oauth",),
+            discovery_mode="doris_oauth",
+            base_url="https://mcp.example.test",
+        ),
+    )
+    await middleware(
+        {"type": "http", "path": "/mcp", "headers": [], "client": ("127.0.0.1", 1)},
+        _receive,
+        _send_collector(messages),
+    )
+
+    assert messages[0]["status"] == 401
+    headers = dict(messages[0]["headers"])
+    assert b"www-authenticate" in headers
+    assert b"oauth-protected-resource" in headers[b"www-authenticate"]
+    assert b"https://mcp.example.test/.well-known/oauth-protected-resource" in headers[b"www-authenticate"]
+    body = json.loads(messages[1]["body"])
+    assert body["error"] == "authentication_required"
+
+
+@pytest.mark.asyncio
+async def test_mcp_auth_middleware_returns_insufficient_scope_challenge_on_operation_denial():
+    auth_context = AuthContext(
+        token_id="t1",
+        user_id="alice",
+        auth_method="doris_oauth",
+        doris_user="alice",
+        oauth_scopes=["tool:list"],
+    )
+
+    class SecurityManager:
+        async def authenticate_request(self, auth_info):
+            return auth_context
+
+    async def downstream(scope, receive, send):
+        raise OperationAuthorizationError(
+            "Missing required scope",
+            status_code=403,
+            error_code="PERMISSION_DENIED",
+            required_scope="tool:call:exec_query",
+            operation="tool:exec_query",
+        )
+
+    messages = []
+    middleware = MCPAuthASGIMiddleware(
+        SecurityManager(),
+        downstream,
+        _effective(
+            auth_methods=("doris_oauth",),
+            discovery_mode="doris_oauth",
+            base_url="https://mcp.example.test",
+        ),
+    )
+    await middleware(
+        {"type": "http", "path": "/mcp", "headers": [(b"authorization", b"Bearer doa_x")], "client": ("127.0.0.1", 1)},
+        _receive,
+        _send_collector(messages),
+    )
+
+    assert messages[0]["status"] == 403
+    headers = dict(messages[0]["headers"])
+    assert b"insufficient_scope" in headers[b"www-authenticate"]
+    assert b"tool:call:exec_query" in headers[b"www-authenticate"]
+    body = json.loads(messages[1]["body"])
+    assert body["error"] == "PERMISSION_DENIED"
+
+
+@pytest.mark.asyncio
+async def test_mcp_auth_middleware_resets_context_on_verify_failure(monkeypatch):
+    auth_context = AuthContext(token_id="t1", user_id="u1", auth_method="token")
+
+    class SecurityManager:
+        async def authenticate_request(self, auth_info):
+            return auth_context
+
+    async def downstream(scope, receive, send):
+        raise AssertionError("downstream must not be called")
+
+    monkeypatch.setattr(
+        middleware_module,
+        "get_current_auth_context",
+        lambda: AuthContext(token_id="different", auth_method="token"),
+    )
+
+    messages = []
+    middleware = MCPAuthASGIMiddleware(SecurityManager(), downstream, _effective())
+    await middleware(
+        {"type": "http", "path": "/mcp", "headers": [], "client": ("127.0.0.1", 1)},
+        _receive,
+        _send_collector(messages),
+    )
+
+    assert messages[0]["status"] == 500
+    assert get_current_auth_context() is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_auth_middleware_force_clears_context_when_reset_fails(monkeypatch):
+    auth_context = AuthContext(token_id="t1", user_id="u1", auth_method="token")
+
+    class SecurityManager:
+        async def authenticate_request(self, auth_info):
+            return auth_context
+
+    async def downstream(scope, receive, send):
+        assert get_current_auth_context() is auth_context
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    def broken_reset(token):
+        raise RuntimeError("reset failed")
+
+    monkeypatch.setattr(middleware_module, "reset_auth_context", broken_reset)
+
+    messages = []
+    middleware = MCPAuthASGIMiddleware(SecurityManager(), downstream, _effective())
+    await middleware(
+        {"type": "http", "path": "/mcp", "headers": [], "client": ("127.0.0.1", 1)},
+        _receive,
+        _send_collector(messages),
+    )
+
+    assert messages[0]["status"] == 200
+    assert get_current_auth_context() is None

--- a/test/security/test_operation_policy.py
+++ b/test/security/test_operation_policy.py
@@ -1,0 +1,307 @@
+from types import SimpleNamespace
+
+import pytest
+
+from doris_mcp_server.auth.operation_policy import (
+    HIGH_RISK_TOOLS,
+    OperationAuthorizationError,
+    P4_DORIS_OAUTH_METADATA_TOOLS,
+    authorize_operation,
+    filter_tools_for_auth_context,
+)
+from doris_mcp_server.auth.doris_oauth_scope_policy import DorisOAuthScopePolicy
+from doris_mcp_server.auth.doris_oauth_types import TokenEndpointError
+from doris_mcp_server.utils.security import AuthContext
+
+
+def doris_context(
+    scopes,
+    *,
+    db_tools_enabled=False,
+    allowlist=None,
+    query_tools_enabled=False,
+    query_allowlist=None,
+    explain_tools_enabled=False,
+    explain_allowlist=None,
+):
+    context = AuthContext(
+        user_id="doris_user",
+        auth_method="doris_oauth",
+        oauth_scopes=list(scopes),
+        pool_key="doris_user:doris_user",
+    )
+    context.doris_oauth_db_tools_enabled = db_tools_enabled
+    context.doris_oauth_db_tool_allowlist = tuple(
+        allowlist if allowlist is not None else sorted(P4_DORIS_OAUTH_METADATA_TOOLS)
+    )
+    context.doris_oauth_query_tools_enabled = query_tools_enabled
+    context.doris_oauth_query_tool_allowlist = tuple(
+        query_allowlist if query_allowlist is not None else ("exec_query",)
+    )
+    context.doris_oauth_explain_tools_enabled = explain_tools_enabled
+    context.doris_oauth_explain_tool_allowlist = tuple(
+        explain_allowlist if explain_allowlist is not None else ("get_sql_explain",)
+    )
+    return context
+
+
+def test_legacy_auth_methods_pass_through_operation_policy():
+    authorize_operation(AuthContext(auth_method="token"), "tool:get_sql_profile")
+
+
+def test_missing_auth_context_passes_for_legacy_stdio_paths():
+    authorize_operation(None, "tool:get_sql_profile")
+
+
+@pytest.mark.parametrize("tool_name", sorted(P4_DORIS_OAUTH_METADATA_TOOLS))
+def test_doris_oauth_rejects_metadata_tools_when_db_gate_false(tool_name):
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(
+            doris_context([f"tool:call:{tool_name}"]),
+            f"tool:{tool_name}",
+        )
+
+    assert exc.value.error_code == "DORIS_OAUTH_DB_TOOLS_NOT_ENABLED"
+
+
+@pytest.mark.parametrize("tool_name", sorted(P4_DORIS_OAUTH_METADATA_TOOLS))
+def test_doris_oauth_allows_metadata_tools_with_gate_allowlist_and_matching_scope(tool_name):
+    authorize_operation(
+        doris_context(
+            [f"tool:call:{tool_name}"],
+            db_tools_enabled=True,
+            allowlist=sorted(P4_DORIS_OAUTH_METADATA_TOOLS),
+        ),
+        f"tool:{tool_name}",
+    )
+
+
+def test_doris_oauth_metadata_gate_respects_configured_allowlist():
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(
+            doris_context(
+                ["tool:call:get_table_schema"],
+                db_tools_enabled=True,
+                allowlist=["get_db_list"],
+            ),
+            "tool:get_table_schema",
+        )
+
+    assert exc.value.error_code == "DORIS_OAUTH_TOOL_NOT_ALLOWED"
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "error_code"),
+    [
+        ("exec_query", "DORIS_OAUTH_QUERY_TOOL_NOT_ENABLED"),
+        ("get_sql_explain", "DORIS_OAUTH_EXPLAIN_TOOL_NOT_ENABLED"),
+    ],
+)
+def test_doris_oauth_query_and_explain_remain_denied_with_db_gate_true(tool_name, error_code):
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(
+            doris_context(
+                [f"tool:call:{tool_name}"],
+                db_tools_enabled=True,
+                allowlist=sorted(P4_DORIS_OAUTH_METADATA_TOOLS),
+            ),
+            f"tool:{tool_name}",
+        )
+
+    assert exc.value.error_code == error_code
+
+
+def test_doris_oauth_allows_query_with_query_gate_and_matching_scope():
+    authorize_operation(
+        doris_context(
+            ["tool:call:exec_query"],
+            query_tools_enabled=True,
+        ),
+        "tool:exec_query",
+    )
+
+
+def test_doris_oauth_allows_explain_with_explain_gate_and_matching_scope():
+    authorize_operation(
+        doris_context(
+            ["tool:call:get_sql_explain"],
+            explain_tools_enabled=True,
+        ),
+        "tool:get_sql_explain",
+    )
+
+
+def test_doris_oauth_query_gate_respects_configured_allowlist():
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(
+            doris_context(
+                ["tool:call:exec_query"],
+                query_tools_enabled=True,
+                query_allowlist=[],
+            ),
+            "tool:exec_query",
+        )
+
+    assert exc.value.error_code == "DORIS_OAUTH_TOOL_NOT_ALLOWED"
+
+
+def test_doris_oauth_explain_gate_respects_configured_allowlist():
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(
+            doris_context(
+                ["tool:call:get_sql_explain"],
+                explain_tools_enabled=True,
+                explain_allowlist=[],
+            ),
+            "tool:get_sql_explain",
+        )
+
+    assert exc.value.error_code == "DORIS_OAUTH_TOOL_NOT_ALLOWED"
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "error_code"),
+    [
+        ("exec_query", "DORIS_OAUTH_QUERY_TOOL_NOT_ENABLED"),
+        ("get_sql_explain", "DORIS_OAUTH_EXPLAIN_TOOL_NOT_ENABLED"),
+    ],
+)
+def test_invalid_metadata_allowlist_cannot_open_query_or_explain(tool_name, error_code):
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(
+            doris_context(
+                [f"tool:call:{tool_name}"],
+                db_tools_enabled=True,
+                allowlist=["get_db_list", tool_name],
+            ),
+            f"tool:{tool_name}",
+        )
+
+    assert exc.value.error_code == error_code
+
+
+def test_doris_oauth_rejects_missing_scope_for_allowed_operations():
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(doris_context([]), "list_tools")
+
+    assert exc.value.status_code == 403
+    assert exc.value.error_code == "PERMISSION_DENIED"
+
+
+@pytest.mark.parametrize(
+    ("operation", "scope"),
+    [
+        ("list_resources", "resource:list"),
+        ("read_resource", "resource:read"),
+    ],
+)
+def test_doris_oauth_allows_resources_with_matching_scope(operation, scope):
+    authorize_operation(doris_context([scope]), operation)
+
+
+@pytest.mark.parametrize(
+    ("operation", "scope"),
+    [
+        ("list_resources", "resource:list"),
+        ("read_resource", "resource:read"),
+    ],
+)
+def test_doris_oauth_rejects_resources_without_matching_scope(operation, scope):
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(doris_context([]), operation)
+
+    assert exc.value.error_code == "PERMISSION_DENIED"
+    assert exc.value.required_scope == scope
+
+
+def test_doris_oauth_prompts_remain_denied_even_with_scope():
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(doris_context(["prompt:list"]), "list_prompts")
+
+    assert exc.value.error_code == "UNSUPPORTED_FOR_DORIS_OAUTH"
+
+
+@pytest.mark.parametrize("tool_name", sorted(HIGH_RISK_TOOLS))
+def test_doris_oauth_rejects_high_risk_tools_even_with_forged_matching_scope(tool_name):
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(
+            doris_context([f"tool:call:{tool_name}"]),
+            f"tool:{tool_name}",
+        )
+
+    assert exc.value.error_code == "UNSUPPORTED_FOR_DORIS_OAUTH"
+
+
+def test_filter_tools_for_doris_oauth_hides_all_high_risk_tools_even_with_forged_scopes():
+    tools = [SimpleNamespace(name=tool_name) for tool_name in sorted(HIGH_RISK_TOOLS)]
+    forged_scopes = [f"tool:call:{tool_name}" for tool_name in sorted(HIGH_RISK_TOOLS)]
+
+    filtered = filter_tools_for_auth_context(
+        doris_context(forged_scopes),
+        tools,
+    )
+
+    assert filtered == []
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "scope:profile:read",
+        "scope:monitoring:read",
+        "scope:adbc:execute",
+        "scope:audit:read",
+        "scope:governance:read",
+        "scope:performance:read",
+        "scope:admin",
+        "scope:service_account",
+    ],
+)
+def test_doris_oauth_scope_policy_rejects_forbidden_channel_scopes(scope):
+    policy = DorisOAuthScopePolicy()
+
+    with pytest.raises(TokenEndpointError) as exc:
+        policy.grant_client_scopes(scope, explicit=True)
+
+    assert exc.value.error == "invalid_scope"
+
+
+def test_doris_oauth_forged_wildcard_scope_does_not_satisfy_metadata_scope():
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(
+            doris_context(
+                ["*"],
+                db_tools_enabled=True,
+                allowlist=["get_db_list"],
+            ),
+            "tool:get_db_list",
+        )
+
+    assert exc.value.error_code == "PERMISSION_DENIED"
+
+
+def test_doris_oauth_unknown_tool_rejected_before_dispatch():
+    with pytest.raises(OperationAuthorizationError) as exc:
+        authorize_operation(doris_context(["tool:call:not_real"]), "tool:not_real")
+
+    assert exc.value.error_code == "UNKNOWN_OPERATION"
+
+
+def test_filter_tools_for_doris_oauth_hides_disabled_or_denied_tools():
+    tools = [
+        SimpleNamespace(name="get_db_list"),
+        SimpleNamespace(name="exec_query"),
+        SimpleNamespace(name="get_sql_profile"),
+    ]
+
+    filtered = filter_tools_for_auth_context(
+        doris_context(
+            ["tool:call:get_db_list", "tool:call:exec_query", "tool:call:get_sql_profile"],
+            db_tools_enabled=True,
+            query_tools_enabled=True,
+            allowlist=["get_db_list"],
+        ),
+        tools,
+    )
+
+    assert [tool.name for tool in filtered] == ["get_db_list", "exec_query"]

--- a/test/security/test_sql_validation.py
+++ b/test/security/test_sql_validation.py
@@ -101,6 +101,34 @@ class TestSQLSecurityValidator:
         assert "comment" in result.error_message.lower()
 
     @pytest.mark.asyncio
+    async def test_legitimate_comment_is_allowed(self, sql_validator, analyst_context):
+        """Test normal comments are not rejected by substring matches."""
+        sql = "SELECT 1 -- order by note"
+
+        result = await sql_validator.validate(sql, analyst_context)
+
+        assert result.is_valid is True
+
+    @pytest.mark.asyncio
+    async def test_legitimate_union_is_allowed(self, sql_validator, analyst_context):
+        """Test ordinary UNION queries are not rejected as sensitive extraction."""
+        sql = "SELECT name FROM users UNION ALL SELECT name FROM archived_users"
+
+        result = await sql_validator.validate(sql, analyst_context)
+
+        assert result.is_valid is True
+
+    @pytest.mark.asyncio
+    async def test_union_sensitive_field_injection_is_rejected(self, sql_validator, analyst_context):
+        """Test UNION extraction of sensitive fields is rejected."""
+        sql = "SELECT name FROM users UNION SELECT password FROM admin_users"
+
+        result = await sql_validator.validate(sql, analyst_context)
+
+        assert result.is_valid is False
+        assert "injection" in result.error_message.lower()
+
+    @pytest.mark.asyncio
     async def test_complex_query_validation(self, sql_validator, analyst_context, test_sql_queries):
         """Test complex query validation"""
         sql = test_sql_queries["complex_query"]
@@ -158,4 +186,4 @@ class TestSQLSecurityValidator:
         result = await sql_validator.validate(malformed_sql, analyst_context)
         
         # Should handle gracefully
-        assert isinstance(result, ValidationResult) 
+        assert isinstance(result, ValidationResult)

--- a/test/security/test_token_prefix_reservation.py
+++ b/test/security/test_token_prefix_reservation.py
@@ -1,0 +1,44 @@
+import json
+
+import pytest
+
+from doris_mcp_server.auth.token_manager import TokenManager
+from doris_mcp_server.utils.config import DorisConfig
+
+
+def _config(tmp_path):
+    config = DorisConfig()
+    config.security.token_file_path = str(tmp_path / "tokens.json")
+    return config
+
+
+@pytest.mark.asyncio
+async def test_token_file_rejects_reserved_doris_oauth_prefix(tmp_path):
+    config = _config(tmp_path)
+    with open(config.security.token_file_path, "w", encoding="utf-8") as f:
+        json.dump({"tokens": [{"token_id": "bad", "token": "doa_bad"}]}, f)
+
+    with pytest.raises(ValueError, match="reserved Doris OAuth prefix"):
+        TokenManager(config)
+
+
+@pytest.mark.asyncio
+async def test_env_token_rejects_reserved_doris_oauth_prefix(tmp_path, monkeypatch):
+    config = _config(tmp_path)
+    monkeypatch.setenv("TOKEN_BAD", "doa_bad")
+
+    with pytest.raises(ValueError, match="reserved Doris OAuth prefix"):
+        TokenManager(config)
+
+
+@pytest.mark.asyncio
+async def test_create_token_rejects_reserved_doris_oauth_prefix(tmp_path):
+    config = _config(tmp_path)
+    with open(config.security.token_file_path, "w", encoding="utf-8") as f:
+        json.dump({"tokens": []}, f)
+    manager = TokenManager(config)
+    try:
+        with pytest.raises(ValueError, match="reserved Doris OAuth prefix"):
+            await manager.create_token("bad", custom_token="doa_bad")
+    finally:
+        manager.stop_hot_reload()

--- a/test/tools/test_resources_manager_cache.py
+++ b/test/tools/test_resources_manager_cache.py
@@ -1,0 +1,326 @@
+from contextlib import asynccontextmanager
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from doris_mcp_server.tools.resources_manager import (
+    DorisOAuthResourceError,
+    DorisResourcesManager,
+    MetadataCache,
+)
+from doris_mcp_server.utils.security import AuthContext, reset_auth_context, set_current_auth_context
+
+
+class FakeConnection:
+    def __init__(self):
+        self.table_metadata_queries = 0
+
+    async def execute(self, sql, params=None, auth_context=None):
+        if "FROM information_schema.tables" in sql and "AND table_type = 'BASE TABLE'" in sql:
+            self.table_metadata_queries += 1
+            return SimpleNamespace(
+                data=[
+                    {
+                        "table_name": f"orders_{self.table_metadata_queries}",
+                        "table_comment": "orders",
+                        "row_count": 1,
+                        "create_time": None,
+                    }
+                ]
+            )
+        if "FROM information_schema.columns" in sql:
+            return SimpleNamespace(data=[])
+        return SimpleNamespace(data=[])
+
+
+class FakeConnectionManager:
+    def __init__(self):
+        self.connection = FakeConnection()
+        self.acquires = 0
+        self.releases = 0
+
+    @asynccontextmanager
+    async def get_connection_context(self, session_id):
+        self.acquires += 1
+        try:
+            yield self.connection
+        finally:
+            self.releases += 1
+
+
+class RaisingConnection:
+    async def execute(self, sql, params=None, auth_context=None):
+        raise RuntimeError("metadata backend failed")
+
+
+class RaisingConnectionManager:
+    def __init__(self):
+        self.connection = RaisingConnection()
+        self.acquires = 0
+        self.releases = 0
+
+    @asynccontextmanager
+    async def get_connection_context(self, session_id):
+        self.acquires += 1
+        try:
+            yield self.connection
+        finally:
+            self.releases += 1
+
+
+class DorisOAuthResourceConnection:
+    def __init__(self):
+        self.calls = []
+
+    async def execute(self, sql, params=None, auth_context=None):
+        self.calls.append((sql, params, auth_context))
+        if sql.strip().upper().startswith("SHOW DATABASES"):
+            return SimpleNamespace(
+                data=[
+                    {"Database": "information_schema"},
+                    {"Database": "db1"},
+                    {"Database": "db2"},
+                    {"Database": "db/slash"},
+                    {"Database": "database"},
+                ]
+            )
+        if "FROM information_schema.tables" in sql and "AND table_type = 'BASE TABLE'" in sql:
+            db_name = params[0]
+            return SimpleNamespace(
+                data=[
+                    {
+                        "table_name": f"{db_name}_orders",
+                        "table_comment": "orders",
+                        "row_count": 1,
+                        "create_time": None,
+                    }
+                ]
+            )
+        if "FROM information_schema.views" in sql and "view_definition" in sql and "AND table_name" not in sql:
+            db_name = params[0]
+            return SimpleNamespace(
+                data=[
+                    {
+                        "table_name": f"{db_name}_view",
+                        "table_comment": "view",
+                        "view_definition": "select 1",
+                    }
+                ]
+            )
+        if "FROM information_schema.columns" in sql:
+            return SimpleNamespace(data=[])
+        if "FROM information_schema.statistics" in sql:
+            return SimpleNamespace(data=[])
+        return SimpleNamespace(data=[])
+
+
+class DorisOAuthResourceConnectionManager:
+    def __init__(self):
+        self.connection = DorisOAuthResourceConnection()
+        self.acquires = 0
+        self.releases = 0
+
+    @asynccontextmanager
+    async def get_connection_context(self, session_id):
+        self.acquires += 1
+        try:
+            yield self.connection
+        finally:
+            self.releases += 1
+
+
+class DorisOAuthReadConnection:
+    def __init__(self):
+        self.calls = []
+
+    async def execute(self, sql, params=None, auth_context=None):
+        self.calls.append((sql, params, auth_context))
+        if "FROM information_schema.tables" in sql and "AND table_name" in sql:
+            assert params in {("db1", "orders"), ("db/slash", "orders/slash")}
+            _db_name, table_name = params
+            return SimpleNamespace(
+                data=[
+                    {
+                        "table_name": table_name,
+                        "table_comment": "orders",
+                        "table_rows": 10,
+                        "create_time": None,
+                        "engine": "Doris",
+                    }
+                ]
+            )
+        if "FROM information_schema.columns" in sql:
+            assert params in {("db1", "orders"), ("db/slash", "orders/slash")}
+            return SimpleNamespace(data=[{"column_name": "id"}])
+        if "FROM information_schema.statistics" in sql:
+            assert params in {("db1", "orders"), ("db/slash", "orders/slash")}
+            return SimpleNamespace(data=[])
+        return SimpleNamespace(data=[])
+
+
+class DorisOAuthReadConnectionManager:
+    def __init__(self):
+        self.connection = DorisOAuthReadConnection()
+        self.acquires = 0
+        self.releases = 0
+
+    @asynccontextmanager
+    async def get_connection_context(self, session_id):
+        self.acquires += 1
+        try:
+            yield self.connection
+        finally:
+            self.releases += 1
+
+
+def doris_context(scopes):
+    return AuthContext(
+        user_id="doris_user",
+        auth_method="doris_oauth",
+        oauth_scopes=list(scopes),
+        pool_key="doris_user:doris_user",
+    )
+
+
+@pytest.mark.asyncio
+async def test_metadata_cache_disabled_by_default():
+    cache = MetadataCache(enabled=False)
+    await cache.set("table_metadata", ["cached"])
+
+    assert await cache.get("table_metadata") is None
+
+
+@pytest.mark.asyncio
+async def test_resources_manager_does_not_reuse_global_metadata_cache():
+    connection_manager = FakeConnectionManager()
+    manager = DorisResourcesManager(connection_manager)
+
+    first = await manager._get_table_metadata()
+    second = await manager._get_table_metadata()
+
+    assert manager.metadata_cache.enabled is False
+    assert [table.name for table in first] == ["orders_1"]
+    assert [table.name for table in second] == ["orders_2"]
+    assert connection_manager.acquires == 2
+    assert connection_manager.releases == 2
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_list_resources_backend_error_is_structured_failure():
+    connection_manager = RaisingConnectionManager()
+    manager = DorisResourcesManager(connection_manager)
+    token = set_current_auth_context(doris_context(["resource:list"]))
+
+    try:
+        with pytest.raises(DorisOAuthResourceError) as exc:
+            await manager.list_resources()
+    finally:
+        reset_auth_context(token)
+
+    assert exc.value.error_code == "DORIS_OAUTH_METADATA_BACKEND_ERROR"
+    assert exc.value.status_code == 502
+    assert connection_manager.acquires == 1
+    assert connection_manager.releases == 1
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_list_resources_uses_database_qualified_uris_without_database_function():
+    connection_manager = DorisOAuthResourceConnectionManager()
+    manager = DorisResourcesManager(connection_manager)
+    token = set_current_auth_context(doris_context(["resource:list"]))
+
+    try:
+        resources = await manager.list_resources()
+    finally:
+        reset_auth_context(token)
+
+    uris = {str(resource.uri) for resource in resources}
+    assert "doris://table/db1/db1_orders" in uris
+    assert "doris://view/db1/db1_view" in uris
+    assert "doris://stats/db1" in uris
+    assert "doris://table/db%2Fslash/db%2Fslash_orders" in uris
+    assert "doris://view/db%2Fslash/db%2Fslash_view" in uris
+    assert "doris://stats/database/database" in uris
+    assert "doris://table/information_schema/information_schema_orders" not in uris
+    assert connection_manager.acquires == 1
+    assert connection_manager.releases == 1
+    assert all("DATABASE()" not in sql for sql, _params, _auth in connection_manager.connection.calls)
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_read_resource_backend_error_is_structured_failure():
+    connection_manager = RaisingConnectionManager()
+    manager = DorisResourcesManager(connection_manager)
+    token = set_current_auth_context(doris_context(["resource:read"]))
+
+    try:
+        with pytest.raises(DorisOAuthResourceError) as exc:
+            await manager.read_resource("doris://table/orders")
+    finally:
+        reset_auth_context(token)
+
+    assert exc.value.error_code == "DORIS_OAUTH_METADATA_BACKEND_ERROR"
+    assert exc.value.status_code == 502
+    assert connection_manager.acquires == 1
+    assert connection_manager.releases == 1
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_read_database_qualified_table_resource_uses_uri_database():
+    connection_manager = DorisOAuthReadConnectionManager()
+    manager = DorisResourcesManager(connection_manager)
+    token = set_current_auth_context(doris_context(["resource:read"]))
+
+    try:
+        result = await manager.read_resource("doris://table/db1/orders")
+    finally:
+        reset_auth_context(token)
+
+    payload = json.loads(result)
+    assert payload["database_name"] == "db1"
+    assert payload["table_name"] == "orders"
+    assert connection_manager.acquires == 1
+    assert connection_manager.releases == 1
+    assert all("DATABASE()" not in sql for sql, _params, _auth in connection_manager.connection.calls)
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_read_percent_encoded_table_resource_uses_decoded_identifiers():
+    connection_manager = DorisOAuthReadConnectionManager()
+    manager = DorisResourcesManager(connection_manager)
+    token = set_current_auth_context(doris_context(["resource:read"]))
+
+    try:
+        result = await manager.read_resource("doris://table/db%2Fslash/orders%2Fslash")
+    finally:
+        reset_auth_context(token)
+
+    payload = json.loads(result)
+    assert payload["database_name"] == "db/slash"
+    assert payload["table_name"] == "orders/slash"
+    assert connection_manager.acquires == 1
+    assert connection_manager.releases == 1
+    assert all("DATABASE()" not in sql for sql, _params, _auth in connection_manager.connection.calls)
+
+
+def test_parse_stats_resource_distinguishes_legacy_current_database_from_literal_database_name():
+    manager = DorisResourcesManager(DorisOAuthResourceConnectionManager())
+
+    assert manager._parse_resource_uri("doris://stats/database") == ("stats", "database", None)
+    assert manager._parse_resource_uri("doris://stats/database/database") == (
+        "stats",
+        "database",
+        "database",
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_read_resource_keeps_json_error_body_compatibility():
+    manager = DorisResourcesManager(RaisingConnectionManager())
+
+    result = await manager.read_resource("doris://table/orders")
+
+    payload = json.loads(result)
+    assert payload["uri"] == "doris://table/orders"
+    assert "metadata backend failed" in payload["error"]

--- a/test/tools/test_tools_operation_guard.py
+++ b/test/tools/test_tools_operation_guard.py
@@ -1,0 +1,620 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import mcp.types as mcp_types
+import pytest
+
+from doris_mcp_server.auth.operation_policy import HIGH_RISK_TOOLS, OperationAuthorizationError, authorize_operation
+from doris_mcp_server.main import DorisServer, Server
+from doris_mcp_server.tools.tools_manager import DorisToolsManager
+from doris_mcp_server.utils.analysis_tools import SQLAnalyzer
+from doris_mcp_server.utils.db import QueryResult
+from doris_mcp_server.utils.query_executor import DorisQueryExecutor
+from doris_mcp_server.utils.schema_extractor import MetadataExtractor
+from doris_mcp_server.utils.security import (
+    AuthContext,
+    get_current_auth_context,
+    reset_auth_context,
+    set_current_auth_context,
+)
+
+
+class FakeRoutedConnection:
+    def __init__(self, manager, session_id, auth_context):
+        self.manager = manager
+        self.session_id = session_id
+        self.auth_context = auth_context
+
+    async def execute(self, sql, params=None, auth_context=None):
+        return await self.manager.execute_query(
+            self.session_id,
+            sql,
+            params,
+            auth_context or self.auth_context,
+        )
+
+
+class FakeRoutedConnectionManager:
+    def __init__(self, tmp_path):
+        self.config = SimpleNamespace(
+            temp_files_dir=str(tmp_path),
+            performance=SimpleNamespace(
+                max_cache_size=100,
+                cache_ttl=300,
+                max_concurrent_queries=10,
+                max_response_content_size=20000,
+            ),
+            security=SimpleNamespace(enable_security_check=False),
+            adbc=SimpleNamespace(
+                default_max_rows=100,
+                default_timeout=30,
+                default_return_format="dict",
+            ),
+        )
+        self.security_manager = None
+        self.routed_calls = []
+        self.global_calls = 0
+        self.token_calls = 0
+        self.connection_acquires = 0
+        self.connection_releases = 0
+
+    def _get_effective_auth_context(self, auth_context=None):
+        return auth_context or get_current_auth_context()
+
+    async def _get_connection_for_auth_context(self, session_id, auth_context=None):
+        self.connection_acquires += 1
+        return FakeRoutedConnection(self, session_id, auth_context)
+
+    async def release_connection(self, session_id, connection):
+        self.connection_releases += 1
+
+    async def execute_query(self, session_id, sql, params=None, auth_context=None):
+        if getattr(auth_context, "auth_method", "") != "doris_oauth":
+            raise AssertionError("Doris OAuth tool path did not pass AuthContext")
+        if getattr(auth_context, "doris_user", "") != "alice":
+            raise AssertionError("Doris OAuth tool path did not use the logged-in Doris user")
+        self.routed_calls.append(
+            {
+                "session_id": session_id,
+                "sql": sql,
+                "params": params,
+                "doris_user": auth_context.doris_user,
+            }
+        )
+        if sql.strip().upper().startswith("EXPLAIN"):
+            return QueryResult(
+                data=[{"Plan": "SCAN"}],
+                metadata={"columns": ["Plan"]},
+                execution_time=0.01,
+                row_count=1,
+                sql=sql,
+            )
+        return QueryResult(
+            data=[{"one": 1}],
+            metadata={"columns": ["one"]},
+            execution_time=0.01,
+            row_count=1,
+            sql=sql,
+        )
+
+    async def _get_global_connection(self, session_id):
+        self.global_calls += 1
+        raise AssertionError("Doris OAuth tool path fell back to the global pool")
+
+    async def get_connection_for_token(self, token, session_id):
+        self.token_calls += 1
+        raise AssertionError("Doris OAuth tool path fell back to token routing")
+
+
+def doris_context(
+    scopes,
+    *,
+    user_id="doris_user",
+    db_tools_enabled=False,
+    allowlist=None,
+    query_tools_enabled=False,
+    query_allowlist=None,
+    explain_tools_enabled=False,
+    explain_allowlist=None,
+):
+    context = AuthContext(
+        user_id=user_id,
+        auth_method="doris_oauth",
+        oauth_scopes=list(scopes),
+        doris_user=user_id,
+        pool_key=f"doris_user:{user_id}",
+    )
+    context.doris_oauth_db_tools_enabled = db_tools_enabled
+    context.doris_oauth_db_tool_allowlist = tuple(allowlist or ())
+    context.doris_oauth_query_tools_enabled = query_tools_enabled
+    context.doris_oauth_query_tool_allowlist = tuple(query_allowlist or ("exec_query",))
+    context.doris_oauth_explain_tools_enabled = explain_tools_enabled
+    context.doris_oauth_explain_tool_allowlist = tuple(explain_allowlist or ("get_sql_explain",))
+    return context
+
+
+def _real_tool_manager_for_routing(tmp_path):
+    connection_manager = FakeRoutedConnectionManager(tmp_path)
+    manager = object.__new__(DorisToolsManager)
+    manager.connection_manager = connection_manager
+    manager.metadata_extractor = MetadataExtractor(connection_manager=connection_manager)
+    manager.sql_analyzer = SQLAnalyzer(connection_manager)
+    return manager, connection_manager
+
+
+def _configured_rbac_default_scopes():
+    return [
+        "tool:list",
+        "resource:list",
+        "resource:read",
+        "tool:call:get_db_list",
+        "tool:call:get_db_table_list",
+        "tool:call:get_table_schema",
+        "tool:call:get_table_comment",
+        "tool:call:get_table_column_comments",
+        "tool:call:get_table_indexes",
+        "tool:call:get_catalog_list",
+        "tool:call:exec_query",
+        "tool:call:get_sql_explain",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_high_risk_tool_is_rejected_before_dispatch():
+    manager = object.__new__(DorisToolsManager)
+    called = False
+
+    async def fake_sql_profile_tool(arguments):
+        nonlocal called
+        called = True
+        return {"unexpected": arguments}
+
+    manager._get_sql_profile_tool = fake_sql_profile_tool
+    token = set_current_auth_context(doris_context(["tool:call:get_sql_profile"]))
+
+    try:
+        with pytest.raises(OperationAuthorizationError) as exc:
+            await manager.call_tool("get_sql_profile", {"query_id": "q1"})
+    finally:
+        reset_auth_context(token)
+
+    assert exc.value.error_code == "UNSUPPORTED_FOR_DORIS_OAUTH"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_exec_query_rejected_before_global_pool_dispatch():
+    manager = object.__new__(DorisToolsManager)
+    called = False
+
+    async def fake_exec_query_tool(arguments):
+        nonlocal called
+        called = True
+        return {"unexpected": arguments}
+
+    manager._exec_query_tool = fake_exec_query_tool
+    token = set_current_auth_context(doris_context(["tool:call:exec_query"]))
+
+    try:
+        with pytest.raises(OperationAuthorizationError) as exc:
+            await manager.call_tool("exec_query", {"sql": "SELECT 1"})
+    finally:
+        reset_auth_context(token)
+
+    assert exc.value.error_code == "DORIS_OAUTH_QUERY_TOOL_NOT_ENABLED"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_exec_query_dispatches_when_query_gate_enabled():
+    manager = object.__new__(DorisToolsManager)
+    called_arguments = None
+
+    async def fake_exec_query_tool(arguments):
+        nonlocal called_arguments
+        called_arguments = arguments
+        return {"ok": True}
+
+    manager._exec_query_tool = fake_exec_query_tool
+    token = set_current_auth_context(
+        doris_context(
+            ["tool:call:exec_query"],
+            user_id="alice",
+            query_tools_enabled=True,
+        )
+    )
+
+    try:
+        result = await manager.call_tool("exec_query", {"sql": "SELECT 1"})
+    finally:
+        reset_auth_context(token)
+
+    payload = json.loads(result)
+    assert payload["ok"] is True
+    assert called_arguments == {"sql": "SELECT 1"}
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_exec_query_real_tool_path_uses_doris_user_route(tmp_path, monkeypatch):
+    monkeypatch.setattr(DorisQueryExecutor, "_start_background_tasks", lambda self: None)
+    manager, connection_manager = _real_tool_manager_for_routing(tmp_path)
+    token = set_current_auth_context(
+        doris_context(
+            ["tool:call:exec_query"],
+            user_id="alice",
+            query_tools_enabled=True,
+        )
+    )
+
+    try:
+        result = await manager.call_tool("exec_query", {"sql": "SELECT 1", "max_rows": 5})
+    finally:
+        reset_auth_context(token)
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["data"] == [{"one": 1}]
+    assert connection_manager.global_calls == 0
+    assert connection_manager.token_calls == 0
+    assert len(connection_manager.routed_calls) == 1
+    assert connection_manager.routed_calls[0]["doris_user"] == "alice"
+    assert connection_manager.routed_calls[0]["sql"] == "SELECT 1 LIMIT 5"
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_exec_query_with_db_catalog_uses_one_routed_connection(tmp_path, monkeypatch):
+    monkeypatch.setattr(DorisQueryExecutor, "_start_background_tasks", lambda self: None)
+    manager, connection_manager = _real_tool_manager_for_routing(tmp_path)
+    token = set_current_auth_context(
+        doris_context(
+            ["tool:call:exec_query"],
+            user_id="alice",
+            query_tools_enabled=True,
+        )
+    )
+
+    try:
+        result = await manager.call_tool(
+            "exec_query",
+            {
+                "sql": "SELECT * FROM orders",
+                "db_name": "db1",
+                "catalog_name": "ctl1",
+                "max_rows": 5,
+            },
+        )
+    finally:
+        reset_auth_context(token)
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert connection_manager.connection_acquires == 1
+    assert connection_manager.connection_releases == 1
+    assert [call["sql"] for call in connection_manager.routed_calls] == [
+        "USE CATALOG `ctl1`",
+        "USE `db1`",
+        "SELECT * FROM orders LIMIT 5",
+    ]
+    assert {call["doris_user"] for call in connection_manager.routed_calls} == {"alice"}
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_sql_explain_real_tool_path_uses_doris_user_route(tmp_path):
+    manager, connection_manager = _real_tool_manager_for_routing(tmp_path)
+    token = set_current_auth_context(
+        doris_context(
+            ["tool:call:get_sql_explain"],
+            user_id="alice",
+            explain_tools_enabled=True,
+        )
+    )
+
+    try:
+        result = await manager.call_tool("get_sql_explain", {"sql": "SELECT 1"})
+    finally:
+        reset_auth_context(token)
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert "EXPLAIN SELECT 1" in payload["content"]
+    assert connection_manager.global_calls == 0
+    assert connection_manager.token_calls == 0
+    assert len(connection_manager.routed_calls) == 1
+    assert connection_manager.routed_calls[0]["doris_user"] == "alice"
+    assert connection_manager.routed_calls[0]["sql"] == "EXPLAIN SELECT 1"
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_sql_explain_with_db_catalog_uses_one_routed_connection(tmp_path):
+    manager, connection_manager = _real_tool_manager_for_routing(tmp_path)
+    token = set_current_auth_context(
+        doris_context(
+            ["tool:call:get_sql_explain"],
+            user_id="alice",
+            explain_tools_enabled=True,
+        )
+    )
+
+    try:
+        result = await manager.call_tool(
+            "get_sql_explain",
+            {
+                "sql": "SELECT * FROM orders",
+                "db_name": "db1",
+                "catalog_name": "ctl1",
+            },
+        )
+    finally:
+        reset_auth_context(token)
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert connection_manager.connection_acquires == 1
+    assert connection_manager.connection_releases == 1
+    assert [call["sql"] for call in connection_manager.routed_calls] == [
+        "USE CATALOG `ctl1`",
+        "USE `db1`",
+        "EXPLAIN SELECT * FROM orders",
+    ]
+    assert {call["doris_user"] for call in connection_manager.routed_calls} == {"alice"}
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_list_tools_uses_configured_default_scope_visibility(tmp_path):
+    manager, _connection_manager = _real_tool_manager_for_routing(tmp_path)
+    token = set_current_auth_context(
+        doris_context(
+            _configured_rbac_default_scopes(),
+            db_tools_enabled=True,
+            allowlist=[
+                "get_db_list",
+                "get_db_table_list",
+                "get_table_schema",
+                "get_table_comment",
+                "get_table_column_comments",
+                "get_table_indexes",
+                "get_catalog_list",
+            ],
+            query_tools_enabled=True,
+            explain_tools_enabled=True,
+        )
+    )
+
+    try:
+        tools = await manager.list_tools()
+    finally:
+        reset_auth_context(token)
+
+    names = {tool.name for tool in tools}
+    assert {
+        "exec_query",
+        "get_sql_explain",
+        "get_db_list",
+        "get_db_table_list",
+        "get_table_schema",
+        "get_table_comment",
+        "get_table_column_comments",
+        "get_table_indexes",
+        "get_catalog_list",
+    } <= names
+    assert names.isdisjoint(HIGH_RISK_TOOLS)
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_exec_query_ddl_rejected_before_backend_when_global_security_disabled():
+    manager = object.__new__(DorisToolsManager)
+    manager.connection_manager = SimpleNamespace(
+        config=SimpleNamespace(security=SimpleNamespace(enable_security_check=False))
+    )
+    called = False
+
+    async def fake_exec_query_tool(arguments):
+        nonlocal called
+        called = True
+        return {"unexpected": arguments}
+
+    manager._exec_query_tool = fake_exec_query_tool
+    token = set_current_auth_context(
+        doris_context(
+            ["tool:call:exec_query"],
+            db_tools_enabled=True,
+            allowlist=["get_db_list"],
+        )
+    )
+
+    try:
+        with pytest.raises(OperationAuthorizationError) as exc:
+            await manager.call_tool("exec_query", {"sql": "DROP TABLE sensitive_table"})
+    finally:
+        reset_auth_context(token)
+
+    assert exc.value.error_code == "DORIS_OAUTH_QUERY_TOOL_NOT_ENABLED"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_metadata_tool_rejected_before_cache_backend_dispatch_when_gate_false():
+    manager = object.__new__(DorisToolsManager)
+    called = False
+
+    async def fake_table_schema_tool(arguments):
+        nonlocal called
+        called = True
+        return {"unexpected": arguments}
+
+    manager._get_table_schema_tool = fake_table_schema_tool
+    token = set_current_auth_context(doris_context(["tool:call:get_table_schema"]))
+
+    try:
+        with pytest.raises(OperationAuthorizationError) as exc:
+            await manager.call_tool("get_table_schema", {"table_name": "orders"})
+    finally:
+        reset_auth_context(token)
+
+    assert exc.value.error_code == "DORIS_OAUTH_DB_TOOLS_NOT_ENABLED"
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_missing_auth_context_keeps_legacy_dispatch_compatible():
+    assert get_current_auth_context() is None
+    manager = object.__new__(DorisToolsManager)
+    called_arguments = None
+
+    async def fake_sql_profile_tool(arguments):
+        nonlocal called_arguments
+        called_arguments = arguments
+        return {"profile": "ok"}
+
+    manager._get_sql_profile_tool = fake_sql_profile_tool
+
+    result = await manager.call_tool("get_sql_profile", {"query_id": "q1"})
+
+    payload = json.loads(result)
+    assert payload["profile"] == "ok"
+    assert payload["_execution_info"]["tool_name"] == "get_sql_profile"
+    assert called_arguments == {"query_id": "q1"}
+
+
+def _server_with_mock_managers():
+    server = object.__new__(DorisServer)
+    server.server = Server("test-doris-mcp-server")
+    server.resources_manager = MagicMock()
+    server.resources_manager.list_resources = AsyncMock(return_value=[])
+    server.resources_manager.read_resource = AsyncMock(return_value="{}")
+    server.prompts_manager = MagicMock()
+    server.prompts_manager.list_prompts = AsyncMock(return_value=[])
+    server.prompts_manager.get_prompt = AsyncMock(return_value="prompt")
+    server.tools_manager = MagicMock()
+    server.logger = MagicMock()
+    DorisServer._setup_handlers(server)
+    return server
+
+
+def _handler_request(operation):
+    if operation == "list_resources":
+        return mcp_types.ListResourcesRequest(method="resources/list")
+    if operation == "read_resource":
+        return SimpleNamespace(params=SimpleNamespace(uri="doris://tables"))
+    if operation == "list_prompts":
+        return mcp_types.ListPromptsRequest(method="prompts/list")
+    if operation == "get_prompt":
+        return SimpleNamespace(
+            params=SimpleNamespace(name="query_analysis", arguments={})
+        )
+    raise AssertionError(f"Unexpected operation: {operation}")
+
+
+def _manager_mock_for_operation(server, operation):
+    return {
+        "list_resources": server.resources_manager.list_resources,
+        "read_resource": server.resources_manager.read_resource,
+        "list_prompts": server.prompts_manager.list_prompts,
+        "get_prompt": server.prompts_manager.get_prompt,
+    }[operation]
+
+
+def _handler_type_for_operation(operation):
+    return {
+        "list_resources": mcp_types.ListResourcesRequest,
+        "read_resource": mcp_types.ReadResourceRequest,
+        "list_prompts": mcp_types.ListPromptsRequest,
+        "get_prompt": mcp_types.GetPromptRequest,
+    }[operation]
+
+
+@pytest.mark.parametrize(
+    ("operation", "scope"),
+    [
+        ("list_resources", "resource:list"),
+        ("read_resource", "resource:read"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_doris_oauth_resources_real_handler_calls_manager_with_matching_scope(
+    operation,
+    scope,
+):
+    server = _server_with_mock_managers()
+    token = set_current_auth_context(doris_context([scope]))
+
+    try:
+        await server.server.request_handlers[_handler_type_for_operation(operation)](
+            _handler_request(operation)
+        )
+    finally:
+        reset_auth_context(token)
+
+    _manager_mock_for_operation(server, operation).assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("operation", "scope"),
+    [
+        ("list_resources", "resource:list"),
+        ("read_resource", "resource:read"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_doris_oauth_resources_real_handler_propagates_manager_errors(
+    operation,
+    scope,
+):
+    server = _server_with_mock_managers()
+    _manager_mock_for_operation(server, operation).side_effect = RuntimeError(
+        f"{operation} backend failed"
+    )
+    token = set_current_auth_context(doris_context([scope]))
+
+    try:
+        with pytest.raises(RuntimeError, match=f"{operation} backend failed"):
+            await server.server.request_handlers[_handler_type_for_operation(operation)](
+                _handler_request(operation)
+            )
+    finally:
+        reset_auth_context(token)
+
+
+@pytest.mark.asyncio
+async def test_legacy_list_resources_handler_keeps_empty_list_compatibility():
+    server = _server_with_mock_managers()
+    server.resources_manager.list_resources.side_effect = RuntimeError("legacy backend failed")
+
+    result = await server.server.request_handlers[mcp_types.ListResourcesRequest](
+        mcp_types.ListResourcesRequest(method="resources/list")
+    )
+
+    assert result.root.resources == []
+
+
+@pytest.mark.parametrize(
+    ("operation", "scope"),
+    [
+        ("list_prompts", "prompt:list"),
+        ("get_prompt", "prompt:get"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_doris_oauth_prompts_real_handler_rejected_before_manager(
+    operation,
+    scope,
+):
+    server = _server_with_mock_managers()
+    metadata_cache = MagicMock()
+    connection_manager = MagicMock()
+    connection_manager.get_connection = AsyncMock()
+    token = set_current_auth_context(doris_context([scope]))
+
+    try:
+        with pytest.raises(OperationAuthorizationError) as exc:
+            await server.server.request_handlers[_handler_type_for_operation(operation)](
+                _handler_request(operation)
+            )
+    finally:
+        reset_auth_context(token)
+
+    assert exc.value.error_code == "UNSUPPORTED_FOR_DORIS_OAUTH"
+    _manager_mock_for_operation(server, operation).assert_not_awaited()
+    metadata_cache.get.assert_not_called()
+    connection_manager.get_connection.assert_not_awaited()

--- a/test/utils/test_doris_user_pool_manager.py
+++ b/test/utils/test_doris_user_pool_manager.py
@@ -1,0 +1,355 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from doris_mcp_server.utils import db as db_module
+from doris_mcp_server.utils.db import (
+    DorisConnection,
+    DorisConnectionManager,
+    DorisUserAuthenticationError,
+    DorisUserPoolMissingError,
+    QueryResult,
+)
+from doris_mcp_server.utils.security import (
+    AuthContext,
+    reset_auth_context,
+    set_current_auth_context,
+)
+
+
+class FakeAuthConnection:
+    def __init__(self):
+        self.closed = False
+        self.close_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+
+class FakeRawConnection:
+    def __init__(self, label):
+        self.label = label
+        self.closed = False
+        self.ensure_closed_calls = 0
+
+    async def ensure_closed(self):
+        self.ensure_closed_calls += 1
+        self.closed = True
+
+
+class FakePool:
+    def __init__(self, name):
+        self.name = name
+        self.closed = False
+        self.size = 0
+        self.freesize = 0
+        self.minsize = 0
+        self.maxsize = 5
+        self.acquire_calls = 0
+        self.release_calls = []
+        self.close_calls = 0
+        self.wait_closed_calls = 0
+
+    async def acquire(self):
+        self.acquire_calls += 1
+        return FakeRawConnection(f"{self.name}:{self.acquire_calls}")
+
+    def release(self, connection):
+        self.release_calls.append(connection)
+
+    def close(self):
+        self.close_calls += 1
+        self.closed = True
+
+    async def wait_closed(self):
+        self.wait_closed_calls += 1
+
+
+def manager_config():
+    return SimpleNamespace(
+        database=SimpleNamespace(
+            host="127.0.0.1",
+            port=9030,
+            user="root",
+            password="root_pw",
+            database="default_cluster:test_db",
+            charset="utf8",
+            min_connections=0,
+            max_connections=20,
+            max_connection_age=3600,
+            connection_timeout=1,
+        ),
+        security=SimpleNamespace(enable_token_auth=False),
+    )
+
+
+@pytest.fixture
+def manager():
+    return DorisConnectionManager(manager_config())
+
+
+def doris_context(user="alice", token=""):
+    return AuthContext(
+        user_id=user,
+        auth_method="doris_oauth",
+        doris_user=user,
+        pool_key=f"doris_user:{user}",
+        token=token,
+    )
+
+
+@pytest.mark.asyncio
+async def test_authenticate_doris_user_success_does_not_create_pool(manager, monkeypatch):
+    connect = AsyncMock(return_value=FakeAuthConnection())
+    create_pool = AsyncMock()
+    monkeypatch.setattr(db_module.aiomysql, "connect", connect)
+    monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
+
+    await manager.authenticate_doris_user("alice", "correct")
+
+    assert connect.await_count == 1
+    assert connect.await_args.kwargs["user"] == "alice"
+    assert connect.await_args.kwargs["db"] == "information_schema"
+    assert create_pool.await_count == 0
+    assert manager.has_doris_user_pool("alice") is False
+
+
+@pytest.mark.asyncio
+async def test_wrong_password_first_login_fails_without_pool(manager, monkeypatch):
+    connect = AsyncMock(side_effect=RuntimeError("access denied"))
+    create_pool = AsyncMock()
+    monkeypatch.setattr(db_module.aiomysql, "connect", connect)
+    monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
+
+    with pytest.raises(DorisUserAuthenticationError) as exc:
+        await manager.create_or_replace_doris_user_pool("alice", "wrong")
+
+    assert exc.value.error_code == "DORIS_AUTHENTICATION_FAILED"
+    assert create_pool.await_count == 0
+    assert manager.has_doris_user_pool("alice") is False
+
+
+@pytest.mark.asyncio
+async def test_repeat_login_reverifies_and_reuses_existing_pool(manager, monkeypatch):
+    pool = FakePool("alice-v1")
+    connect = AsyncMock(side_effect=[FakeAuthConnection(), FakeAuthConnection()])
+    create_pool = AsyncMock(return_value=pool)
+    monkeypatch.setattr(db_module.aiomysql, "connect", connect)
+    monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
+
+    await manager.create_or_replace_doris_user_pool("alice", "pw1")
+    first_meta = manager.doris_user_pool_meta["alice"]
+    await manager.create_or_replace_doris_user_pool("alice", "pw1")
+
+    assert connect.await_count == 2
+    assert create_pool.await_count == 1
+    assert create_pool.await_args.kwargs["db"] == "information_schema"
+    assert manager.doris_user_pools["alice"] is pool
+    assert manager.doris_user_pool_meta["alice"].credential_fingerprint == first_meta.credential_fingerprint
+
+
+@pytest.mark.asyncio
+async def test_wrong_password_after_existing_pool_preserves_old_pool(manager, monkeypatch):
+    old_pool = FakePool("alice-v1")
+    connect = AsyncMock(side_effect=[FakeAuthConnection(), RuntimeError("access denied")])
+    create_pool = AsyncMock(return_value=old_pool)
+    monkeypatch.setattr(db_module.aiomysql, "connect", connect)
+    monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
+
+    await manager.create_or_replace_doris_user_pool("alice", "pw1")
+    old_meta = manager.doris_user_pool_meta["alice"]
+
+    with pytest.raises(DorisUserAuthenticationError):
+        await manager.create_or_replace_doris_user_pool("alice", "wrong")
+
+    assert manager.doris_user_pools["alice"] is old_pool
+    assert manager.doris_user_pool_meta["alice"].owner_id == old_meta.owner_id
+    assert manager.doris_user_pool_meta["alice"].credential_fingerprint == old_meta.credential_fingerprint
+    assert create_pool.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_soft_replace_releases_old_checked_out_connection_to_old_owner(manager, monkeypatch):
+    old_pool = FakePool("alice-v1")
+    new_pool = FakePool("alice-v2")
+    connect = AsyncMock(side_effect=[FakeAuthConnection(), FakeAuthConnection()])
+    create_pool = AsyncMock(side_effect=[old_pool, new_pool])
+    monkeypatch.setattr(db_module.aiomysql, "connect", connect)
+    monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
+
+    await manager.create_or_replace_doris_user_pool("alice", "pw1")
+    checked_out = await manager.get_connection_for_doris_user("alice", "s1")
+
+    await manager.create_or_replace_doris_user_pool("alice", "pw2")
+
+    assert manager.doris_user_pools["alice"] is new_pool
+    assert old_pool.close_calls == 1
+
+    await manager.release_connection_for_doris_user("alice", checked_out)
+
+    assert old_pool.release_calls == [checked_out.connection]
+    assert new_pool.release_calls == []
+
+
+@pytest.mark.asyncio
+async def test_new_pool_create_failure_preserves_existing_pool(manager, monkeypatch):
+    old_pool = FakePool("alice-v1")
+    connect = AsyncMock(side_effect=[FakeAuthConnection(), FakeAuthConnection()])
+    create_pool = AsyncMock(side_effect=[old_pool, RuntimeError("create failed")])
+    monkeypatch.setattr(db_module.aiomysql, "connect", connect)
+    monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
+
+    await manager.create_or_replace_doris_user_pool("alice", "pw1")
+    old_meta = manager.doris_user_pool_meta["alice"]
+
+    with pytest.raises(RuntimeError):
+        await manager.create_or_replace_doris_user_pool("alice", "pw2")
+
+    assert manager.doris_user_pools["alice"] is old_pool
+    assert manager.doris_user_pool_meta["alice"].owner_id == old_meta.owner_id
+    assert manager.doris_user_pool_meta["alice"].credential_fingerprint == old_meta.credential_fingerprint
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_pool_missing_does_not_fallback_to_token_or_global(manager):
+    manager.pool = FakePool("global")
+    manager.get_connection_for_token = AsyncMock()
+    manager._recover_pool_with_lock = AsyncMock()
+    token = set_current_auth_context(doris_context(token="static-token"))
+
+    try:
+        with pytest.raises(DorisUserPoolMissingError) as exc:
+            await manager.get_connection("s1")
+    finally:
+        reset_auth_context(token)
+
+    assert exc.value.error_code == "DORIS_OAUTH_POOL_MISSING"
+    assert manager.pool.acquire_calls == 0
+    assert manager.get_connection_for_token.await_count == 0
+    assert manager._recover_pool_with_lock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_query_pool_missing_does_not_fallback_to_global_or_token(manager):
+    manager.pool = FakePool("global")
+    manager.get_connection_for_token = AsyncMock()
+    manager._recover_pool_with_lock = AsyncMock()
+
+    with pytest.raises(DorisUserPoolMissingError):
+        await manager.execute_query(
+            "s1",
+            "SELECT 1",
+            auth_context=doris_context(token="static-token"),
+        )
+
+    assert manager.pool.acquire_calls == 0
+    assert manager.get_connection_for_token.await_count == 0
+    assert manager._recover_pool_with_lock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_execute_query_releases_to_captured_doris_user_owner(manager, monkeypatch):
+    pool = FakePool("alice-v1")
+    connect = AsyncMock(return_value=FakeAuthConnection())
+    create_pool = AsyncMock(return_value=pool)
+    monkeypatch.setattr(db_module.aiomysql, "connect", connect)
+    monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
+
+    await manager.create_or_replace_doris_user_pool("alice", "pw1")
+
+    async def fake_execute(self, sql, params=None, auth_context=None):
+        return QueryResult(data=[{"ok": 1}], metadata={}, execution_time=0.0, row_count=1, sql=sql)
+
+    monkeypatch.setattr(DorisConnection, "execute", fake_execute)
+
+    result = await manager.execute_query("s1", "SELECT 1", auth_context=doris_context())
+
+    assert result.row_count == 1
+    assert len(pool.release_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_connection_context_uses_owner_based_release(manager, monkeypatch):
+    pool = FakePool("alice-v1")
+    connect = AsyncMock(return_value=FakeAuthConnection())
+    create_pool = AsyncMock(return_value=pool)
+    monkeypatch.setattr(db_module.aiomysql, "connect", connect)
+    monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
+    await manager.create_or_replace_doris_user_pool("alice", "pw1")
+    token = set_current_auth_context(doris_context())
+
+    try:
+        async with manager.get_connection_context("s1") as connection:
+            assert connection.owner_pool is pool
+    finally:
+        reset_auth_context(token)
+
+    assert len(pool.release_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_static_token_release_uses_captured_owner_pool(manager, monkeypatch):
+    token = "static-token"
+    old_pool = FakePool("token-v1")
+    new_pool = FakePool("token-v2")
+    token_db_config = SimpleNamespace(
+        host="token-host",
+        port=9030,
+        user="token_user",
+        password="token_pw",
+        database="token_db",
+        charset="utf8",
+    )
+    manager.token_manager = SimpleNamespace(get_database_config_by_token=lambda raw: token_db_config)
+    create_pool = AsyncMock(return_value=old_pool)
+    monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
+
+    connection = await manager.get_connection_for_token(token, "s1")
+    token_hash = manager._get_token_hash(token)
+    manager.token_pools[token_hash] = new_pool
+
+    await manager.release_connection_for_token(token, connection)
+
+    assert old_pool.release_calls == [connection.connection]
+    assert new_pool.release_calls == []
+
+
+@pytest.mark.parametrize(
+    ("pool_kind", "route_key"),
+    [
+        ("doris_user", "doris_user:alice"),
+        ("static_token", "static_token:tokenhash"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_release_routed_connection_releases_closed_raw_to_captured_owner(
+    manager,
+    pool_kind,
+    route_key,
+):
+    old_owner = FakePool(f"{pool_kind}-old")
+    current_pool = FakePool(f"{pool_kind}-current")
+    raw_connection = FakeRawConnection("closed-raw")
+    raw_connection.closed = True
+    connection = DorisConnection(
+        raw_connection,
+        "s1",
+        pool_kind=pool_kind,
+        route_key=route_key,
+        owner_id=f"{route_key}:gen:1",
+        generation=1,
+        owner_pool=old_owner,
+    )
+
+    if pool_kind == "doris_user":
+        manager.doris_user_pools["alice"] = current_pool
+    else:
+        manager.token_pools["tokenhash"] = current_pool
+
+    await manager.release_routed_connection(connection)
+
+    assert old_owner.release_calls == [raw_connection]
+    assert current_pool.release_calls == []
+    assert raw_connection.ensure_closed_calls == 0

--- a/test/utils/test_query_executor.py
+++ b/test/utils/test_query_executor.py
@@ -20,10 +20,13 @@ Query executor tests
 """
 
 import pytest
+from datetime import datetime
 from unittest.mock import Mock, AsyncMock, patch
 
-from doris_mcp_server.utils.query_executor import DorisQueryExecutor
+from doris_mcp_server.utils.query_executor import CachedQuery, DorisQueryExecutor, QueryRequest
 from doris_mcp_server.utils.config import DorisConfig
+from doris_mcp_server.utils.db import QueryResult
+from doris_mcp_server.utils.security import AuthContext
 
 
 class TestDorisQueryExecutor:
@@ -271,3 +274,74 @@ class TestDorisQueryExecutor:
             
             # Verify execute_query was called three times
             assert mock_execute.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_doris_oauth_cache_enabled_query_forces_no_cache(self, query_executor):
+        query_executor.query_cache.get = AsyncMock()
+        query_executor.query_cache.set = AsyncMock()
+        query_executor.query_optimizer.optimize_query = AsyncMock(return_value="SELECT 1")
+        query_executor.connection_manager.execute_query = AsyncMock(
+            return_value=QueryResult(
+                data=[{"one": 1}],
+                metadata={},
+                execution_time=0.01,
+                row_count=1,
+                sql="SELECT 1",
+            )
+        )
+        auth_context = AuthContext(
+            auth_method="doris_oauth",
+            roles=["doris_oauth_user"],
+            doris_user="alice",
+            oauth_scopes=["tool:call:exec_query"],
+            pool_key="doris_user:alice",
+        )
+
+        result = await query_executor.execute_query(
+            QueryRequest(
+                sql="SELECT 1",
+                session_id="s1",
+                user_id="alice",
+                cache_enabled=True,
+            ),
+            auth_context,
+        )
+
+        assert result.row_count == 1
+        query_executor.query_cache.get.assert_not_awaited()
+        query_executor.query_cache.set.assert_not_awaited()
+        query_executor.connection_manager.execute_query.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_static_or_global_cache_enabled_query_still_uses_query_cache(self, query_executor):
+        cached_result = QueryResult(
+            data=[{"cached": True}],
+            metadata={},
+            execution_time=0.01,
+            row_count=1,
+            sql="SELECT 1",
+        )
+        query_executor.query_cache.get = AsyncMock(
+            return_value=CachedQuery(
+                result=cached_result,
+                created_at=datetime.utcnow(),
+                ttl=300,
+            )
+        )
+        query_executor.query_cache.set = AsyncMock()
+        query_executor.connection_manager.execute_query = AsyncMock()
+
+        result = await query_executor.execute_query(
+            QueryRequest(
+                sql="SELECT 1",
+                session_id="s1",
+                user_id="legacy",
+                cache_enabled=True,
+            ),
+            AuthContext(auth_method="token"),
+        )
+
+        assert result is cached_result
+        query_executor.query_cache.get.assert_awaited_once()
+        query_executor.query_cache.set.assert_not_awaited()
+        query_executor.connection_manager.execute_query.assert_not_awaited()

--- a/test/utils/test_schema_extractor_doris_oauth_metadata_errors.py
+++ b/test/utils/test_schema_extractor_doris_oauth_metadata_errors.py
@@ -1,0 +1,184 @@
+import pytest
+
+from doris_mcp_server.utils.db import DorisUserPoolMissingError, QueryResult
+from doris_mcp_server.utils.schema_extractor import MetadataExtractor
+from doris_mcp_server.utils.security import AuthContext, reset_auth_context, set_current_auth_context
+
+
+METADATA_TOOL_CASES = [
+    ("get_db_list", "get_db_list_for_mcp", (None,)),
+    ("get_db_table_list", "get_db_table_list_for_mcp", ("db1", None)),
+    ("get_table_schema", "get_table_schema_for_mcp", ("tbl1", "db1", None)),
+    ("get_table_comment", "get_table_comment_for_mcp", ("tbl1", "db1", None)),
+    ("get_table_column_comments", "get_table_column_comments_for_mcp", ("tbl1", "db1", None)),
+    ("get_table_indexes", "get_table_indexes_for_mcp", ("tbl1", "db1", None)),
+    ("get_catalog_list", "get_catalog_list_for_mcp", ()),
+]
+
+VISIBLE_EMPTY_COLLECTION_CASES = [
+    ("get_db_list", "get_db_list_for_mcp", (None,), []),
+    ("get_db_table_list", "get_db_table_list_for_mcp", ("db1", None), []),
+    ("get_catalog_list", "get_catalog_list_for_mcp", (), []),
+]
+
+TABLE_SCOPED_NO_ROW_CASES = [
+    ("get_table_schema", "get_table_schema_for_mcp", ("tbl1", "db1", None)),
+    ("get_table_comment", "get_table_comment_for_mcp", ("tbl1", "db1", None)),
+    ("get_table_column_comments", "get_table_column_comments_for_mcp", ("tbl1", "db1", None)),
+    ("get_table_indexes", "get_table_indexes_for_mcp", ("tbl1", "db1", None)),
+]
+
+
+class FakeConnectionManager:
+    def __init__(self, *, rows=None, error=None, responses=None):
+        self.rows = rows if rows is not None else []
+        self.error = error
+        self.responses = list(responses) if responses is not None else None
+        self.calls = []
+
+    async def execute_query(self, session_id, sql, params=None, auth_context=None):
+        self.calls.append((session_id, sql, params, auth_context))
+        if self.error:
+            raise self.error
+        if self.responses is not None:
+            response = self.responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            rows = response
+        else:
+            rows = self.rows
+        return QueryResult(
+            data=rows,
+            metadata={},
+            execution_time=0.01,
+            row_count=len(rows),
+            sql=sql,
+        )
+
+
+def doris_context():
+    return AuthContext(
+        auth_method="doris_oauth",
+        user_id="alice",
+        doris_user="alice",
+        oauth_scopes=["tool:call:get_db_list"],
+        pool_key="doris_user:alice",
+    )
+
+
+async def _call_tool(method_name, args, connection_manager):
+    extractor = MetadataExtractor(db_name="db1", connection_manager=connection_manager)
+    method = getattr(extractor, method_name)
+    token = set_current_auth_context(doris_context())
+    try:
+        return await method(*args)
+    finally:
+        reset_auth_context(token)
+
+
+@pytest.mark.parametrize(("tool_name", "method_name", "args"), METADATA_TOOL_CASES)
+@pytest.mark.parametrize(
+    ("error", "error_code", "status_code"),
+    [
+        (DorisUserPoolMissingError("missing doris pool"), "DORIS_OAUTH_POOL_MISSING", 401),
+        (RuntimeError("Access denied; missing privilege"), "DORIS_OAUTH_METADATA_PERMISSION_DENIED", 403),
+        (RuntimeError(1142, "SELECT command denied to user"), "DORIS_OAUTH_METADATA_PERMISSION_DENIED", 403),
+        (RuntimeError("backend exploded"), "DORIS_OAUTH_METADATA_BACKEND_ERROR", 502),
+    ],
+)
+@pytest.mark.asyncio
+async def test_doris_oauth_metadata_errors_are_structured_failures(
+    tool_name,
+    method_name,
+    args,
+    error,
+    error_code,
+    status_code,
+):
+    response = await _call_tool(method_name, args, FakeConnectionManager(error=error))
+
+    assert response["success"] is False, tool_name
+    assert response["error_code"] == error_code
+    assert response["status_code"] == status_code
+    assert "result" not in response
+
+
+@pytest.mark.parametrize(("tool_name", "method_name", "args", "empty_result"), VISIBLE_EMPTY_COLLECTION_CASES)
+@pytest.mark.asyncio
+async def test_doris_oauth_true_empty_collection_metadata_results_are_not_backend_errors(
+    tool_name,
+    method_name,
+    args,
+    empty_result,
+):
+    response = await _call_tool(method_name, args, FakeConnectionManager(rows=[]))
+
+    assert response["success"] is True, tool_name
+    assert "error_code" not in response
+    assert response["result"] == empty_result
+
+
+@pytest.mark.parametrize(("tool_name", "method_name", "args"), TABLE_SCOPED_NO_ROW_CASES)
+@pytest.mark.asyncio
+async def test_doris_oauth_table_scoped_no_rows_are_structured_not_visible(
+    tool_name,
+    method_name,
+    args,
+):
+    response = await _call_tool(method_name, args, FakeConnectionManager(rows=[]))
+
+    assert response["success"] is False, tool_name
+    assert response["error_code"] == "DORIS_OAUTH_METADATA_NOT_VISIBLE"
+    assert response["status_code"] == 404
+    assert "result" not in response
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_empty_table_comment_is_success_when_table_row_exists():
+    response = await _call_tool(
+        "get_table_comment_for_mcp",
+        ("tbl1", "db1", None),
+        FakeConnectionManager(rows=[{"TABLE_COMMENT": ""}]),
+    )
+
+    assert response["success"] is True
+    assert "error_code" not in response
+    assert response["result"] == ""
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_empty_column_comments_are_success_when_column_rows_exist():
+    response = await _call_tool(
+        "get_table_column_comments_for_mcp",
+        ("tbl1", "db1", None),
+        FakeConnectionManager(
+            rows=[
+                {"COLUMN_NAME": "c1", "COLUMN_COMMENT": ""},
+                {"COLUMN_NAME": "c2", "COLUMN_COMMENT": None},
+            ]
+        ),
+    )
+
+    assert response["success"] is True
+    assert "error_code" not in response
+    assert response["result"] == {"c1": "", "c2": ""}
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_empty_indexes_are_success_after_visibility_check():
+    connection_manager = FakeConnectionManager(
+        responses=[
+            [],
+            [{"TABLE_VISIBLE": 1}],
+        ]
+    )
+    response = await _call_tool(
+        "get_table_indexes_for_mcp",
+        ("tbl1", "db1", None),
+        connection_manager,
+    )
+
+    assert response["success"] is True
+    assert "error_code" not in response
+    assert response["result"] == []
+    assert len(connection_manager.calls) == 2


### PR DESCRIPTION
## Doris OAuth Implementation Notes and Limitations

  This PR adds a Doris-backed OAuth mode. In this mode, the MCP server
  acts as the OAuth provider. Users sign in with their Doris username
  and password; the server validates those credentials against Doris and
  creates a dedicated per-user Doris connection pool. Subsequent MCP
  requests are bound to that user pool, and data/metadata authorization
  is ultimately enforced by Doris RBAC.

  ### Relationship With Existing OAuth

  `doris-oauth` is mutually exclusive with the existing external OAuth/
  OIDC mode. External OAuth/OIDC delegates identity to a third-party
  identity provider, while Doris OAuth uses Doris itself as the
  authentication and authorization backend. They cannot be enabled at
  the same time to avoid mismatches between MCP identity and Doris
  execution identity.

  ### Token Lifetime

  Doris OAuth access and refresh token lifetimes are configurable:

  - `DORIS_OAUTH_ACCESS_TOKEN_EXPIRE_SECONDS`, default `900`
  - `DORIS_OAUTH_REFRESH_TOKEN_EXPIRE_SECONDS`, default `86400`

  When an access token expires, the client must refresh it with a valid
  refresh token. When the refresh token expires or is revoked, the user
  must sign in again.

  ### Connection Pool Lifecycle

  A per-user Doris connection pool is created after successful login.
  Doris OAuth requests must execute through that bound user pool. If a
  token is valid but the corresponding user pool is missing, the request
  fails closed and never falls back to the global Doris service account.

  The current implementation closes Doris OAuth user pools during server
  shutdown and covers revoke-related paths. However, automatic pool
  disposal when access/refresh tokens naturally expire is not yet a
  complete capability. The following configuration is reserved:

  - `DORIS_OAUTH_GC_INTERVAL_SECONDS`
  - `DORIS_OAUTH_IDLE_TIMEOUT_SECONDS`

  These options should not be interpreted as full token-expiry-driven
  pool cleanup yet.

  ### DCR Limitations

  Basic Dynamic Client Registration support is included, with the
  following configuration:

  - `DORIS_OAUTH_DYNAMIC_CLIENT_REGISTRATION_MODE`
  - `DORIS_OAUTH_DCR_MAX_CLIENTS`
  - `DORIS_OAUTH_DCR_CLIENT_TTL_SECONDS`
  - `DORIS_OAUTH_DCR_RATE_LIMIT_PER_IP`

  DCR clients, authorization codes, access tokens, and refresh tokens
  are currently memory-only and process-local. They are not shared
  across workers, processes, or nodes.

  ### Multi-Worker and Multi-Node Limitations

  Doris OAuth is not currently a stateless horizontal-scaling
  implementation. Token state, DCR client state, authorization code
  state, and per-user Doris connection pools are all process-local.

  For this reason, the recommended deployment shape for Doris OAuth is:

  ```bash
  WORKERS=1

  True multi-worker or multi-node deployment requires a future shared
  token store, shared DCR client store, shared authorization code store,
  and either per-user pool reconstruction or sticky-session routing.

  ### Resource Cache and Metadata Isolation

  Doris OAuth must avoid cross-tenant metadata leakage. For example,
  database/table metadata visible to user A must not be cached and later
  exposed to user B. This PR adds safeguards around resource metadata
  caching so Doris OAuth resource and tool access remains scoped to the
  current Doris user, with final visibility controlled by Doris RBAC.