### PR TITLE
feat: add MCP 2026-07-28 protocol core

### DIFF
--- a/MCP-2026-07-28-AUDIT-REPORT.zh-CN.md
+++ b/MCP-2026-07-28-AUDIT-REPORT.zh-CN.md
@@ -1,0 +1,1020 @@
+# Apache Doris MCP Server 对 MCP 2026-07-28 的完整审计报告
+
+> 审计日期：2026-07-29
+> 审计对象：`apache/doris-mcp-server`
+> 仓库基线：`0e843ae3432115ea5895fbd90a97d495c77f911c`（`master`，2026-06-11）
+> 协议基线：MCP `2026-07-28`，规范提交 `5f5440bb26a62e2cf3440b92da5a667efa03b267`
+> Python SDK 基线：`mcp` `v2.0.0`，提交 `6f69a3758ebf2ee55ce050f58b470ce11af71133`
+
+## 一、执行摘要
+
+### 1. 最终判断
+
+当前 Doris MCP Server **不兼容 MCP 2026-07-28**。这不是“缺少少数新增能力”，而是协议生命周期、传输语义、消息结构、错误模型和鉴权边界都仍停留在旧协议。
+
+更严重的是，真实 HTTP 探针证明：
+
+1. 服务器要求旧版 `Mcp-Session-Id`，无法接受新版无会话请求；
+2. 合法的新版 `server/discover` 请求进入旧 SDK 后，会产生未捕获的协议解析异常；
+3. 请求返回 HTTP 500 后，服务进程随 AnyIO `TaskGroup` 一起退出；
+4. 后续 `/health` 也无法连接。
+
+因此，当前版本面对会主动探测 2026-07-28 的新客户端时，不只是“协商失败”，而是存在**远程拒绝服务风险**。
+
+### 2. 发布建议
+
+在完成迁移和验收前：
+
+- 不应宣称支持 MCP 2026-07-28；
+- 不应把当前 HTTP 模式作为面向公网或不可信网络的生产服务发布；
+- 不应继续以“production-ready”“100%”等措辞描述当前质量门禁；
+- 可以继续将现版本定位为旧协议兼容版，但必须限定支持范围，并先修复异常请求导致进程退出、默认凭证、CORS 和查询参数令牌问题。
+
+### 3. 风险概览
+
+本报告的 P0/P1/P2 表示修复与发布优先级，不等同于 CVSS 定级。
+
+| 等级 | 数量 | 代表性问题 |
+|---|---:|---|
+| P0 / 发布阻断 | 4 | 新版合法请求可导致进程退出；完全不支持 2026-07-28；任意 Origin + 凭证式 CORS；已知固定默认令牌与默认匿名访问组合 |
+| P1 / 高优先级 | 10 | OAuth audience/resource 边界、外部 OAuth Bearer 链路断裂、错误被包装成成功、明文令牌多进程写入、健康检查失真、客户端包入口损坏、无 CI/一致性门禁 |
+| P2 / 中优先级 | 10 | 重复架构、类型和 lint 债务、部署配置冲突、依赖分层、文档漂移、时间 API 弃用等 |
+
+### 4. 已有优点
+
+本报告不是对项目已有工作的否定。当前代码有几项值得保留的基础：
+
+- Doris OAuth 已实现 PKCE S256、受保护资源元数据、scope、刷新令牌轮换、吊销和速率限制等机制；
+- SQL 安全单元测试本次为 `31 passed`；
+- OAuth/鉴权策略聚焦测试本次为 `97 passed`；
+- 当前 `0.6.1` 已不在 CVE-2025-66335 的已知受影响版本范围内；
+- Dockerfile 使用非 root 用户；
+- 工具列表当前由固定顺序构造，满足新版“确定性顺序”的方向；
+- 包可构建，锁文件可校验。
+
+问题主要在于：这些能力尚未被一个可靠的协议核心、鉴权边界和持续质量门禁统一起来。
+
+---
+
+## 二、审计范围、方法与限制
+
+### 1. 审计范围
+
+本次覆盖：
+
+- MCP 2026-07-28 官方规范、Schema、变更日志、弃用清单；
+- 官方 Python SDK `v2.0.0` 和迁移指南；
+- 官方 MCP Conformance Suite 的服务端无状态场景；
+- 当前仓库的协议入口、STDIO、Streamable HTTP、多进程模式；
+- tools、resources、prompts、错误语义和缓存语义；
+- 静态令牌、JWT、外部 OAuth、Doris OAuth；
+- 数据库访问和 SQL 安全边界；
+- 配置、Docker、打包、测试、lint、类型检查和文档；
+- 实际构建、实际启动和 HTTP 协议探针。
+
+### 2. 证据原则
+
+结论分为三类：
+
+- **已验证**：由本地测试、构建、静态工具或真实 HTTP 请求复现；
+- **代码确认**：由当前提交中的明确控制流确认；
+- **待运行环境验证**：需要真实 Doris、Redis、代理或浏览器环境才能最终确认。
+
+### 3. 限制
+
+- 本次没有可用的真实 Doris 集群，因此没有验证真实查询正确性、性能、FE/BE 故障恢复和 Doris 权限映射；
+- 官方 Conformance npm 包在本机拉取时没有返回，未能完成官方套件执行；已使用精确 Schema 对照和真实线级探针补充验证；
+- Bandit 的 B608 等结果是审计线索，不等同于已证明存在 SQL 注入；
+- 本报告没有修改业务代码，只新增审计报告。
+
+---
+
+## 三、MCP 2026-07-28 到底改变了什么
+
+官方资料：
+
+- [MCP 2026-07-28 规范](https://modelcontextprotocol.io/specification/2026-07-28)
+- [2026-07-28 变更日志](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [规范正式 Release](https://github.com/modelcontextprotocol/modelcontextprotocol/releases/tag/2026-07-28)
+- [Streamable HTTP 传输规范](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http)
+- [授权规范](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization)
+- [授权安全注意事项](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/security-considerations)
+- [Python SDK v2.0.0](https://github.com/modelcontextprotocol/python-sdk/releases/tag/v2.0.0)
+- [Python SDK v2 迁移指南](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md)
+- [官方 Conformance Suite](https://github.com/modelcontextprotocol/conformance)
+
+### 1. 九项主变化
+
+| 变化 | 2025-11-25 及以前 | 2026-07-28 |
+|---|---|---|
+| 会话 | HTTP 可使用 `Mcp-Session-Id` | 删除协议级会话和该 Header |
+| 初始化 | `initialize` + `notifications/initialized` | 删除握手；每个请求自描述 |
+| 请求元数据 | 初始化时协商 | 每个请求 `_meta` 必须带协议版本和客户端能力 |
+| 服务发现 | 无统一前置发现 | 服务器必须实现 `server/discover` |
+| 服务端通知 | GET/SSE、资源订阅等多种路径 | 统一为长 POST `subscriptions/listen` |
+| 工具性 RPC | `ping`、`logging/setLevel` 等 | 删除；日志级别改为请求级 `_meta` |
+| Tasks | 核心实验能力 | 移出核心，成为 `io.modelcontextprotocol/tasks` 扩展 |
+| 服务端反向请求 | roots/sampling/elicitation 由服务端发起 | 改为 MRTR：`InputRequiredResult` + 原请求重试 |
+| 结果与恢复 | 普通结果无统一类型，SSE 可恢复 | 所有结果有 `resultType`；删除 Last-Event-ID 重放 |
+
+### 2. 每个请求必须携带的新版元数据
+
+新版请求 `_meta` 的关键字段是完整命名空间键：
+
+```json
+{
+  "_meta": {
+    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+    "io.modelcontextprotocol/clientCapabilities": {},
+    "io.modelcontextprotocol/clientInfo": {
+      "name": "example-client",
+      "version": "1.0.0"
+    }
+  }
+}
+```
+
+前两个字段为必需；`clientInfo` 为 SHOULD。HTTP 中 `_meta` 协议版本必须与 `MCP-Protocol-Version` Header 一致。
+
+### 3. 新版服务端必须处理的基础语义
+
+- 必须实现 `server/discover`；
+- 普通结果必须包含 `resultType: "complete"`；
+- 需要客户端补充信息时返回 `resultType: "input_required"`；
+- HTTP POST 必须校验 `Mcp-Method`，带名称的请求还要校验 `Mcp-Name`；
+- Header 与请求体不匹配返回 `HeaderMismatch` `-32020`；
+- 缺少必要客户端能力返回 `-32021`；
+- 不支持协议版本返回 `-32022`，并告知支持版本；
+- `tools/list`、`prompts/list`、`resources/list`、`resources/read`、`resources/templates/list` 等可缓存结果必须带 `ttlMs` 和 `cacheScope`；
+- tools 应保持确定性顺序；
+- JSON Schema 按 2020-12 完整关键字处理，并限制 `$ref`、组合关键字带来的资源消耗。
+
+### 4. 授权侧变化
+
+- 授权服务器 SHOULD 在授权响应中返回 RFC 9207 `iss`；
+- 客户端看到 `iss` 后必须与记录的 issuer 比对；
+- Dynamic Client Registration 的 MCP 客户端必须提供适当的 `application_type`；
+- 客户端凭证必须按 authorization server issuer 隔离；
+- DCR 已进入弃用路径，新实现应优先 Client ID Metadata Documents；
+- Bearer token 不得放进 URI query；
+- Resource Server 不得接受不是为自己签发的 access token。
+
+### 5. 官方 Python SDK v2 的直接影响
+
+当前项目使用低层 `Server` API，因此迁移不是只改依赖版本：
+
+- 旧低层装饰器被移除，改为构造器 `on_*` handlers；
+- handler 接收 `(ctx, params)`；
+- handler 返回完整协议 Result 类型；
+- 字段名改为 Python `snake_case`；
+- SDK 不再自动替应用包装结果；
+- handler 抛异常不会再自动变成工具的 `isError: true`；
+- 推荐用统一高层 `MCPServer`，或按 v2 低层 API 显式实现错误和结果语义；
+- v2 Streamable HTTP 可在同一实现中处理新版无状态请求和旧版握手兼容。
+
+---
+
+## 四、当前项目基线
+
+### 1. 仓库状态
+
+```text
+branch: master
+HEAD:   0e843ae3432115ea5895fbd90a97d495c77f911c
+pull:   Already up to date
+```
+
+仓库没有 `.codegraph/`，因此本次按普通源码审计执行。
+
+### 2. 依赖和协议版本
+
+- 项目版本：`0.6.1`；
+- Python：`>=3.12`；
+- 声明依赖：`mcp>=1.8.0,<2.0.0`；
+- 锁定版本：`mcp==1.9.3`；
+- 运行时旧服务器协商到：`2025-03-26`；
+- 官方支持 2026-07-28 的 Python SDK：`2.0.0`。
+
+结论：依赖约束明确排除了实现新协议的 SDK 主版本。
+
+### 3. 当前协议结构
+
+```mermaid
+flowchart TD
+    A["CLI: stdio / http"] --> B["main.py 单进程实现"]
+    A --> C["multiworker_app.py 多进程实现"]
+    B --> D["旧版 mcp.server.lowlevel.Server"]
+    C --> E["另一份旧版 Server 与 handlers"]
+    B --> F["Resources / Prompts / Tools managers"]
+    C --> F
+    F --> G["Doris 连接池与 SQL 执行"]
+    B --> H["Static Token / JWT / OAuth 中间件"]
+    C --> H
+```
+
+单进程和多进程入口各自复制了服务器构造、协议 handlers、鉴权和 ASGI 组装。两者已经发生行为漂移：单进程 `stateless=False`，多进程 `stateless=True`，但两者都仍是 SDK 1.9 的旧协议实现。
+
+---
+
+## 五、MCP 2026-07-28 逐项符合性矩阵
+
+| 检查项 | 规范要求 | 当前状态 | 判定 |
+|---|---|---|---|
+| `server/discover` | MUST | 没有实现；合法请求可导致进程退出 | ❌ P0 |
+| 无协议会话 | 删除 `Mcp-Session-Id` | 单进程强制旧会话；多进程仍由旧 SDK 处理 | ❌ |
+| 删除初始化握手 | 每个请求自描述 | 仍依赖 `initialize`/`initialized` | ❌ |
+| 请求 `_meta` | 版本、客户端能力必需 | 无新版元数据解析/验证 | ❌ |
+| Result `_meta` | serverInfo SHOULD | 无 | ❌ |
+| `resultType` | 所有结果必需 | 全仓未实现 | ❌ |
+| `Mcp-Method` / `Mcp-Name` | HTTP POST 必须校验 | 未实现 | ❌ |
+| 标准协议错误 | `-32020/-32021/-32022` | 未实现 | ❌ |
+| `subscriptions/listen` | 新通知统一入口 | 未实现；仍保留 GET 兼容路径 | ❌ |
+| HTTP GET | 新版已移除 | 仍主动改写/兼容 GET | ❌ |
+| SSE resumability | 已移除 | 由旧 transport 语义主导 | ❌ |
+| 缓存提示 | 指定结果必须有 `ttlMs/cacheScope` | 未实现 | ❌ |
+| tools 顺序 | SHOULD 确定 | 手工固定列表 | ✅ |
+| MRTR | 需要客户端输入时采用 | 未实现；当前业务暂未依赖 | ⚠️ |
+| Tasks 扩展 | 核心已移除 | 当前未实现 Tasks | ✅ N/A |
+| JSON Schema 2020-12 | 完整关键字和资源边界 | 手工 schema，未见系统验证和资源上限 | ⚠️ |
+| DCR `application_type` | 客户端必须提供，服务端应校验 | 注册实现未校验/持久化 | ❌ |
+| 授权响应 `iss` | AS SHOULD 返回 | 未返回 | ❌ |
+| audience/resource | 只接受为本 RS 签发的 token | Doris OAuth 存在 resource 校验缺口；外部 OAuth 依赖 userinfo | ❌ |
+| Bearer query | MUST NOT | 多条链路接受 query token | ❌ |
+| Origin 防护 | 必须校验，防 DNS rebinding | 任意 Origin 被反射并允许 credentials | ❌ P0 |
+| 旧版兼容 | 可兼容早期客户端 | `2025-03-26` 初始化可成功 | ✅ 有限 |
+
+---
+
+## 六、关键缺陷详解
+
+### P0-1：合法新版请求可让 HTTP 服务进程退出
+
+**状态：已验证。**
+
+复现流程：
+
+1. 启动当前 HTTP 服务；
+2. 旧版 `initialize` 成功，返回 `protocolVersion: 2025-03-26`；
+3. 发送符合 2026-07-28 结构的 `server/discover`；
+4. 服务器返回 HTTP 500：`No response received`；
+5. 旧 SDK 对未知请求产生多分支 Pydantic `ValidationError`；
+6. 异常穿透 AnyIO `TaskGroup`，Uvicorn 进程退出；
+7. 再访问 `/health`，连接失败。
+
+在没有旧会话 ID 时，同一新版请求先返回 HTTP 400 “Missing session ID”，响应仍下发 `mcp-session-id`。这同时证明传输层仍以旧会话为核心。
+
+**影响：**
+
+- 默认匿名 HTTP 服务只要网络可达即可触发；
+- 开启鉴权后，任意合法客户端凭证持有者仍可能触发；
+- 新客户端的正常兼容性探测本身就可能造成服务中断；
+- 健康检查和进程编排会进入重启循环。
+
+**修复要求：**
+
+- 首选直接迁移 SDK v2，让 `server/discover` 由新版协议栈处理；
+- 在迁移完成前，协议解析失败必须被请求边界捕获，不能终止 ASGI lifespan；
+- 对未知方法返回 JSON-RPC `Method not found`，而不是传播模型解析异常；
+- 加一条回归测试：任意未知或新版方法都不得影响下一次 `/health` 和 `tools/list`。
+
+### P0-2：协议核心完全不具备 2026-07-28 互操作性
+
+**状态：代码确认 + 真实探针验证。**
+
+主要证据：
+
+- [`pyproject.toml`](./pyproject.toml) 明确限制 `mcp<2.0.0`；
+- [`main.py`](./doris_mcp_server/main.py) 使用旧版低层装饰器和 `InitializationOptions`；
+- 单进程 HTTP 使用 `stateless=False`；
+- 多进程的 `stateless=True` 只是 SDK 1.9 的传输配置，并不会自动实现 2026-07-28；
+- 代码中没有 `server/discover`、新版 `_meta`、`resultType`、`subscriptions/listen`、`ttlMs`、`cacheScope`、MRTR 和新版错误码。
+
+**影响：**
+
+- 新客户端无法使用；
+- 协议协商、缓存、安全代理、通知和错误处理均不符合最新版；
+- 继续在旧低层 API 上补丁式兼容，会扩大下一轮迁移成本。
+
+**修复要求：**
+
+- 升级 `mcp>=2.0,<3.0`；
+- 采用 SDK v2 高层 `MCPServer`，或完整迁移低层 `on_*` handlers；
+- 以新版无状态路径为主，利用 SDK 的旧版兼容能力保留现有客户端；
+- 删除所有依赖 SDK 私有实现的 monkey patch。
+
+### P0-3：Origin/CORS 允许不可信网页携带凭证调用 MCP
+
+**状态：已验证。**
+
+当前 [`mcp_cors.py`](./doris_mcp_server/auth/mcp_cors.py) 会反射任意 Origin；两个 ASGI 入口还配置了：
+
+```python
+allow_origins=["*"]
+allow_credentials=True
+```
+
+真实预检请求：
+
+```text
+Origin: https://evil.example
+```
+
+得到：
+
+```text
+Access-Control-Allow-Origin: https://evil.example
+Access-Control-Allow-Credentials: true
+```
+
+同时允许 `Authorization`、`content-type` 和 MCP 会话 Header。
+
+**影响：**
+
+- 违反 Streamable HTTP 对 Origin 校验和 DNS rebinding 防护的要求；
+- 浏览器存在可用凭证时，恶意页面可能跨源调用 MCP；
+- 配合监听 `0.0.0.0`、弱/固定令牌或本地代理，会把本地数据库能力暴露给网页。
+
+**修复要求：**
+
+- 默认只绑定 `127.0.0.1`；
+- 默认拒绝所有跨域 Origin；
+- 显式 allowlist，且只允许可信 HTTPS Origin；
+- 不需要浏览器凭证时关闭 `allow_credentials`；
+- 使用 SDK v2 的 transport security / DNS rebinding 防护；
+- 测试 `Origin: null`、攻击域、同源、伪造 Host 和反向代理场景。
+
+### P0-4：固定默认令牌、默认匿名访问和数据库工具形成危险组合
+
+**状态：代码确认。**
+
+当前存在：
+
+- 鉴权功能默认全部关闭，启动日志明确提示匿名访问；
+- [`token_manager.py`](./doris_mcp_server/auth/token_manager.py) 内置可预测的 admin/analyst/readonly 固定令牌；
+- 仓库跟踪的 `tokens.json` 保存令牌记录；
+- legacy 配置存在 `default_secret`；
+- README 直接展示固定默认令牌；
+- 文档大量使用 `0.0.0.0` 部署方式。
+
+即使单项是为了本地快速体验，组合后仍会形成生产误配置陷阱。
+
+**修复要求：**
+
+- 删除全部可工作的默认令牌和默认 secret；
+- 首次启用静态令牌模式时强制显式配置高熵密钥；
+- 非 loopback 地址启动且无鉴权时直接拒绝启动，除非显式危险开关；
+- `tokens.json` 只能作为无凭证模板，不能包含可用 token；
+- 文档把匿名模式标成仅限本机开发。
+
+---
+
+### P1-1：外部 OAuth 的 Bearer 认证链路字段不一致
+
+**状态：代码确认。**
+
+HTTP 中间件将 `Authorization: Bearer ...` 保存为：
+
+```python
+auth_info["token"]
+```
+
+但外部 OAuth 分支只接受：
+
+```python
+auth_info["access_token"]
+```
+
+或 `code + state`。因此普通 Bearer token 进入外部 OAuth 流程时无法被识别。
+
+**修复要求：**
+
+- 只定义一种规范化后的内部凭证结构；
+- 在鉴权边界统一解析 Header，后续 provider 不再自行猜字段；
+- 用端到端测试覆盖 Bearer → middleware → provider → AuthContext。
+
+### P1-2：OAuth audience/resource 边界不完整
+
+**状态：代码确认。**
+
+外部 OAuth 主要通过 provider 的 userinfo 接口判断 token 有效，没有证明 token 的 audience/resource 是 Doris MCP Server。
+
+Doris OAuth 的授权事务允许 resource 是 MCP resource 或 issuer，但 `authenticate_access_token` 没有再次确认 token record 的 resource 与当前 MCP resource 一致。
+
+**影响：**
+
+- 可能接受为其他资源签发的 token；
+- 多个 Resource Server 共用 Authorization Server 时出现 confused deputy；
+- 违反 MCP OAuth 的 resource indicator 边界。
+
+**修复要求：**
+
+- token 入口强制校验 issuer、audience/resource、scope、expiry、revocation；
+- access token 记录必须绑定规范化后的 MCP resource URI；
+- 不以 userinfo 成功代替 audience 校验；
+- 用两个不同 resource 的集成测试证明 token 不可串用。
+
+### P1-3：OAuth 2026 细节未跟进
+
+**状态：代码确认。**
+
+- DCR 未验证或持久化 `application_type`；
+- 授权成功和错误重定向均不返回 RFC 9207 `iss`；
+- token endpoint 没有显式校验请求中的 `resource` 与授权码绑定值；
+- 仍只围绕 DCR 设计，没有 Client ID Metadata Documents 路线。
+
+**修复要求：**
+
+- 校验 `application_type` 与 redirect URI 规则；
+- 所有授权响应增加 `iss`；
+- 授权码兑换再次校验 resource；
+- 保留 DCR 兼容，但增加 Client ID Metadata Documents；
+- issuer 变化时让客户端重新注册，不复用旧凭证。
+
+### P1-4：Bearer 和管理令牌可通过 query string 传递
+
+**状态：代码确认。**
+
+至少三条链路接受 query token：
+
+- MCP 请求 `?token=...`；
+- MCP auth middleware 的 legacy query token；
+- 管理页面 `?admin_token=...`。
+
+README 也给出管理令牌 query 示例。
+
+**影响：**
+
+令牌会进入浏览器历史、Referer、代理日志、APM、服务器 access log、截图和复制链接。
+
+**修复要求：**
+
+- 删除所有 query token 入口；
+- 只接受 `Authorization: Bearer` 或专用管理 Header；
+- 管理 UI 改为一次性表单输入并只保存在内存；
+- 对旧 query 入口返回明确弃用错误，不能继续静默接受。
+
+### P1-5：业务错误被伪装成协议成功
+
+**状态：代码确认。**
+
+当前 handlers 中：
+
+- `list_resources`、`list_tools`、`list_prompts` 捕获异常后返回空列表；
+- resource 和 prompt 异常常被包装为 JSON 字符串内容；
+- tool manager 捕获大量异常后返回错误 JSON 字符串；
+- 外层仍返回普通 `TextContent`，没有可靠设置 `isError: true`。
+
+**影响：**
+
+- 客户端误把故障当成“没有资源/工具”；
+- Agent 可能把错误 JSON 当作业务数据继续推理；
+- 监控无法区分空结果、权限拒绝、Doris 不可达和服务器异常；
+- SDK v2 取消自动错误包装后，迁移时问题会更明显。
+
+**修复要求：**
+
+- 建立统一错误分类：协议错误、鉴权错误、参数错误、Doris 错误、内部错误；
+- list 失败不能返回空列表；
+- 工具业务失败返回 `CallToolResult(is_error=True, ...)`；
+- 非预期异常转为稳定的内部错误 ID，详细堆栈只写服务端日志；
+- 每类错误建立契约测试。
+
+### P1-6：令牌持久化不适合多进程
+
+**状态：代码确认。**
+
+静态令牌以 JSON 明文保存；多处直接：
+
+```python
+open(path, "w")
+```
+
+没有文件锁、临时文件、`fsync`、原子 `os.replace` 或版本冲突控制。多 worker 各自持有 manager 并可能同时写同一文件。
+
+另有保存路径会把无法恢复的旧 raw token 替换为类似 `<existing_token_hash_...>` 的占位文本，持久化语义不一致。
+
+**影响：**
+
+- 并发管理操作可能丢更新或损坏文件；
+- 容器重启和横向扩容无法保持一致状态；
+- 明文 token 和可能的数据库口令扩大泄露面。
+
+**修复要求：**
+
+- 生产模式使用 SQLite/PostgreSQL/Redis 等统一存储；
+- 只存不可逆 token digest，展示值仅在创建时返回一次；
+- 单机文件方案至少采用文件锁和原子替换；
+- 数据库密码进入 Secret Manager/KMS，不写 token JSON；
+- 所有 worker 使用同一吊销和权限状态。
+
+### P1-7：健康检查只证明 HTTP 进程存在，不证明服务可用
+
+**状态：已验证。**
+
+在 Doris 初始化失败时，`/health` 仍返回：
+
+```json
+{"status": "healthy", "service": "doris-mcp-server"}
+```
+
+**影响：**
+
+- Kubernetes/Docker 会把不可查询的实例送入流量；
+- 数据库故障无法触发正确摘流；
+- 当前新版协议异常导致进程退出前，也没有协议能力检查。
+
+**修复要求：**
+
+- `/live`：只检查进程/event loop；
+- `/ready`：检查配置归一化、Doris 最小探针、鉴权依赖和协议服务就绪；
+- `/health` 可汇总但必须标注 degraded/unready；
+- 对依赖探针增加短超时和缓存，避免健康检查压垮 Doris。
+
+### P1-8：发布的 `doris-mcp-client` 命令不可运行
+
+**状态：已验证。**
+
+`pyproject.toml` 声明：
+
+```toml
+doris-mcp-client = "doris_mcp_server.client:main"
+```
+
+实际客户端在 `doris_mcp_client/client.py`，构建 wheel 只包含 `doris_mcp_server`。安装 wheel 后执行命令得到：
+
+```text
+ModuleNotFoundError: No module named 'doris_mcp_server.client'
+```
+
+**修复要求：**
+
+- 将 entry point 改到真实模块；
+- 明确把 `doris_mcp_client` 纳入 wheel；
+- CI 中对新建虚拟环境安装 wheel，并运行两个 CLI 的 `--help` smoke test。
+
+### P1-9：测试套件不是可重复的发布门禁
+
+**状态：已验证。**
+
+完整 pytest：
+
+```text
+384 collected
+319 passed
+45 failed
+12 skipped
+8 errors
+267 warnings
+coverage: 36%
+```
+
+失败构成：
+
+- 45 个 SQL injection API 测试硬依赖外部已启动服务，没有 fixture 或条件 skip；
+- 8 个 end-to-end setup error 来自 mock config 未执行有效鉴权配置归一化；
+- `pyproject.toml` 写的是 `testpaths = ["tests"]`，实际目录是 `test`，pytest 只能 fallback；
+- 核心入口覆盖率低：`main.py` 23%、`multiworker_app.py` 22%、`tools_manager.py` 36%。
+
+仓库也没有 `.github/workflows`。
+
+**修复要求：**
+
+- 把纯单元、组件、真实 Doris、外部服务安全测试分成明确 marker；
+- 外部测试要么自行启动依赖，要么明确 skip，不能把“连接失败”算测试失败；
+- 修复 `testpaths`；
+- 为 HTTP 生命周期、协议探针、异常隔离和鉴权矩阵补测试；
+- 增加 GitHub Actions：Python 3.12、锁文件、测试、ruff、mypy、bandit、wheel smoke、conformance。
+
+### P1-10：私有 monkey patch 与双实现让协议升级非常脆弱
+
+**状态：代码确认。**
+
+`main.py` 和 `multiworker_app.py` 都会：
+
+- 修改 `typing._check_generic`；
+- 删除已导入的 MCP 模块；
+- 重新加载模块以兼容 `RequestContext`；
+- 复制大段相同的 Server/handler 构造。
+
+这是对 Python 和 SDK 私有实现的全局进程级修改，在 Uvicorn、测试、插件或其他库已经导入 MCP 时尤其危险。
+
+**修复要求：**
+
+- 删除全部 monkey patch；
+- 严格使用 SDK 公共 API；
+- 单进程/多进程共享一个 `create_server()` 和一个 `create_asgi_app()`；
+- worker 数只影响部署，不应改变协议语义。
+
+---
+
+## 七、工程、部署与维护问题
+
+### P2-1：静态质量债务已经妨碍安全迁移
+
+本次结果：
+
+```text
+ruff src:  4,297 errors（3,754 可自动修复）
+mypy:      889 errors in 37 files（检查 47 个源码文件）
+bandit:    107 findings
+           High 3 / Medium 65 / Low 39
+```
+
+Ruff 主要是空白、旧 typing 写法、未使用 import、import 顺序和未使用变量。Mypy 大量报错意味着协议类型、URI、handler 返回值和配置对象没有可靠静态边界。
+
+Bandit 中 65 条 B608 是动态 SQL 审计线索；3 条 High 是 MD5 用于缓存/追踪标识，不能直接解释成密码学漏洞。应逐条分诊，而不是把工具总数等同于可利用漏洞。
+
+建议采用“先基线、再收紧”：
+
+1. 机械格式问题一次性修复；
+2. 新增代码要求 ruff 零新增；
+3. 先把协议入口、鉴权、query executor 设为 mypy strict；
+4. 再逐模块消除存量；
+5. Bandit 对确认安全的标识用途写精确注释，对 SQL 构造做 taint 审计和真实回归。
+
+### P2-2：数据库与工具层职责过重
+
+核心文件体量很大：
+
+- `tools_manager.py` 约 1,926 行；
+- `db.py` 约 2,246 行；
+- `schema_extractor.py` 约 2,176 行；
+- `security.py` 约 1,559 行；
+- `main.py` 约 1,030 行。
+
+工具 schema、注册逻辑、执行分派、错误包装和审计混杂；工具定义在装饰器和 `list_tools` 中存在多份来源，容易产生 schema 与执行器漂移。
+
+建议建立单一 Tool Definition Registry，由同一对象生成：
+
+- MCP tool schema；
+- 参数验证模型；
+- 权限策略；
+- 执行 handler；
+- 审计字段；
+- 文档。
+
+### P2-3：Docker Compose 存在可直接导致部署失败的配置问题
+
+代码确认：
+
+- MCP healthcheck 请求 `localhost:8082/health`，服务实际监听 3000；
+- metrics 配置和端口映射不一致；
+- MCP 与 Grafana 存在主机端口 3000 冲突；
+- Compose 固定写入 Doris、Redis、Grafana 弱密码；
+- 多个镜像使用可变 `latest`；
+- Doris 镜像版本较旧。
+
+建议：
+
+- 端口和环境变量只保留单一来源；
+- secrets 改用 `.env` 模板 + Docker Secret/Kubernetes Secret；
+- 镜像固定 digest 或明确版本；
+- CI 启动 Compose 并执行 readiness；
+- `docker compose config` 和端口冲突检查加入门禁。
+
+### P2-4：运行时依赖与开发依赖混杂
+
+`pytest`、`pytest-cov`、`pytest-asyncio` 等测试包被放进运行时依赖，同时又存在开发依赖重复。
+
+影响：
+
+- wheel 体积和供应链面增加；
+- 用户安装服务时带入不必要工具；
+- 锁文件和漏洞扫描噪音扩大。
+
+应把测试、lint、build 工具全部放到 dev/test dependency group。
+
+### P2-5：版本、命令和文档漂移
+
+已发现：
+
+- package 是 0.6.1，README 安装示例仍有 0.6.0；
+- 配置中的 server version 仍有 0.4.1；
+- 真实旧初始化响应的 `serverInfo.version` 是 SDK 1.9.3，而不是产品版本；
+- Makefile `start-sse` 调用 CLI 不支持的 `sse` transport；
+- project URL 声明 CHANGELOG，但仓库无 `CHANGELOG.md`；
+- README 对生产成熟度的表述与当前失败门禁不一致。
+
+版本必须来自一个构建时单一来源，并在 `server/discover` / legacy serverInfo / CLI / package metadata 中一致。
+
+### P2-6：`debug=True` 不适合生产
+
+两个 Starlette 应用都设置 `debug=True`，同时部分路径把原始异常文本返回客户端。
+
+应默认关闭 debug；用相关 ID 连接客户端安全错误和服务端完整堆栈。
+
+### P2-7：GET 兼容和宽路径匹配扩大协议面
+
+当前为了 Dify 兼容会重写 MCP GET，并接受 `/mcp/...`。新版已移除 GET 入口。
+
+建议：
+
+- 新版端点只接受规范的方法和精确路径；
+- 旧 Dify 兼容放到独立、显式启用的 legacy adapter；
+- 不让 legacy 行为污染核心协议处理器。
+
+### P2-8：没有分页和合理缓存策略
+
+大型 Doris 集群的表、视图、分区、物化视图和 schema 可能很大。当前 list 类接口没有形成明确分页策略，新版 `ttlMs/cacheScope` 也未实现。
+
+建议：
+
+- 对可分页协议接口实现 cursor；
+- 对业务工具的超大列表设计 limit/cursor/filter；
+- 元数据结果可使用短 TTL；
+- 任何受用户权限影响的结果必须 `cacheScope: "private"`；
+- 缓存键必须包含 principal、scope、Doris endpoint 和数据库上下文。
+
+### P2-9：监控工具存在内部网络访问面，需要约束
+
+监控功能会根据 Doris 元数据访问 FE/BE HTTP 地址。若这些地址或配置可被低可信输入影响，可能形成 SSRF/内部探测能力。
+
+本次未证明可利用，但应：
+
+- 只允许已配置的 Doris 节点；
+- 拒绝 link-local、metadata service 和非预期协议；
+- 设置连接/读取超时、响应体上限和重定向策略；
+- 把监控类工具纳入单独权限 scope。
+
+### P2-10：弃用 API 和告警积累
+
+测试中出现 267 条 warning，其中包含 `datetime.utcnow()` 弃用。应统一使用带时区的 UTC 时间，避免 OAuth expiry、审计时间和缓存 TTL 的时区错误。
+
+---
+
+## 八、安全专项判断
+
+### 1. SQL 注入
+
+审慎结论：
+
+- 当前 `0.6.1` 已不在 CVE-2025-66335 公布的受影响范围；
+- 聚焦 SQL 安全单元测试 `31 passed`；
+- 但 API 级注入测试依赖外部进程，本次完整套件中 45 项全部失败，不能作为可重复门禁；
+- Bandit 仍标出 65 个动态 SQL 构造点，其中不少已有 identifier 校验或 quoting，不能直接判成漏洞。
+
+所以正确表述不是“已发现 65 个 SQL 注入”，也不是“SQL 注入已经彻底解决”，而是：
+
+> 已有修复和单元防线，但缺少自包含的真实 API 回归门禁，动态标识符和管理 SQL 仍需按数据流逐项审计。
+
+建议新增：
+
+- 标识符白名单与转义的 property-based tests；
+- 每个动态 SQL 构造的 source → validation → sink 清单；
+- 真实 Doris 容器的只读和写入权限矩阵；
+- 多语句、注释、Unicode、编码、反引号、模板变量和 SSRF 联动测试；
+- 禁止凭字符串前缀判断只读语句，使用解析器或强制只读数据库账号。
+
+### 2. 权限模型
+
+项目已经有 operation policy 和多类认证，但需要把“工具是否可见”和“工具是否可执行”统一：
+
+- `tools/list` 不能向低权限用户泄露不可执行的敏感工具；
+- 缓存不能跨 principal 共享私有工具列表；
+- 服务端执行时必须再次授权，不能只靠列表过滤；
+- 所有工具应声明最小 scope；
+- 数据库账号权限是最后一道边界，MCP admin 不应默认映射 Doris root。
+
+### 3. 密钥和敏感信息
+
+- 不把 token 放在 query；
+- 不记录 Authorization Header；
+- 不保存 raw token；
+- 数据库密码不进入普通 JSON；
+- 日志、错误、追踪和工具结果统一做 secret redaction；
+- 测试默认凭证必须与生产配置隔离。
+
+---
+
+## 九、建议的目标架构
+
+```mermaid
+flowchart TD
+    C["MCP Clients\n2026-07-28 + legacy"] --> T["SDK v2 Transport Security\nOrigin / Host / Header validation"]
+    T --> A["Authentication Boundary\nBearer normalization + issuer/resource/scope"]
+    A --> P["Single Protocol Core\nserver/discover + stateless + typed results"]
+    P --> R["Tool Definition Registry\nschema + policy + handler + audit"]
+    R --> Q["Doris Query Service\nvalidated identifiers + bounded execution"]
+    P --> S["Subscription Service\nonly when real change events exist"]
+    A --> I["Durable Identity Store\nhashed tokens + revocation + atomic writes"]
+    Q --> O["Telemetry\nOpenTelemetry + redaction"]
+    I --> O
+```
+
+### 1. 一个协议核心
+
+建立：
+
+```text
+create_mcp_server(settings) -> MCPServer
+create_asgi_app(settings)    -> ASGI app
+```
+
+STDIO、单 worker、多 worker 只能是 transport/deployment 参数，不再复制 handlers。
+
+### 2. SDK v2 优先
+
+优先高层 `MCPServer`，原因：
+
+- 自动支持 `server/discover` 和现代 metadata/header；
+- 可同时服务新旧协议；
+- 减少手工 Result 包装和底层 transport 细节；
+- 避免继续依赖私有 monkey patch。
+
+只有确有 Doris 特殊传输需求时才使用低层 `Server`，并严格按 v2 的 `(ctx, params) -> Result` 契约实现。
+
+### 3. 显式状态
+
+新版协议无会话。需要跨调用状态时：
+
+- 服务端创建不透明 handle；
+- handle 作为普通工具参数返回和传入；
+- handle 绑定 principal、scope、expiry 和 resource；
+- 状态进入共享存储，不能绑定某个 worker 内存；
+- 客户端不可自行伪造或越权复用。
+
+### 4. 统一结果和错误
+
+所有成功结果：
+
+```json
+{
+  "resultType": "complete",
+  "_meta": {
+    "io.modelcontextprotocol/serverInfo": {
+      "name": "doris-mcp-server",
+      "version": "..."
+    }
+  }
+}
+```
+
+需要用户/客户端补充信息时才使用 MRTR。Doris 业务失败与 JSON-RPC 协议失败分开建模。
+
+### 5. 多租户安全缓存
+
+- 公共静态 schema 才能用 `cacheScope: "public"`；
+- 受权限、数据库、用户或行列策略影响的结果必须 `private`；
+- cache key 至少包含 issuer、principal、scopes、Doris cluster、catalog/database 和参数；
+- 权限变化和 token 吊销应使私有缓存失效。
+
+---
+
+## 十、迁移路线图
+
+### 阶段 0：立即止血
+
+目标：当前旧版服务不再因正常或畸形请求退出。
+
+- 捕获未知方法/模型解析异常，保持进程存活；
+- 默认 loopback；非 loopback + 无鉴权时拒绝启动；
+- 关闭任意 Origin、credentials CORS 和 `debug=True`；
+- 删除 query token；
+- 删除固定默认 token/secret；
+- 修复 `/live`、`/ready`；
+- 文档明确只支持到当前旧协议，不宣称 2026-07-28。
+
+验收：连续发送未知方法、新版 `server/discover`、畸形 JSON 和 Header mismatch 后，服务仍可处理下一请求。
+
+### 阶段 1：协议核心迁移
+
+- 升级官方 Python SDK v2；
+- 删除 monkey patch；
+- 合并单/多 worker 实现；
+- 实现/启用 `server/discover`；
+- 每请求新版 `_meta` 和标准 Header 校验；
+- 去除协议会话依赖；
+- 全部 Result 增加 `resultType`；
+- 实现 `ttlMs/cacheScope`；
+- 保持官方 SDK 提供的 legacy compatibility。
+
+验收：官方 `server-stateless` 场景通过，手工新旧客户端均成功。
+
+### 阶段 2：错误和工具模型重构
+
+- 建立 Tool Definition Registry；
+- 全部 handler 返回类型化 Result；
+- 统一 `isError` 和 JSON-RPC error；
+- 增加分页、超时、取消和输出上限；
+- 给工具列表和执行同时做权限过滤。
+
+验收：Doris 不可达、超时、权限不足、参数错误、内部错误均有不同且稳定的协议表现。
+
+### 阶段 3：授权和状态治理
+
+- 统一 Bearer 解析；
+- 校验 issuer/resource/audience/scope；
+- DCR `application_type`、授权响应 `iss`；
+- 增加 Client ID Metadata Documents；
+- 令牌改为不可逆摘要和共享持久化；
+- 明确 handle、缓存和 worker 的 principal 绑定。
+
+验收：两个 issuer、两个 resource、三个 scope 的交叉矩阵全部符合最小权限。
+
+### 阶段 4：持续交付门禁
+
+- GitHub Actions；
+- 自包含 pytest；
+- 官方 conformance；
+- ruff/mypy/bandit；
+- wheel 安装 smoke；
+- Docker Compose readiness；
+- 真实 Doris 集成矩阵；
+- 自动生成协议支持矩阵和 CHANGELOG。
+
+### 阶段 5：按需求增加新版高级能力
+
+- 只有存在真实变更源时才实现 `subscriptions/listen`；
+- 交互式工具再引入 MRTR；
+- 长任务确有需求时再评估 `io.modelcontextprotocol/tasks` 扩展；
+- OpenTelemetry 传播 `traceparent`、`tracestate`、`baggage`，全链路脱敏。
+
+---
+
+## 十一、建议的发布验收清单
+
+以下全部通过，才建议标记“支持 MCP 2026-07-28”：
+
+### 协议
+
+- [ ] `server/discover` 在 STDIO 和 HTTP 均通过；
+- [ ] 新版请求不要求 `Mcp-Session-Id`；
+- [ ] `_meta` 缺失、版本不支持、Header 不一致返回规范错误；
+- [ ] 所有 Result 有 `resultType`；
+- [ ] list/read 结果有正确 `ttlMs/cacheScope`；
+- [ ] 标准 `Mcp-Method` / `Mcp-Name` 校验；
+- [ ] 新版删除的方法不会走旧语义；
+- [ ] legacy 客户端兼容路径独立测试；
+- [ ] 官方 Conformance `server-stateless` 全通过。
+
+### 稳定性
+
+- [ ] 未知方法、畸形 JSON、取消、断流不会终止进程；
+- [ ] `/live` 与 `/ready` 语义准确；
+- [ ] Doris 故障、恢复和超时经过真实环境验证；
+- [ ] 多 worker 状态和吊销一致；
+- [ ] 输出大小、并发和查询时长有上限。
+
+### 安全
+
+- [ ] 默认无固定 token/secret；
+- [ ] 非 loopback 必须鉴权；
+- [ ] query token 全部删除；
+- [ ] Origin/Host/DNS rebinding 测试通过；
+- [ ] issuer/resource/audience/scope 严格校验；
+- [ ] 私有 cache 不跨 principal；
+- [ ] token 只存 digest；
+- [ ] SQL 注入 API 测试可自包含运行；
+- [ ] 真实 Doris 最小权限账号通过。
+
+### 工程
+
+- [ ] pytest 全绿且无外部隐式前提；
+- [ ] ruff 零错误；
+- [ ] 协议/鉴权核心 mypy strict；
+- [ ] Bandit findings 已逐项分诊；
+- [ ] wheel 安装后的 server/client CLI smoke 通过；
+- [ ] Docker Compose 无端口冲突、弱密码和错误 healthcheck；
+- [ ] 文档版本、命令、能力声明与产物一致。
+
+---
+
+## 十二、本次执行回执
+
+| 检查 | 结果 |
+|---|---|
+| `git pull --ff-only` | 已是最新 |
+| `uv sync --frozen` | 通过 |
+| `uv lock --check` | 通过 |
+| `uv build` | 通过 |
+| 安装 wheel 后 server/client CLI | client 失败，入口模块不存在 |
+| 完整 pytest | 319 passed / 45 failed / 12 skipped / 8 errors |
+| SQL 安全单测 | 31 passed |
+| OAuth/鉴权策略聚焦测试 | 97 passed |
+| coverage | 36% |
+| Ruff 源码 | 4,297 errors |
+| Mypy | 889 errors |
+| Bandit | 107 findings |
+| 旧协议 initialize | 成功，协商 `2025-03-26` |
+| 2026 `server/discover` | HTTP 500，随后进程退出 |
+| 恶意 Origin 预检 | 被反射，且允许 credentials |
+| 官方 Conformance | npm 包拉取未返回，本次未完成 |
+
+---
+
+## 十三、优先级排序后的行动清单
+
+如果只按顺序做十件事，应是：
+
+1. 修复未知/新版请求导致进程退出；
+2. 收紧 bind、Origin/CORS，关闭 debug；
+3. 删除默认令牌、默认 secret 和 query token；
+4. 升级 MCP Python SDK v2；
+5. 合并单进程/多进程协议核心，删除 monkey patch；
+6. 完成 `server/discover`、无状态、`resultType`、Header、缓存字段迁移；
+7. 修正错误语义，禁止“异常变空列表/成功文本”；
+8. 修复 OAuth Bearer 字段和 issuer/resource/audience 边界；
+9. 建立自包含测试、官方 conformance 和 GitHub Actions；
+10. 修复 wheel 客户端入口、Docker 配置、版本和文档漂移。
+
+完成前六项，项目才进入“具备新版协议骨架”；完成前九项，才接近可发布；全部门禁通过后，才适合正式声明支持 MCP 2026-07-28。

--- a/MCP-2026-07-28-DEVELOPMENT-LEDGER.md
+++ b/MCP-2026-07-28-DEVELOPMENT-LEDGER.md
@@ -1,0 +1,355 @@
+# Apache Doris MCP Server：MCP 2026-07-28 / SDK 2.0 开发台账
+
+> 建账日期：2026-07-29
+> 目标协议：MCP `2026-07-28`
+> 目标 Python SDK：`mcp==2.0.x`
+> 起始仓库基线：`0e843ae3432115ea5895fbd90a97d495c77f911c`
+> 审计依据：[MCP-2026-07-28-AUDIT-REPORT.zh-CN.md](./MCP-2026-07-28-AUDIT-REPORT.zh-CN.md)
+
+## 1. 目标与发布边界
+
+最终目标不是“依赖能安装”，而是：
+
+1. STDIO 和 Streamable HTTP 均原生支持 MCP 2026-07-28；
+2. 同一服务保留官方 SDK 2.0 提供的 legacy 协议兼容；
+3. HTTP 现代路径无协议会话，旧版多 worker 路径不依赖粘性会话；
+4. `server/discover`、逐请求 `_meta`、标准 Header、`resultType`、缓存提示和标准错误完整；
+5. 合法、未知或畸形请求均不能终止服务进程；
+6. 鉴权、Origin、resource/audience、缓存和跨 worker 状态符合最小权限；
+7. 官方 Conformance、测试、类型、静态安全、wheel 和容器门禁全部可重复执行。
+
+在 `REL-003` 完成前，不得对外宣称完整支持 MCP 2026-07-28。
+
+## 2. 状态与证据规则
+
+| 状态 | 含义 |
+|---|---|
+| `BACKLOG` | 已识别，尚未领取 |
+| `READY` | 前置条件满足，可以开始 |
+| `IN_PROGRESS` | 当前批次正在开发 |
+| `BLOCKED` | 有明确外部阻塞，必须记录原因 |
+| `VERIFY` | 实现完成，等待真实门禁 |
+| `DONE` | 完成定义全部满足，证据已回填 |
+| `DEFERRED` | 有意识延期，必须记录重新评估条件 |
+
+证据只接受：
+
+- 可重复命令及退出码；
+- 自动化测试名称和结果；
+- 真实 HTTP/STDIO 请求与响应；
+- 构建产物安装后的 smoke；
+- 真实 Doris/Redis/代理环境回执；
+- 对应提交或明确工作区 diff。
+
+“代码已写”“肉眼看起来正确”不算完成。
+
+## 3. 当前开发批次
+
+批次：`BATCH-01-PROTOCOL-CORE`（已完成）
+
+目标：
+
+- 锁定 MCP Python SDK 2.0；
+- 建立单一 v2 低层协议工厂；
+- 让 STDIO、单 worker HTTP、多 worker HTTP 复用同一组 handlers；
+- HTTP 使用官方 v2 双时代 transport，现代请求无状态；
+- `server/discover` 成功；
+- 未知方法不影响后续请求；
+- 默认不再开放任意 Origin CORS；
+- 为现代与 legacy 调用补最小自动化回归。
+
+本批领取：
+
+| PBI | 状态 |
+|---|---|
+| `PROTO-001` | `DONE` |
+| `PROTO-002` | `DONE` |
+| `PROTO-003` | `DONE` |
+| `PROTO-004` | `DONE` |
+| `PROTO-005` | `DONE` |
+| `PROTO-006` | `DONE` |
+| `PROTO-007` | `DONE` |
+| `PROTO-009` | `DONE` |
+| `PROTO-010` | `DONE` |
+| `SEC-001` | `DONE` |
+| `SEC-002` | `DONE` |
+| `CORE-002` | `DONE` |
+| `TEST-001` | `DONE` |
+| `TEST-002` | `DONE` |
+| `TEST-004` | `DONE` |
+| `PKG-001` | `DONE` |
+
+## 4. 协议核心台账
+
+| ID | 优先级 | 工作项 | 前置 | 完成定义 | 状态 |
+|---|---|---|---|---|---|
+| `PROTO-001` | P0 | 将 `mcp` 依赖和锁文件升级到 2.0.x | 无 | `uv lock --check`、导入和 build 通过；不再允许 1.x | `DONE` |
+| `PROTO-002` | P0 | 建立单一 SDK v2 `Server` 工厂 | PROTO-001 | tools/resources/prompts 六类 handlers 只定义一次；Result 类型完整 | `DONE` |
+| `PROTO-003` | P0 | HTTP 切换官方 v2 双时代 runner | PROTO-002 | `server/discover` 成功；现代请求无 session ID；legacy initialize 可用 | `DONE` |
+| `PROTO-004` | P0 | STDIO 切换 v2 dual-era runner | PROTO-002 | 现代 discover 和 legacy initialize 均有自动化或真实探针 | `DONE` |
+| `PROTO-005` | P0 | 单/多 worker 复用协议工厂 | PROTO-002 | 两种模式不再复制 MCP handlers；现代请求行为一致 | `DONE` |
+| `PROTO-006` | P0 | 未知/畸形请求异常隔离 | PROTO-003 | 未知方法、错 Header、错版本、畸形 body 后服务仍可处理下一请求 | `DONE` |
+| `PROTO-007` | P1 | 标准请求 Header 验证 | PROTO-003 | `Mcp-Method`、条件式 `Mcp-Name` 和 body 不一致返回 `-32020`/400 | `DONE` |
+| `PROTO-008` | P1 | 逐请求 `_meta` 与版本错误 | PROTO-003 | 缺能力、版本不支持分别返回 `-32021/-32022` | `READY` |
+| `PROTO-009` | P1 | 所有 Result 的 `resultType` | PROTO-002 | 现代 wire 所有成功结果包含 `complete`；MRTR 为 `input_required` | `DONE` |
+| `PROTO-010` | P1 | 缓存提示策略 | PROTO-002 | cacheable 结果都有 `ttlMs/cacheScope`；身份相关结果一律 private | `DONE` |
+| `PROTO-011` | P1 | 删除核心 GET/SSE 兼容改写 | PROTO-003 | 现代核心只走规范 POST；legacy adapter 独立且默认关闭 | `BACKLOG` |
+| `PROTO-012` | P1 | 资源/工具/Prompt 分页 | PROTO-002 | 大列表使用稳定 cursor；无重复、丢失和跨权限翻页 | `BACKLOG` |
+| `PROTO-013` | P2 | `subscriptions/listen` 决策与实现 | PROTO-003 | 有真实变更源才实现；否则能力不虚报并记录 N/A | `BACKLOG` |
+| `PROTO-014` | P2 | MRTR 输入流程 | PROTO-009 | 至少一个真实交互需求用 `InputRequiredResult` 完成新旧协议回归 | `DEFERRED` |
+| `PROTO-015` | P2 | Tasks 扩展决策 | PROTO-003 | 形成 ADR；无真实长任务需求则保持不启用 | `DEFERRED` |
+| `PROTO-016` | P1 | JSON Schema 2020-12 验证和资源上限 | PROTO-002 | schema 合法；外部 `$ref` 不自动抓取；组合复杂度有界 | `BACKLOG` |
+| `PROTO-017` | P2 | OpenTelemetry `_meta` 传播 | PROTO-003 | trace 上下文传播且不进入模型内容；敏感字段脱敏 | `BACKLOG` |
+| `PROTO-018` | P1 | 产品身份版本单一来源 | PROTO-001 | discover、legacy serverInfo、CLI、包版本一致，不再回报 SDK 版本 | `VERIFY` |
+
+## 5. 安全与授权台账
+
+| ID | 优先级 | 工作项 | 前置 | 完成定义 | 状态 |
+|---|---|---|---|---|---|
+| `SEC-001` | P0 | 收紧 Origin/Host/CORS | PROTO-003 | 默认 loopback allowlist；攻击 Origin/Host 被拒绝；无通配 credentials | `DONE` |
+| `SEC-002` | P0 | 删除 MCP Bearer query token | 无 | `?token=` 不再认证；只接受 Authorization Header | `DONE` |
+| `SEC-003` | P0 | 删除管理 query token | 无 | `?admin_token=` 不再认证或传播；管理 Header 测试通过 | `BACKLOG` |
+| `SEC-004` | P0 | 删除固定默认令牌和 secret | 无 | 新安装没有可用默认凭证；启用时强制高熵配置 | `BACKLOG` |
+| `SEC-005` | P0 | 非 loopback 无鉴权拒绝启动 | SEC-001, SEC-004 | 非本机绑定且 auth 关闭时 fail closed，危险开关需显式 | `BACKLOG` |
+| `SEC-006` | P1 | 统一 Bearer 规范化结构 | 无 | static/JWT/external OAuth/Doris OAuth 使用同一 credentials DTO | `BACKLOG` |
+| `SEC-007` | P1 | issuer/resource/audience/scope 强校验 | SEC-006 | 两 issuer、两 resource、三 scope 交叉矩阵全部最小权限 | `BACKLOG` |
+| `SEC-008` | P1 | 修复 external OAuth Bearer 字段断裂 | SEC-006 | Header token 能进入 provider；错误 challenge 合规 | `BACKLOG` |
+| `SEC-009` | P1 | Doris OAuth token resource 绑定 | SEC-007 | 非当前 MCP resource 的 token 被拒绝 | `BACKLOG` |
+| `SEC-010` | P1 | DCR `application_type` | 无 | 注册时必填、校验、持久化，redirect URI 规则匹配 | `BACKLOG` |
+| `SEC-011` | P1 | 授权响应 RFC 9207 `iss` | 无 | 成功和错误响应都有正确 iss；客户端测试验证 issuer | `BACKLOG` |
+| `SEC-012` | P1 | token endpoint 二次校验 resource | SEC-009 | 授权码绑定值与兑换请求不一致时拒绝 | `BACKLOG` |
+| `SEC-013` | P2 | Client ID Metadata Documents | SEC-010 | 增加推荐注册路径；DCR 仅保留兼容 | `BACKLOG` |
+| `SEC-014` | P1 | 令牌不可逆存储 | 无 | 只存 digest，明文只在创建时显示一次 | `BACKLOG` |
+| `SEC-015` | P1 | 多 worker 统一吊销和状态存储 | SEC-014 | 并发写无丢失；任意 worker 立即看到吊销 | `BACKLOG` |
+| `SEC-016` | P1 | 日志与错误脱敏 | 无 | Authorization、密码、token、SQL 敏感值不进入日志和响应 | `BACKLOG` |
+| `SEC-017` | P1 | SQL 动态构造逐 sink 审计 | 无 | B608 逐项分诊；source-validation-sink 清单和回归齐全 | `BACKLOG` |
+| `SEC-018` | P2 | FE/BE 监控 SSRF 边界 | 无 | 只访问配置节点；拒绝 metadata/link-local；超时和响应上限 | `BACKLOG` |
+
+## 6. 行为正确性与架构台账
+
+| ID | 优先级 | 工作项 | 前置 | 完成定义 | 状态 |
+|---|---|---|---|---|---|
+| `CORE-001` | P1 | list 异常不再返回空列表 | PROTO-002 | DB/权限/内部错误与真实空列表可区分 | `BACKLOG` |
+| `CORE-002` | P1 | Tool 错误使用 `isError=true` | PROTO-002 | 可恢复业务错误对模型可见；内部异常为稳定协议错误 | `DONE` |
+| `CORE-003` | P1 | Resource not found 使用 `-32602` | PROTO-002 | 不存在 URI 返回 Invalid Params，不返回错误正文成功 | `READY` |
+| `CORE-004` | P1 | Prompt 错误类型化 | PROTO-002 | 缺参数、未知 prompt、DB 上下文失败语义不同 | `READY` |
+| `CORE-005` | P1 | 单一 Tool Definition Registry | PROTO-002 | schema、policy、handler、审计和文档同源 | `BACKLOG` |
+| `CORE-006` | P1 | `/live` 与 `/ready` 分离 | 无 | Doris 不可用时 live 可真、ready 必假；探针有短超时 | `BACKLOG` |
+| `CORE-007` | P1 | 显式跨调用 handle | PROTO-003, SEC-015 | 状态不依赖协议 session；handle 绑定 principal/expiry | `BACKLOG` |
+| `CORE-008` | P2 | 大结果边界 | 无 | 行数、字节数、超时和取消可配置且有硬上限 | `BACKLOG` |
+| `CORE-009` | P2 | manager 模块职责拆分 | CORE-005 | 不改变行为前提下缩小超大文件，模块边界有测试 | `BACKLOG` |
+| `CORE-010` | P1 | 修复 SQL profile 分析未绑定 `auth_context` | 无 | 真实 Doris 调用不再触发局部变量未赋值；鉴权上下文覆盖测试通过 | `READY` |
+| `CORE-011` | P1 | 修复数据新鲜度空阈值比较 | 无 | 阈值缺失或为 `None` 时返回类型化错误/默认值，不抛 `TypeError` | `READY` |
+| `COMPAT-001` | P1 | Doris 4.0 元数据字段兼容 | 无 | Doris 4.0.5 的角色/权限查询不再依赖不存在的 `Default_role` 字段 | `READY` |
+| `COMPAT-002` | P2 | FE/BE HTTP 端点独立配置 | SEC-018 | SQL、FE HTTP、BE HTTP 可分别配置主机/端口并通过代理/隧道环境测试 | `BACKLOG` |
+
+## 7. 测试、构建和发布台账
+
+| ID | 优先级 | 工作项 | 前置 | 完成定义 | 状态 |
+|---|---|---|---|---|---|
+| `TEST-001` | P0 | SDK v2 现代/legacy 协议单测 | PROTO-002 | discover、list/call/read/get、legacy initialize 自动化通过 | `DONE` |
+| `TEST-002` | P0 | HTTP 进程存活回归 | PROTO-003 | 新版、未知、畸形请求后下一次请求成功 | `DONE` |
+| `TEST-003` | P0 | 官方 Conformance `server-stateless` | PROTO-003 | 2026-07-28 场景全绿，回执入账 | `READY` |
+| `TEST-004` | P1 | 修复 pytest 路径和 E2E fixture | 无 | 完整 pytest 无 setup error；外部测试自启或明确 skip | `DONE` |
+| `TEST-005` | P1 | 真实 Doris 集成矩阵 | TEST-004 | 只读/写入、权限不足、故障恢复、超时均覆盖 | `IN_PROGRESS` |
+| `TEST-006` | P1 | 鉴权交叉矩阵 | SEC-007 | auth method × scope × tool × resource 全覆盖 | `BACKLOG` |
+| `TEST-007` | P1 | GitHub Actions | TEST-001 | sync、test、ruff、mypy、bandit、build、wheel smoke、conformance | `BACKLOG` |
+| `TEST-008` | P2 | Ruff 存量清零 | 无 | 源码和测试 `ruff check` 零错误 | `BACKLOG` |
+| `TEST-009` | P2 | Mypy 分层收紧 | PROTO-002 | 协议/鉴权 strict 先归零，再消除全部存量 | `BACKLOG` |
+| `TEST-010` | P2 | Bandit 分诊 | SEC-017 | 所有 finding 有修复或精确豁免理由 | `BACKLOG` |
+| `TEST-011` | P2 | 消除测试运行时与时间 API 告警 | TEST-004 | 无未 await coroutine；迁移 timezone-aware UTC；pytest warning 归零 | `IN_PROGRESS` |
+| `TEST-012` | P1 | 真实 Doris 工具错误路径回归 | TEST-005 | CORE-010/011、COMPAT-001 的失败样例自动化并在真实环境转绿 | `READY` |
+| `TEST-013` | P2 | 覆盖率分域提升 | TEST-004 | 协议/鉴权/核心 manager 先达 80%，再定义全仓门槛 | `BACKLOG` |
+| `PKG-001` | P1 | 修复 `doris-mcp-client` wheel | 无 | 干净 venv 安装 wheel 后两个 CLI `--help` 成功 | `DONE` |
+| `PKG-002` | P2 | 运行时/开发依赖分层 | PROTO-001 | runtime 不包含 pytest/lint/build 工具 | `BACKLOG` |
+| `DEPLOY-001` | P1 | Compose 端口和 healthcheck | CORE-006 | 无端口冲突；health/readiness 指向真实端口 | `BACKLOG` |
+| `DEPLOY-002` | P1 | Compose secrets 与镜像固定 | SEC-004 | 无仓库弱密码；镜像使用明确版本或 digest | `BACKLOG` |
+| `DOC-001` | P1 | 协议支持矩阵和迁移指南 | PROTO-003 | README 明确现代/legacy 行为、Header、部署限制 | `BACKLOG` |
+| `DOC-002` | P2 | 版本、命令和 CHANGELOG 对齐 | PROTO-018, PKG-001 | 示例、CLI、包、serverInfo、CHANGELOG 一致 | `BACKLOG` |
+
+## 8. 发布门台账
+
+| ID | 优先级 | 发布门 | 完成定义 | 状态 |
+|---|---|---|---|---|
+| `REL-001` | P0 | Alpha：协议骨架 | PROTO-001～010、SEC-001、TEST-001/002 全部完成 | `BACKLOG` |
+| `REL-002` | P0 | Beta：安全与真实 Doris | P0/P1 安全项、真实 Doris、Conformance、wheel、Compose 全绿 | `BACKLOG` |
+| `REL-003` | P0 | GA：宣称支持 2026-07-28 | 完整测试绿；无未接受 P0/P1；文档和回执齐全 | `BACKLOG` |
+
+## 9. 决策记录
+
+### ADR-001：协议层使用 SDK v2 低层 `Server`
+
+状态：`ACCEPTED`
+
+理由：
+
+- 当前工具 schema 是手工定义，低层 API 能原样保留；
+- 当前已有统一 `call_tool(name, arguments)` 分派，适合一个 `on_call_tool`；
+- 可以显式控制 `CallToolResult`、`is_error`、缓存和 `_meta`；
+- 官方 v2 runner 仍自动提供 `server/discover`、双时代协议和现代 Header/元数据处理。
+
+约束：
+
+- 不继续复制 handlers；
+- 不使用 SDK 私有模块或 monkey patch；
+- 低层 handler 必须自行构造完整 Result；
+- 参数 schema 验证将在 `PROTO-016` / `CORE-005` 补齐。
+
+### ADR-002：HTTP legacy 路径使用 `stateless_http=True`
+
+状态：`ACCEPTED`
+
+理由：
+
+- 当前 Doris 工具没有服务端反向请求依赖；
+- 多 worker 不再需要粘性 session；
+- 2026-07-28 现代路径本身始终无状态；
+- 后续若增加 MRTR，由现代协议完成；legacy 交互能力需单独评估。
+
+### ADR-003：缓存默认私有
+
+状态：`ACCEPTED`
+
+理由：
+
+- tools/resources 可随身份、scope 和 Doris 用户变化；
+- 在身份感知 cache key 完成前，公共缓存存在越权泄露风险；
+- 初期宁可 `ttlMs=0`，不以性能换隔离性。
+
+## 10. 验证回执
+
+### 建账基线
+
+```text
+HEAD: 0e843ae3432115ea5895fbd90a97d495c77f911c
+mcp locked: 1.9.3
+full pytest: 319 passed / 45 failed / 12 skipped / 8 errors
+coverage: 36%
+2026 server/discover: HTTP 500, process exited
+```
+
+### BATCH-01
+
+#### 实现回执
+
+- `mcp` 依赖已锁定为 `>=2.0.0,<2.1.0`，`uv.lock` 解析为 `mcp==2.0.0`；
+- 新增 `doris_mcp_server/protocol.py`，六类 MCP handlers 由 STDIO、单 worker HTTP、多 worker HTTP 共用；
+- 删除 SDK 1.x 私有行为改写和 transport monkey patch；
+- HTTP 使用 SDK 2.0 双时代、无状态 runner，路由固定为 `/mcp`；
+- STDIO 使用 SDK 2.0 dual-era runner；
+- 多 worker 父进程将解析后的 Doris/Server 配置显式传给子进程，避免 worker 回退到默认连接；
+- SDK 2.0 客户端迁移完成，`doris-mcp-client` 已作为 wheel 内可执行入口发布；
+- MCP query-string token 已拒绝，Origin/Host 默认按 loopback allowlist 收紧；
+- 测试发现的无事件循环 coroutine 泄漏已修复；pytest 收集目录已修正为 `test/`。
+
+#### 自动化回执
+
+```text
+uv run pytest -q
+331 passed / 57 skipped / 0 failed / 247 warnings
+coverage: 36%
+
+uv run pytest -q test/protocol/test_mcp_v2_protocol.py
+3 passed
+
+uv lock --check
+resolved: 181 packages
+
+ruff（本批协议、客户端、鉴权和新增测试文件）
+All checks passed
+
+python -m compileall
+passed
+```
+
+协议回归覆盖：
+
+- 现代 `server/discover`；
+- legacy `initialize`；
+- tools/resources/prompts 的 list/call/read/get；
+- `resultType=complete`；
+- 私有 `ttlMs=0/cacheScope=private`；
+- tool 错误 `isError=true`；
+- 未知 method `-32601`；
+- malformed JSON `-32700`；
+- Header/body 不一致 `-32020`；
+- 不支持版本 `-32022`；
+- 攻击 Origin `403`；
+- 攻击 Host `421`；
+- 失败请求后下一次 discover 仍成功。
+
+#### 真实 Doris 回执
+
+环境：
+
+```text
+host: 192.168.31.63
+Doris FE MySQL: 9030
+Doris FE HTTP: 8030
+Doris BE HTTP: 8040
+Doris: 4.0.5-rc01-59de8c4c524
+database: hhm_dt_sim
+current tables: 1008
+org_tenant rows: 47040
+```
+
+连接通过既有 SSH key 和临时本地隧道完成；凭据未写入仓库、测试或台账。
+
+真实矩阵：
+
+| 入口 | 协议时代 | worker | tools | 真实查询 |
+|---|---|---:|---:|---:|
+| HTTP | `2026-07-28` | 1 | 25 | `org_tenant=47040` |
+| HTTP | `2025-11-25` | 1 | 25 | `org_tenant=47040` |
+| STDIO | `2026-07-28` | 1 | 25 | `org_tenant=47040` |
+| STDIO | `2025-11-25` | 1 | 25 | `org_tenant=47040` |
+| HTTP | `2026-07-28` | 2 | 25 | 4/4 成功 |
+| HTTP | `2025-11-25` | 2 | 25 | 2/2 成功 |
+
+多 worker health 并发探针同时观察到两个 worker PID；现代路径无 session ID，legacy 路径在 `stateless_http=True` 下无需粘性会话。
+
+外部安全 API 套件通过显式环境变量接入当前 MCP 实例：
+
+```text
+test/security/test_sql_injection_api.py
+45 passed
+```
+
+#### 构建回执
+
+```text
+uv build
+dist/doris_mcp_server-0.6.1.tar.gz
+dist/doris_mcp_server-0.6.1-py3-none-any.whl
+
+isolated wheel install:
+server package: 0.6.1
+mcp SDK: 2.0.0
+doris-mcp-server --help: passed
+doris-mcp-client --help: passed
+```
+
+#### 真实环境新增缺陷
+
+这些缺陷不是协议 runner 的失败，已分别登记，不能用 BATCH-01 的协议门禁掩盖：
+
+1. `CORE-010`：SQL profile 分析路径存在未绑定 `auth_context`；
+2. `CORE-011`：数据新鲜度路径可能对 `None` 阈值做数值比较；
+3. `COMPAT-001`：部分权限分析 SQL 与 Doris 4.0.5 元数据字段不兼容；
+4. `COMPAT-002`：FE/BE HTTP 与 SQL 连接端点需要独立配置，代理/隧道场景不能假设同一 host。
+
+## 11. 下一开发批次
+
+批次：`BATCH-02-CONFORMANCE-AND-ERROR-SEMANTICS`
+
+按以下顺序推进：
+
+1. `PROTO-008`：补齐缺 capability `-32021` 和逐请求 `_meta` 边界；
+2. `CORE-003` / `CORE-004`：Resource 与 Prompt 错误类型化；
+3. `CORE-010` / `CORE-011` / `COMPAT-001`：修复真实 Doris 已复现缺陷；
+4. `TEST-003`：运行官方 `server-stateless` Conformance；
+5. `TEST-005` / `TEST-012`：补权限不足、超时、故障恢复和工具错误路径；
+6. `PROTO-018` / `DOC-001` / `DOC-002`：版本单一来源和迁移文档；
+7. `SEC-003`～`SEC-005`：进入下一安全批，完成非 loopback fail-closed。
+
+`REL-001` 尚未开启：BATCH-01 已完成协议骨架，但 `PROTO-008` 与官方 Conformance 仍是 Alpha 发布门的硬缺口。

--- a/doris_mcp_client/client.py
+++ b/doris_mcp_client/client.py
@@ -22,16 +22,17 @@ Combines the correct HTTP implementation from http_client.py and the complete ar
 Provides complete support for the three major primitives: Resources, Tools, and Prompts
 """
 
+import argparse
 import asyncio
 import json
 import logging
-from typing import Any, Callable
-from datetime import timedelta
+from collections.abc import Callable
+from typing import Any
 
+from mcp import Client as MCPClient
+from mcp import StdioServerParameters
 from mcp.client.session import ClientSession
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
-from mcp import StdioServerParameters
 from mcp.types import (
     Prompt,
     Resource,
@@ -299,17 +300,17 @@ class DorisUnifiedClient:
                 args=self.config.server_args,
             )
 
-            async with stdio_client(server_params) as (read, write):
-                async with ClientSession(read, write) as session:
-                    self.session = session
-                    self._init_sub_clients()
-
-                    # Initialize server
-                    await session.initialize()
-                    self.logger.info("Server initialized successfully")
-
-                    # Execute callback function
-                    await callback_func(self)
+            async with MCPClient(
+                stdio_client(server_params),
+                read_timeout_seconds=self.config.timeout,
+            ) as client:
+                self.session = client.session
+                self._init_sub_clients()
+                self.logger.info(
+                    "Server connected successfully using MCP %s",
+                    client.protocol_version,
+                )
+                await callback_func(self)
 
         except Exception as e:
             self.logger.error(f"stdio mode execution failed: {e}")
@@ -320,20 +321,17 @@ class DorisUnifiedClient:
         try:
             self.logger.info(f"Starting HTTP client: {self.config.server_url}")
 
-            async with streamablehttp_client(
+            async with MCPClient(
                 self.config.server_url,
-                timeout=timedelta(seconds=self.config.timeout)
-            ) as (read, write, _):
-                async with ClientSession(read, write) as session:
-                    self.session = session
-                    self._init_sub_clients()
-
-                    # Initialize server
-                    await session.initialize()
-                    self.logger.info("Server initialized successfully")
-
-                    # Execute callback function
-                    await callback_func(self)
+                read_timeout_seconds=self.config.timeout,
+            ) as client:
+                self.session = client.session
+                self._init_sub_clients()
+                self.logger.info(
+                    "Server connected successfully using MCP %s",
+                    client.protocol_version,
+                )
+                await callback_func(self)
 
         except Exception as e:
             self.logger.error(f"HTTP mode execution failed: {e}")
@@ -460,6 +458,74 @@ async def create_http_client(server_url: str, timeout: int = 60) -> DorisUnified
     return DorisUnifiedClient(config)
 
 
+def create_arg_parser() -> argparse.ArgumentParser:
+    """Create the command line parser for the packaged MCP client."""
+    parser = argparse.ArgumentParser(
+        description="Connect to an Apache Doris MCP server using SDK 2.0.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["http", "stdio"],
+        default="http",
+        help="MCP transport to use (default: http)",
+    )
+    parser.add_argument(
+        "--url",
+        default="http://127.0.0.1:3000/mcp",
+        help="Streamable HTTP MCP endpoint",
+    )
+    parser.add_argument(
+        "--command",
+        default="doris-mcp-server",
+        help="Server command used in stdio mode",
+    )
+    parser.add_argument(
+        "--server-arg",
+        action="append",
+        default=[],
+        help="Argument passed to the stdio server command; may be repeated",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="Request timeout in seconds (default: 60)",
+    )
+    parser.add_argument(
+        "--query",
+        help="Execute one SQL query; otherwise list available tools",
+    )
+    return parser
+
+
+async def _run_cli(args: argparse.Namespace) -> None:
+    if args.transport == "stdio":
+        config = DorisClientConfig.stdio(args.command, args.server_arg)
+        config.timeout = args.timeout
+    else:
+        config = DorisClientConfig.http(args.url, args.timeout)
+
+    client = DorisUnifiedClient(config)
+
+    async def output(connected: DorisUnifiedClient) -> None:
+        if args.query:
+            payload = await connected.execute_sql(args.query)
+        else:
+            tools = await connected.list_all_tools()
+            payload = {
+                "tool_count": len(tools),
+                "tools": [tool.name for tool in tools],
+            }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    await client.connect_and_run(output)
+
+
+def main() -> None:
+    """Run the packaged Doris MCP client."""
+    asyncio.run(_run_cli(create_arg_parser().parse_args()))
+
+
 # Example usage
 async def example_stdio():
     """stdio mode example"""
@@ -502,8 +568,4 @@ async def example_http():
 
 
 if __name__ == "__main__":
-    # Run stdio example
-    asyncio.run(example_stdio())
-
-    # Run HTTP example
-    # asyncio.run(example_http()) 
+    main()

--- a/doris_mcp_server/__init__.py
+++ b/doris_mcp_server/__init__.py
@@ -24,6 +24,6 @@ This package provides:
 - Enterprise-grade security and monitoring
 """
 
-__version__ = "1.0.0"
+__version__ = "0.6.1"
 __author__ = "Doris MCP Team"
 __description__ = "Apache Doris MCP Server Implementation"

--- a/doris_mcp_server/auth/mcp_auth_middleware.py
+++ b/doris_mcp_server/auth/mcp_auth_middleware.py
@@ -17,16 +17,11 @@
 # under the License.
 """Shared ASGI authentication middleware for MCP HTTP routes."""
 
-from typing import Any, Awaitable, Callable
-from urllib.parse import parse_qs
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from starlette.responses import JSONResponse
 
-from .doris_oauth_handlers import (
-    insufficient_scope_response,
-    protected_resource_error_response,
-)
-from .operation_policy import OperationAuthorizationError
 from ..utils.config import EffectiveAuthConfig
 from ..utils.logger import get_logger
 from ..utils.security import (
@@ -35,7 +30,11 @@ from ..utils.security import (
     reset_auth_context,
     set_current_auth_context,
 )
-
+from .doris_oauth_handlers import (
+    insufficient_scope_response,
+    protected_resource_error_response,
+)
+from .operation_policy import OperationAuthorizationError
 
 ASGIApp = Callable[[dict[str, Any], Callable[..., Awaitable[Any]], Callable[..., Awaitable[Any]]], Awaitable[Any]]
 logger = get_logger(__name__)
@@ -57,13 +56,6 @@ async def extract_auth_info_from_scope(scope: dict[str, Any]) -> dict[str, Any]:
         auth_info["token"] = authorization[7:]
     elif authorization.startswith("Token "):
         auth_info["token"] = authorization[6:]
-    else:
-        query_string = scope.get("query_string", b"")
-        if query_string:
-            query_params = parse_qs(query_string.decode("utf-8", errors="ignore"))
-            token_values = query_params.get("token") or []
-            if token_values:
-                auth_info["token"] = token_values[0]
     return auth_info
 
 

--- a/doris_mcp_server/main.py
+++ b/doris_mcp_server/main.py
@@ -24,193 +24,14 @@ Supports both stdio and streamable HTTP startup modes
 
 import argparse
 import asyncio
-import json
 import logging
+import os
 import sys
-from typing import Any
 
-# MCP version compatibility handling
-MCP_VERSION = 'unknown'
-Server = None
-InitializationOptions = None
-Prompt = None
-Resource = None
-TextContent = None
-Tool = None
-
-def _import_mcp_with_compatibility():
-    """Import MCP components with multi-version compatibility"""
-    global MCP_VERSION, Server, InitializationOptions, Prompt, Resource, TextContent, Tool
-    
-    try:
-        # Strategy 1: Try direct server-only imports to avoid client-side issues
-        from mcp.server import Server as _Server
-        from mcp.server.models import InitializationOptions as _InitOptions
-        from mcp.types import (
-            Prompt as _Prompt,
-            Resource as _Resource, 
-            TextContent as _TextContent,
-            Tool as _Tool,
-        )
-        
-        # Assign to globals
-        Server = _Server
-        InitializationOptions = _InitOptions
-        Prompt = _Prompt
-        Resource = _Resource
-        TextContent = _TextContent
-        Tool = _Tool
-        
-        # Try to get version safely
-        try:
-            import mcp
-            MCP_VERSION = getattr(mcp, '__version__', None)
-            if not MCP_VERSION:
-                # Fallback: try to get version from package metadata
-                try:
-                    import importlib.metadata
-                    MCP_VERSION = importlib.metadata.version('mcp')
-                except Exception:
-                    # Second fallback: try pkg_resources
-                    try:
-                        import pkg_resources
-                        MCP_VERSION = pkg_resources.get_distribution('mcp').version
-                    except Exception:
-                        MCP_VERSION = 'detected-but-version-unknown'
-        except Exception:
-            # Version detection failed, but imports worked
-            try:
-                import importlib.metadata
-                MCP_VERSION = importlib.metadata.version('mcp')
-            except Exception:
-                try:
-                    import pkg_resources
-                    MCP_VERSION = pkg_resources.get_distribution('mcp').version
-                except Exception:
-                    MCP_VERSION = 'imported-successfully'
-            
-        logger = logging.getLogger(__name__)
-        logger.info(f"MCP components imported successfully, version: {MCP_VERSION}")
-        return True
-        
-    except Exception as import_error:
-        logger = logging.getLogger(__name__)
-        
-        # Strategy 2: Handle RequestContext compatibility issues in 1.9.x versions
-        error_str = str(import_error).lower()
-        if 'requestcontext' in error_str and 'too few arguments' in error_str:
-            logger.warning(f"Detected MCP RequestContext compatibility issue: {import_error}")
-            logger.info("Attempting comprehensive workaround for MCP 1.9.x RequestContext issue...")
-            
-            try:
-                # Comprehensive monkey patch approach
-                import sys
-                import types
-                
-                # Create and install mock modules before any MCP imports
-                if 'mcp.shared.context' not in sys.modules:
-                    mock_context_module = types.ModuleType('mcp.shared.context')
-                    
-                    class FlexibleRequestContext:
-                        """Flexible RequestContext that accepts variable arguments"""
-                        def __init__(self, *args, **kwargs):
-                            self.args = args
-                            self.kwargs = kwargs
-                        
-                        def __class_getitem__(cls, params):
-                            # Accept any number of parameters and return cls
-                            return cls
-                        
-                        # Add other methods that might be called
-                        def __getattr__(self, name):
-                            return lambda *args, **kwargs: None
-                    
-                    mock_context_module.RequestContext = FlexibleRequestContext
-                    sys.modules['mcp.shared.context'] = mock_context_module
-                
-                # Also patch the typing system to be more permissive  
-                original_check_generic = None
-                try:
-                    import typing
-                    if hasattr(typing, '_check_generic'):
-                        original_check_generic = typing._check_generic
-                        def permissive_check_generic(cls, params, elen):
-                            # Don't enforce strict parameter count checking
-                            return
-                        typing._check_generic = permissive_check_generic
-                except Exception:
-                    pass
-                
-                # Clear any cached imports that might have failed
-                modules_to_clear = [k for k in sys.modules.keys() if k.startswith('mcp.')]
-                for module in modules_to_clear:
-                    if module in sys.modules:
-                        del sys.modules[module]
-                
-                # Now try importing again with the patches in place
-                from mcp.server import Server as _Server
-                from mcp.server.models import InitializationOptions as _InitOptions
-                from mcp.types import (
-                    Prompt as _Prompt,
-                    Resource as _Resource, 
-                    TextContent as _TextContent,
-                    Tool as _Tool,
-                )
-                
-                # Assign to globals
-                Server = _Server
-                InitializationOptions = _InitOptions
-                Prompt = _Prompt
-                Resource = _Resource
-                TextContent = _TextContent
-                Tool = _Tool
-                
-                # Try to detect actual version even in compatibility mode
-                try:
-                    import importlib.metadata
-                    actual_version = importlib.metadata.version('mcp')
-                    MCP_VERSION = f'compatibility-mode-{actual_version}'
-                except Exception:
-                    try:
-                        import pkg_resources
-                        actual_version = pkg_resources.get_distribution('mcp').version
-                        MCP_VERSION = f'compatibility-mode-{actual_version}'
-                    except Exception:
-                        MCP_VERSION = 'compatibility-mode-1.9.x'
-                
-                logger.info("MCP 1.9.x compatibility workaround successful!")
-                
-                # Restore original typing function if we patched it
-                if original_check_generic:
-                    typing._check_generic = original_check_generic
-                
-                return True
-                
-            except Exception as workaround_error:
-                logger.error(f"MCP compatibility workaround failed: {workaround_error}")
-                
-                # Restore original typing function if we patched it
-                if original_check_generic:
-                    try:
-                        import typing
-                        typing._check_generic = original_check_generic
-                    except Exception:
-                        pass
-        
-        logger.error(f"Failed to import MCP components: {import_error}")
-        return False
-
-# Perform MCP import with compatibility handling
-if not _import_mcp_with_compatibility():
-    raise ImportError(
-        "Failed to import MCP components. Please ensure MCP is properly installed. "
-        "Supported versions: 1.8.x, 1.9.x"
-    )
-
-from .tools.tools_manager import DorisToolsManager
+from .protocol import create_doris_mcp_server, create_transport_security
 from .tools.prompts_manager import DorisPromptsManager
 from .tools.resources_manager import DorisResourcesManager
-from .auth.operation_policy import OperationAuthorizationError, authorize_operation
+from .tools.tools_manager import DorisToolsManager
 from .utils.config import (
     DorisConfig,
     _mark_source,
@@ -218,14 +39,36 @@ from .utils.config import (
     normalize_effective_auth_config,
 )
 from .utils.db import DorisConnectionManager
-from .utils.security import DorisSecurityManager, get_current_auth_context
-import os
+from .utils.security import DorisSecurityManager
 
 # Configure logging - will be properly initialized later
 logger = logging.getLogger(__name__)
 
 # Create a default config instance for getting default values
 _default_config = DorisConfig()
+
+
+def _multiworker_environment(
+    config: DorisConfig,
+    *,
+    host: str,
+    port: int,
+    workers: int,
+) -> dict[str, str]:
+    """Serialize resolved parent settings inherited by Uvicorn workers."""
+    return {
+        "DORIS_HOST": config.database.host,
+        "DORIS_PORT": str(config.database.port),
+        "DORIS_USER": config.database.user,
+        "DORIS_PASSWORD": config.database.password,
+        "DORIS_DATABASE": config.database.database,
+        "SERVER_HOST": host,
+        "SERVER_PORT": str(port),
+        "SERVER_NAME": config.server_name,
+        "SERVER_VERSION": config.server_version,
+        "TRANSPORT": "http",
+        "WORKERS": str(workers),
+    }
 
 
 
@@ -235,7 +78,6 @@ class DorisServer:
 
     def __init__(self, config: DorisConfig):
         self.config = config
-        self.server = Server("doris-mcp-server")
 
         # Initialize security manager (without connection_manager initially)
         self.security_manager = DorisSecurityManager(config)
@@ -256,201 +98,14 @@ class DorisServer:
         # Import here to avoid circular imports
         from .utils.logger import get_logger
         self.logger = get_logger(f"{__name__}.DorisServer")
-        self._setup_handlers()
-
-    async def _extract_auth_info_from_scope(self, scope, headers):
-        """Extract authentication information from ASGI scope and headers"""
-        auth_info = {}
-        
-        # Extract client IP
-        client = scope.get("client")
-        if client:
-            auth_info["client_ip"] = client[0]
-        else:
-            auth_info["client_ip"] = "unknown"
-        
-        # Extract token from Authorization header
-        authorization = headers.get(b'authorization', b'').decode('utf-8')
-        if authorization:
-            if authorization.startswith('Bearer '):
-                auth_info["token"] = authorization[7:]
-                auth_info["authorization"] = authorization
-            elif authorization.startswith('Token '):
-                auth_info["token"] = authorization[6:]
-                auth_info["authorization"] = authorization
-        
-        # Extract token from query parameters (for compatibility)
-        query_string = scope.get("query_string", b"").decode('utf-8')
-        if query_string and "token=" in query_string:
-            import urllib.parse
-            query_params = urllib.parse.parse_qs(query_string)
-            if "token" in query_params:
-                auth_info["token"] = query_params["token"][0]
-        
-        # If no token found, this will be handled by the authentication system
-        # (either return anonymous context if auth disabled, or raise error if auth enabled)
-        
-        return auth_info
-
-    def _get_mcp_capabilities(self):
-        """Get MCP capabilities with version compatibility"""
-        try:
-            # For MCP 1.9.x and newer
-            from mcp.server.lowlevel.server import NotificationOptions
-            
-            return self.server.get_capabilities(
-                notification_options=NotificationOptions(
-                    prompts_changed=True,
-                    resources_changed=True,
-                    tools_changed=True
-                ),
-                experimental_capabilities={}
-            )
-        except TypeError:
-            try:
-                # For MCP 1.8.x
-                from mcp.server.lowlevel.server import NotificationOptions
-                
-                return self.server.get_capabilities(
-                    notification_options=NotificationOptions(
-                        prompts_changed=True,
-                        resources_changed=True,
-                        tools_changed=True
-                    ),
-                    experimental_capabilities={}
-                )
-            except Exception as e:
-                self.logger.warning(f"Could not get capabilities with NotificationOptions: {e}")
-                # Fallback for older versions
-                try:
-                    return self.server.get_capabilities()
-                except Exception as fallback_e:
-                    self.logger.error(f"Failed to get capabilities: {fallback_e}")
-                    # Return minimal capabilities
-                    return {
-                        "resources": {},
-                        "tools": {},
-                        "prompts": {}
-                    }
-
-    def _setup_handlers(self):
-        """Setup MCP protocol handlers"""
-
-        @self.server.list_resources()
-        async def handle_list_resources() -> list[Resource]:
-            """Handle resource list request"""
-            try:
-                authorize_operation(get_current_auth_context(), "list_resources")
-                self.logger.info("Handling resource list request")
-                resources = await self.resources_manager.list_resources()
-                self.logger.info(f"Returning {len(resources)} resources")
-                return resources
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                self.logger.error(f"Failed to handle resource list request: {e}")
-                if getattr(get_current_auth_context(), "auth_method", "") == "doris_oauth":
-                    raise
-                return []
-
-        @self.server.read_resource()
-        async def handle_read_resource(uri: str) -> str:
-            """Handle resource read request"""
-            try:
-                authorize_operation(get_current_auth_context(), "read_resource")
-                self.logger.info(f"Handling resource read request: {uri}")
-                content = await self.resources_manager.read_resource(uri)
-                return content
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                self.logger.error(f"Failed to handle resource read request: {e}")
-                if getattr(get_current_auth_context(), "auth_method", "") == "doris_oauth":
-                    raise
-                return json.dumps(
-                    {"error": f"Failed to read resource: {str(e)}", "uri": uri},
-                    ensure_ascii=False,
-                    indent=2,
-                )
-
-        @self.server.list_tools()
-        async def handle_list_tools() -> list[Tool]:
-            """Handle tool list request"""
-            try:
-                authorize_operation(get_current_auth_context(), "list_tools")
-                self.logger.info("Handling tool list request")
-                tools = await self.tools_manager.list_tools()
-                self.logger.info(f"Returning {len(tools)} tools")
-                return tools
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                self.logger.error(f"Failed to handle tool list request: {e}")
-                return []
-
-        @self.server.call_tool()
-        async def handle_call_tool(
-            name: str, arguments: dict[str, Any]
-        ) -> list[TextContent]:
-            """Handle tool call request"""
-            try:
-                self.logger.info(f"Handling tool call request: {name}")
-                result = await self.tools_manager.call_tool(name, arguments)
-
-                return [TextContent(type="text", text=result)]
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                self.logger.error(f"Failed to handle tool call request: {e}")
-                error_result = json.dumps(
-                    {
-                        "error": f"Tool call failed: {str(e)}",
-                        "tool_name": name,
-                        "arguments": arguments,
-                    },
-                    ensure_ascii=False,
-                    indent=2,
-                )
-
-                return [TextContent(type="text", text=error_result)]
-
-        @self.server.list_prompts()
-        async def handle_list_prompts() -> list[Prompt]:
-            """Handle prompt list request"""
-            try:
-                authorize_operation(get_current_auth_context(), "list_prompts")
-                self.logger.info("Handling prompt list request")
-                prompts = await self.prompts_manager.list_prompts()
-                self.logger.info(f"Returning {len(prompts)} prompts")
-                return prompts
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                self.logger.error(f"Failed to handle prompt list request: {e}")
-                return []
-
-        @self.server.get_prompt()
-        async def handle_get_prompt(name: str, arguments: dict[str, Any]) -> str:
-            """Handle prompt get request"""
-            try:
-                authorize_operation(get_current_auth_context(), "get_prompt")
-                self.logger.info(f"Handling prompt get request: {name}")
-                result = await self.prompts_manager.get_prompt(name, arguments)
-                return result
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                self.logger.error(f"Failed to handle prompt get request: {e}")
-                error_result = json.dumps(
-                    {
-                        "error": f"Failed to get prompt: {str(e)}",
-                        "prompt_name": name,
-                        "arguments": arguments,
-                    },
-                    ensure_ascii=False,
-                    indent=2,
-                )
-                return error_result
+        self.server = create_doris_mcp_server(
+            resources_manager=self.resources_manager,
+            tools_manager=self.tools_manager,
+            prompts_manager=self.prompts_manager,
+            name=config.server_name,
+            version=config.server_version,
+            logger=self.logger,
+        )
 
     async def start_stdio(self):
         """Start stdio transport mode"""
@@ -465,16 +120,7 @@ class DorisServer:
             # Use the dedicated stdio mode initialization method
             await self.connection_manager.initialize_for_stdio_mode()
 
-            # Start stdio server - using compatible import approach
-            try:
-                from mcp.server.stdio import stdio_server
-            except ImportError:
-                # Fallback for different MCP versions
-                try:
-                    from mcp.server import stdio_server
-                except ImportError as stdio_import_error:
-                    self.logger.error(f"Failed to import stdio_server: {stdio_import_error}")
-                    raise RuntimeError("stdio_server module not available in this MCP version")
+            from mcp.server.stdio import stdio_server
             
             self.logger.info("Creating stdio_server transport...")
             
@@ -484,19 +130,13 @@ class DorisServer:
                     read_stream, write_stream = streams
                     self.logger.info("stdio_server streams created successfully")
                     
-                    # Create initialization options with version compatibility
-                    capabilities = self._get_mcp_capabilities()
-                    
-                    init_options = InitializationOptions(
-                        server_name="doris-mcp-server",
-                        server_version=os.getenv("SERVER_VERSION", _default_config.server_version),
-                        capabilities=capabilities,
-                    )
-                    self.logger.info("Initialization options created successfully")
-                    
                     # Run server
                     self.logger.info("Starting to run MCP server...")
-                    await self.server.run(read_stream, write_stream, init_options)
+                    await self.server.run(
+                        read_stream,
+                        write_stream,
+                        self.server.create_initialization_options(),
+                    )
                     
             except Exception as inner_e:
                 self.logger.error(f"stdio_server internal error: {inner_e}")
@@ -544,23 +184,22 @@ class DorisServer:
                     )
                 self.logger.info("HTTP mode running without global database pool, will use token-bound configurations")
 
-            # Use Starlette and StreamableHTTPSessionManager according to official example
-            import uvicorn
+            # Use the SDK v2 dual-era Streamable HTTP manager.
             import contextlib
             from collections.abc import AsyncIterator
+
+            import uvicorn
             from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
             from starlette.applications import Starlette
-            from starlette.routing import Route
             from starlette.responses import JSONResponse, Response
-            from starlette.types import Scope
-            from starlette.middleware.cors import CORSMiddleware
-            from .auth.mcp_cors import mcp_cors_preflight_response, send_with_mcp_cors
-            
+            from starlette.routing import Route
+
             # Create session manager
             session_manager = StreamableHTTPSessionManager(
                 app=self.server,
-                json_response=True,  # Enable JSON response
-                stateless=False  # Maintain session state
+                json_response=True,
+                stateless=True,
+                security_settings=create_transport_security(host),
             )
             
             self.logger.info(f"StreamableHTTP session manager created, will start at http://{host}:{port}")
@@ -646,7 +285,7 @@ class DorisServer:
 
             # Create ASGI application - use direct session manager as ASGI app
             starlette_app = Starlette(
-                debug=True,
+                debug=False,
                 routes=routes,
                 lifespan=lifespan,
             )
@@ -655,27 +294,6 @@ class DorisServer:
 
             async def authenticated_mcp_downstream(scope, receive, send):
                 """Handle authenticated MCP request after auth context is set."""
-                method = scope.get("method", "UNKNOWN")
-                headers = dict(scope.get("headers", []))
-
-                # Handle Dify compatibility for GET requests
-                if method == "GET":
-                    accept_header = headers.get(b'accept', b'').decode('utf-8')
-
-                    # For other GET requests, try to add application/json to Accept header
-                    if 'text/event-stream' in accept_header and 'application/json' not in accept_header:
-                        self.logger.info("Adding application/json to Accept header for GET request")
-                        new_headers = []
-                        for name, value in scope.get("headers", []):
-                            if name == b'accept':
-                                new_value = value.decode('utf-8') + ', application/json'
-                                new_headers.append((name, new_value.encode('utf-8')))
-                            else:
-                                new_headers.append((name, value))
-                        scope = dict(scope)
-                        scope["headers"] = new_headers
-                        self.logger.info(f"Modified Accept header to: {new_value}")
-
                 await session_manager.handle_request(scope, receive, send)
 
             mcp_auth_middleware = MCPAuthASGIMiddleware(
@@ -684,16 +302,7 @@ class DorisServer:
                 effective_auth,
             )
 
-            # Add CORS middleware allowing all origins
-            starlette_app.add_middleware(
-                CORSMiddleware,
-                allow_origins=["*"],
-                allow_credentials=True,
-                allow_methods=["*"],
-                allow_headers=["*"],
-            )
-            
-            # Custom ASGI app that handles both /mcp and /mcp/ without redirects
+            # Custom ASGI app that keeps auxiliary routes outside MCP auth.
             async def mcp_app(scope, receive, send):
                 # Handle lifespan events
                 if scope["type"] == "lifespan":
@@ -722,18 +331,9 @@ class DorisServer:
                             await starlette_app(scope, receive, send)
                             return
                         
-                        # Handle MCP requests - both /mcp and /mcp/ go to session manager
-                        if path == "/mcp" or path.startswith("/mcp/"):
+                        if path == "/mcp":
                             self.logger.info(f"Handling MCP request for path: {path}")
-                            method = scope.get("method", "UNKNOWN")
-                            if method == "OPTIONS":
-                                response = mcp_cors_preflight_response(scope)
-                                await response(scope, receive, send)
-                                return
-                            async def send_with_cors(message):
-                                await send_with_mcp_cors(scope, send, message)
-
-                            await mcp_auth_middleware(scope, receive, send_with_cors)
+                            await mcp_auth_middleware(scope, receive, send)
                             return
                         
                         # 404 for other paths
@@ -755,7 +355,19 @@ class DorisServer:
             if workers > 1:
                 self.logger.info(f"Using multi-process mode with {workers} workers")
                 self.logger.info("Note: Multi-worker mode provides full MCP functionality with independent worker processes")
-                
+
+                # Uvicorn workers import ``multiworker_app`` in fresh processes.
+                # Persist the already-resolved parent configuration so CLI
+                # overrides are not lost when each child calls ``from_env()``.
+                os.environ.update(
+                    _multiworker_environment(
+                        self.config,
+                        host=host,
+                        port=port,
+                        workers=workers,
+                    )
+                )
+
                 # Use the dedicated multiworker app module with full MCP support
                 uvicorn.run(
                     "doris_mcp_server.multiworker_app:app",
@@ -818,7 +430,7 @@ def create_arg_parser():
         epilog="""
 Transport Modes:
   stdio    - Standard input/output (for local process communication)
-  http     - Streamable HTTP mode (MCP 2025-03-26 protocol)
+  http     - Streamable HTTP mode (MCP 2026-07-28 with legacy compatibility)
 
 Examples:
   python -m doris_mcp_server --transport stdio

--- a/doris_mcp_server/multiworker_app.py
+++ b/doris_mcp_server/multiworker_app.py
@@ -24,205 +24,28 @@ robust architecture as the single-worker mode.
 """
 
 import os
-import asyncio
 from contextlib import asynccontextmanager
-import json
-import logging
-from typing import Any
-
-# Import MCP components with compatibility handling
-# Use the same import strategy as main.py for consistency
-MCP_VERSION = 'unknown'
-Server = None
-InitializationOptions = None
-Prompt = None
-Resource = None
-TextContent = None
-Tool = None
-
-def _import_mcp_with_compatibility():
-    """Import MCP components with multi-version compatibility"""
-    global MCP_VERSION, Server, InitializationOptions, Prompt, Resource, TextContent, Tool
-    
-    try:
-        # Strategy 1: Try direct server-only imports to avoid client-side issues
-        from mcp.server import Server as _Server
-        from mcp.server.models import InitializationOptions as _InitOptions
-        from mcp.types import (
-            Prompt as _Prompt,
-            Resource as _Resource, 
-            TextContent as _TextContent,
-            Tool as _Tool,
-        )
-        
-        # Assign to globals
-        Server = _Server
-        InitializationOptions = _InitOptions
-        Prompt = _Prompt
-        Resource = _Resource
-        TextContent = _TextContent
-        Tool = _Tool
-        
-        # Try to get version safely
-        try:
-            import mcp
-            MCP_VERSION = getattr(mcp, '__version__', None)
-            if not MCP_VERSION:
-                # Fallback: try to get version from package metadata
-                try:
-                    import importlib.metadata
-                    MCP_VERSION = importlib.metadata.version('mcp')
-                except Exception:
-                    # Second fallback: try pkg_resources
-                    try:
-                        import pkg_resources
-                        MCP_VERSION = pkg_resources.get_distribution('mcp').version
-                    except Exception:
-                        MCP_VERSION = 'detected-but-version-unknown'
-        except Exception:
-            # Version detection failed, but imports worked
-            try:
-                import importlib.metadata
-                MCP_VERSION = importlib.metadata.version('mcp')
-            except Exception:
-                try:
-                    import pkg_resources
-                    MCP_VERSION = pkg_resources.get_distribution('mcp').version
-                except Exception:
-                    MCP_VERSION = 'imported-successfully'
-            
-        logger = logging.getLogger(__name__)
-        logger.info(f"MCP components imported successfully in multiworker, version: {MCP_VERSION}")
-        return True
-        
-    except Exception as import_error:
-        logger = logging.getLogger(__name__)
-        
-        # Strategy 2: Handle RequestContext compatibility issues in 1.9.x versions
-        error_str = str(import_error).lower()
-        if 'requestcontext' in error_str and 'too few arguments' in error_str:
-            logger.warning(f"Detected MCP RequestContext compatibility issue: {import_error}")
-            logger.info("Attempting comprehensive workaround for MCP 1.9.x RequestContext issue...")
-            
-            try:
-                # Comprehensive monkey patch approach
-                import sys
-                import types
-                
-                # Create and install mock modules before any MCP imports
-                if 'mcp.shared.context' not in sys.modules:
-                    mock_context_module = types.ModuleType('mcp.shared.context')
-                    
-                    class FlexibleRequestContext:
-                        """Flexible RequestContext that accepts variable arguments"""
-                        def __init__(self, *args, **kwargs):
-                            self.args = args
-                            self.kwargs = kwargs
-                        
-                        def __class_getitem__(cls, params):
-                            # Accept any number of parameters and return cls
-                            return cls
-                        
-                        # Add other methods that might be called
-                        def __getattr__(self, name):
-                            return lambda *args, **kwargs: None
-                    
-                    mock_context_module.RequestContext = FlexibleRequestContext
-                    sys.modules['mcp.shared.context'] = mock_context_module
-                
-                # Also patch the typing system to be more permissive  
-                original_check_generic = None
-                try:
-                    import typing
-                    if hasattr(typing, '_check_generic'):
-                        original_check_generic = typing._check_generic
-                        def permissive_check_generic(cls, params, elen):
-                            # Don't enforce strict parameter count checking
-                            return
-                        typing._check_generic = permissive_check_generic
-                except Exception:
-                    pass
-                
-                # Clear any cached imports that might have failed
-                modules_to_clear = [k for k in sys.modules.keys() if k.startswith('mcp.')]
-                for module in modules_to_clear:
-                    if module in sys.modules:
-                        del sys.modules[module]
-                
-                # Now try importing again with the patches in place
-                from mcp.server import Server as _Server
-                from mcp.server.models import InitializationOptions as _InitOptions
-                from mcp.types import (
-                    Prompt as _Prompt,
-                    Resource as _Resource, 
-                    TextContent as _TextContent,
-                    Tool as _Tool,
-                )
-                
-                # Assign to globals
-                Server = _Server
-                InitializationOptions = _InitOptions
-                Prompt = _Prompt
-                Resource = _Resource
-                TextContent = _TextContent
-                Tool = _Tool
-                
-                # Try to detect actual version even in compatibility mode
-                try:
-                    import importlib.metadata
-                    actual_version = importlib.metadata.version('mcp')
-                    MCP_VERSION = f'compatibility-mode-{actual_version}'
-                except Exception:
-                    try:
-                        import pkg_resources
-                        actual_version = pkg_resources.get_distribution('mcp').version
-                        MCP_VERSION = f'compatibility-mode-{actual_version}'
-                    except Exception:
-                        MCP_VERSION = 'compatibility-mode-1.9.x'
-                
-                logger.info("MCP 1.9.x compatibility workaround successful in multiworker!")
-                
-                # Restore original typing function if we patched it
-                if original_check_generic:
-                    typing._check_generic = original_check_generic
-                
-                return True
-                
-            except Exception as workaround_error:
-                logger.error(f"MCP compatibility workaround failed in multiworker: {workaround_error}")
-                
-                # Restore original typing function if we patched it
-                if original_check_generic:
-                    try:
-                        import typing
-                        typing._check_generic = original_check_generic
-                    except Exception:
-                        pass
-        
-        logger.error(f"Failed to import MCP components in multiworker: {import_error}")
-        return False
-
-# Perform MCP import with compatibility handling
-if not _import_mcp_with_compatibility():
-    raise ImportError(
-        "Failed to import MCP components in multiworker. Please ensure MCP is properly installed. "
-        "Supported versions: 1.8.x, 1.9.x"
-    )
+from importlib.metadata import version as distribution_version
 
 from starlette.applications import Starlette
+from starlette.responses import JSONResponse
 from starlette.routing import Route
-from starlette.responses import JSONResponse, Response
-from starlette.middleware.cors import CORSMiddleware
+
+from .protocol import create_doris_mcp_server, create_transport_security
+from .tools.prompts_manager import DorisPromptsManager
+from .tools.resources_manager import DorisResourcesManager
 
 # Import Doris MCP components
 from .tools.tools_manager import DorisToolsManager
-from .tools.prompts_manager import DorisPromptsManager
-from .tools.resources_manager import DorisResourcesManager
-from .auth.mcp_cors import mcp_cors_preflight_response, send_with_mcp_cors
-from .auth.operation_policy import OperationAuthorizationError, authorize_operation
-from .utils.config import DorisConfig, get_effective_auth_config, normalize_effective_auth_config
+from .utils.config import (
+    DorisConfig,
+    get_effective_auth_config,
+    normalize_effective_auth_config,
+)
 from .utils.db import DorisConnectionManager
-from .utils.security import DorisSecurityManager, get_current_auth_context
+from .utils.security import DorisSecurityManager
+
+MCP_VERSION = distribution_version("mcp")
 
 # Global variables for worker-specific instances
 _worker_server = None
@@ -233,35 +56,6 @@ _worker_session_manager_context = None
 _worker_initialized = False
 _worker_effective_auth = None
 _doris_oauth_handlers = None
-
-
-def get_mcp_capabilities():
-    """Get MCP capabilities for worker - use the same logic as main.py"""
-    try:
-        # For MCP 1.9.x and newer
-        from mcp.server.lowlevel.server import NotificationOptions
-        
-        capabilities = {
-            "resources": {},
-            "tools": {},
-            "prompts": {},
-            "notification_options": {
-                "prompts_changed": True,
-                "resources_changed": True,
-                "tools_changed": True
-            }
-        }
-        return capabilities
-    except Exception as e:
-        # Import logger properly
-        from .utils.logger import get_logger
-        logger = get_logger(__name__)
-        logger.warning(f"Failed to get full capabilities in multiworker: {e}")
-        return {
-            "resources": {},
-            "tools": {},
-            "prompts": {}
-        }
 
 async def initialize_worker():
     """Initialize MCP server and managers for this worker process"""
@@ -305,126 +99,19 @@ async def initialize_worker():
         
         await _worker_connection_manager.initialize()
         
-        # Create MCP server
-        _worker_server = Server("doris-mcp-server")
-        
         # Create managers
         resources_manager = DorisResourcesManager(_worker_connection_manager)
         tools_manager = DorisToolsManager(_worker_connection_manager)
         prompts_manager = DorisPromptsManager(_worker_connection_manager)
-        
-        # Setup MCP handlers
-        @_worker_server.list_resources()
-        async def handle_list_resources() -> list[Resource]:
-            """Handle resource list request"""
-            try:
-                authorize_operation(get_current_auth_context(), "list_resources")
-                logger.info("Handling resource list request in worker")
-                resources = await resources_manager.list_resources()
-                logger.info(f"Returning {len(resources)} resources from worker")
-                return resources
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to handle resource list request in worker: {e}")
-                if getattr(get_current_auth_context(), "auth_method", "") == "doris_oauth":
-                    raise
-                return []
 
-        @_worker_server.read_resource()
-        async def handle_read_resource(uri: str) -> str:
-            """Handle resource read request"""
-            try:
-                authorize_operation(get_current_auth_context(), "read_resource")
-                logger.info(f"Handling resource read request in worker: {uri}")
-                content = await resources_manager.read_resource(uri)
-                return content
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to handle resource read request in worker: {e}")
-                if getattr(get_current_auth_context(), "auth_method", "") == "doris_oauth":
-                    raise
-                return json.dumps(
-                    {"error": f"Failed to read resource: {str(e)}", "uri": uri},
-                    ensure_ascii=False,
-                    indent=2,
-                )
-
-        @_worker_server.list_tools()
-        async def handle_list_tools() -> list[Tool]:
-            """Handle tool list request"""
-            try:
-                authorize_operation(get_current_auth_context(), "list_tools")
-                logger.info("Handling tool list request in worker")
-                tools = await tools_manager.list_tools()
-                logger.info(f"Returning {len(tools)} tools from worker")
-                return tools
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to handle tool list request in worker: {e}")
-                return []
-
-        @_worker_server.call_tool()
-        async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
-            """Handle tool call request"""
-            try:
-                logger.info(f"Handling tool call request in worker: {name}")
-                result = await tools_manager.call_tool(name, arguments)
-                return [TextContent(type="text", text=result)]
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to handle tool call request in worker: {e}")
-                error_result = json.dumps(
-                    {
-                        "error": f"Tool call failed: {str(e)}",
-                        "tool_name": name,
-                        "arguments": arguments,
-                    },
-                    ensure_ascii=False,
-                    indent=2,
-                )
-                return [TextContent(type="text", text=error_result)]
-
-        @_worker_server.list_prompts()
-        async def handle_list_prompts() -> list[Prompt]:
-            """Handle prompt list request"""
-            try:
-                authorize_operation(get_current_auth_context(), "list_prompts")
-                logger.info("Handling prompt list request in worker")
-                prompts = await prompts_manager.list_prompts()
-                logger.info(f"Returning {len(prompts)} prompts from worker")
-                return prompts
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to handle prompt list request in worker: {e}")
-                return []
-
-        @_worker_server.get_prompt()
-        async def handle_get_prompt(name: str, arguments: dict[str, Any]) -> str:
-            """Handle prompt get request"""
-            try:
-                authorize_operation(get_current_auth_context(), "get_prompt")
-                logger.info(f"Handling prompt get request in worker: {name}")
-                result = await prompts_manager.get_prompt(name, arguments)
-                return result
-            except OperationAuthorizationError:
-                raise
-            except Exception as e:
-                logger.error(f"Failed to handle prompt get request in worker: {e}")
-                error_result = json.dumps(
-                    {
-                        "error": f"Failed to get prompt: {str(e)}",
-                        "prompt_name": name,
-                        "arguments": arguments,
-                    },
-                    ensure_ascii=False,
-                    indent=2,
-                )
-                return error_result
+        _worker_server = create_doris_mcp_server(
+            resources_manager=resources_manager,
+            tools_manager=tools_manager,
+            prompts_manager=prompts_manager,
+            name=config.server_name,
+            version=config.server_version,
+            logger=logger,
+        )
         
         # Create session manager for this worker
         from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
@@ -432,7 +119,8 @@ async def initialize_worker():
         _worker_session_manager = StreamableHTTPSessionManager(
             app=_worker_server,
             json_response=True,
-            stateless=True  # Use stateless mode for multi-worker compatibility
+            stateless=True,
+            security_settings=create_transport_security(config.server_host),
         )
         
         # Start the session manager context
@@ -699,7 +387,7 @@ async def mcp_asgi_app(scope, receive, send):
 
 # Create Starlette app with basic routes
 basic_app = Starlette(
-    debug=True,
+    debug=False,
     routes=[
         Route("/", root_info, methods=["GET"]),
         Route("/health", health_check, methods=["GET"]),
@@ -729,31 +417,13 @@ basic_app = Starlette(
     lifespan=lifespan
 )
 
-# Add CORS middleware allowing all origins
-basic_app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
 # Create main ASGI app that routes between basic app and MCP
 async def app(scope, receive, send):
     """Main ASGI app that routes requests"""
     path = scope.get('path', '/')
     
-    if path == "/mcp" or path.startswith('/mcp/'):
-        if scope.get("type") == "http" and scope.get("method", "UNKNOWN") == "OPTIONS":
-            response = mcp_cors_preflight_response(scope)
-            await response(scope, receive, send)
-            return
-
-        async def send_with_cors(message):
-            await send_with_mcp_cors(scope, send, message)
-
-        # Handle MCP requests with session manager
-        await mcp_asgi_app(scope, receive, send_with_cors)
+    if path == "/mcp":
+        await mcp_asgi_app(scope, receive, send)
     elif path.startswith("/auth/") and _worker_effective_auth and not _worker_effective_auth.enable_external_oauth_auth:
         response = JSONResponse({"error": "external_oauth_disabled"}, status_code=404)
         await response(scope, receive, send)

--- a/doris_mcp_server/protocol.py
+++ b/doris_mcp_server/protocol.py
@@ -1,0 +1,204 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""MCP 2026-07-28 protocol boundary for Doris managers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Protocol
+
+from mcp.server import Server, ServerRequestContext
+from mcp.server.caching import CacheHint
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    GetPromptRequestParams,
+    GetPromptResult,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    Prompt,
+    ReadResourceRequestParams,
+    ReadResourceResult,
+    Resource,
+    TextContent,
+    TextResourceContents,
+    Tool,
+)
+
+from .auth.operation_policy import authorize_operation
+from .utils.security import get_current_auth_context
+
+
+class ResourcesManager(Protocol):
+    async def list_resources(self) -> list[Resource]: ...
+
+    async def read_resource(self, uri: str) -> str: ...
+
+
+class ToolsManager(Protocol):
+    async def list_tools(self) -> list[Tool]: ...
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> str: ...
+
+
+class PromptsManager(Protocol):
+    async def list_prompts(self) -> list[Prompt]: ...
+
+    async def get_prompt(
+        self, name: str, arguments: dict[str, Any]
+    ) -> GetPromptResult: ...
+
+
+def create_transport_security(host: str) -> TransportSecuritySettings:
+    """Create a fail-closed Host and Origin policy for a bind host."""
+    if host in {"127.0.0.1", "localhost", "::1"}:
+        allowed_hosts = ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+        allowed_origins = [
+            "http://127.0.0.1:*",
+            "http://localhost:*",
+            "http://[::1]:*",
+        ]
+    else:
+        # A bind address is not a public deployment hostname. Explicit
+        # deployment allowlists will replace this conservative fallback.
+        allowed_hosts = [host, f"{host}:*"]
+        allowed_origins = []
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins,
+    )
+
+
+def _decode_structured_tool_result(payload: str) -> tuple[Any | None, bool]:
+    """Extract safe structured content and the legacy manager's error marker."""
+    try:
+        decoded = json.loads(payload)
+    except (TypeError, json.JSONDecodeError):
+        return None, False
+
+    if not isinstance(decoded, dict):
+        return None, False
+    return decoded, "error" in decoded
+
+
+def create_doris_mcp_server(
+    *,
+    resources_manager: ResourcesManager,
+    tools_manager: ToolsManager,
+    prompts_manager: PromptsManager,
+    name: str,
+    version: str,
+    logger: logging.Logger,
+) -> Server:
+    """Create the one low-level SDK v2 server used by every transport."""
+
+    async def list_resources(
+        ctx: ServerRequestContext,
+        params: PaginatedRequestParams | None,
+    ) -> ListResourcesResult:
+        del ctx, params
+        authorize_operation(get_current_auth_context(), "list_resources")
+        resources = await resources_manager.list_resources()
+        logger.info("Returning %d resources", len(resources))
+        return ListResourcesResult(resources=resources)
+
+    async def read_resource(
+        ctx: ServerRequestContext,
+        params: ReadResourceRequestParams,
+    ) -> ReadResourceResult:
+        del ctx
+        authorize_operation(get_current_auth_context(), "read_resource")
+        content = await resources_manager.read_resource(params.uri)
+        return ReadResourceResult(
+            contents=[
+                TextResourceContents(
+                    uri=params.uri,
+                    mime_type="application/json",
+                    text=content,
+                )
+            ]
+        )
+
+    async def list_tools(
+        ctx: ServerRequestContext,
+        params: PaginatedRequestParams | None,
+    ) -> ListToolsResult:
+        del ctx, params
+        authorize_operation(get_current_auth_context(), "list_tools")
+        tools = await tools_manager.list_tools()
+        logger.info("Returning %d tools", len(tools))
+        return ListToolsResult(tools=tools)
+
+    async def call_tool(
+        ctx: ServerRequestContext,
+        params: CallToolRequestParams,
+    ) -> CallToolResult:
+        del ctx
+        arguments = params.arguments or {}
+        payload = await tools_manager.call_tool(params.name, arguments)
+        structured_content, is_error = _decode_structured_tool_result(payload)
+        return CallToolResult(
+            content=[TextContent(type="text", text=payload)],
+            structured_content=structured_content,
+            is_error=is_error,
+        )
+
+    async def list_prompts(
+        ctx: ServerRequestContext,
+        params: PaginatedRequestParams | None,
+    ) -> ListPromptsResult:
+        del ctx, params
+        authorize_operation(get_current_auth_context(), "list_prompts")
+        prompts = await prompts_manager.list_prompts()
+        logger.info("Returning %d prompts", len(prompts))
+        return ListPromptsResult(prompts=prompts)
+
+    async def get_prompt(
+        ctx: ServerRequestContext,
+        params: GetPromptRequestParams,
+    ) -> GetPromptResult:
+        del ctx
+        authorize_operation(get_current_auth_context(), "get_prompt")
+        return await prompts_manager.get_prompt(
+            params.name,
+            dict(params.arguments or {}),
+        )
+
+    private_no_cache = CacheHint(ttl_ms=0, scope="private")
+    return Server(
+        name,
+        version=version,
+        description="Model Context Protocol server for Apache Doris",
+        cache_hints={
+            "server/discover": CacheHint(ttl_ms=300_000, scope="public"),
+            "tools/list": private_no_cache,
+            "resources/list": private_no_cache,
+            "resources/read": private_no_cache,
+            "prompts/list": private_no_cache,
+        },
+        on_list_resources=list_resources,
+        on_read_resource=read_resource,
+        on_list_tools=list_tools,
+        on_call_tool=call_tool,
+        on_list_prompts=list_prompts,
+        on_get_prompt=get_prompt,
+    )

--- a/doris_mcp_server/utils/config.py
+++ b/doris_mcp_server/utils/config.py
@@ -22,8 +22,8 @@ Implements configuration loading, validation and management functionality
 
 import json
 import logging
-import os
 import multiprocessing
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -492,7 +492,7 @@ class DorisConfig:
 
     # Basic configuration
     server_name: str = "doris-mcp-server"
-    server_version: str = "0.4.1"
+    server_version: str = "0.6.1"
     server_host: str = "localhost"
     server_port: int = 3000
     transport: str = "stdio"
@@ -919,6 +919,9 @@ class DorisConfig:
         # Server configuration
         config.server_name = os.getenv("SERVER_NAME", config.server_name)
         config.server_version = os.getenv("SERVER_VERSION", config.server_version)
+        server_host = os.getenv("SERVER_HOST", "").strip()
+        if server_host:
+            config.server_host = server_host
         if "TRANSPORT" in os.environ:
             config.transport = os.getenv("TRANSPORT", config.transport)
             _mark_source(config, "transport", "env")
@@ -1497,8 +1500,9 @@ class ConfigManager:
 
     def setup_logging(self):
         """Setup logging configuration using enhanced logger"""
-        from .logger import setup_logging, get_logger
         import sys
+
+        from .logger import setup_logging
         
         # Determine log directory
         log_dir = "logs"

--- a/doris_mcp_server/utils/query_executor.py
+++ b/doris_mcp_server/utils/query_executor.py
@@ -369,12 +369,14 @@ class DorisQueryExecutor:
     def _start_background_tasks(self):
         """Start background tasks"""
         try:
-            # Cache cleanup task
-            cleanup_task = asyncio.create_task(self._cache_cleanup_loop())
-            self._background_tasks.append(cleanup_task)
+            loop = asyncio.get_running_loop()
         except RuntimeError:
             # No event loop running (e.g., in tests), skip background tasks
             self.logger.debug("No event loop running, skipping background tasks")
+            return
+
+        cleanup_task = loop.create_task(self._cache_cleanup_loop())
+        self._background_tasks.append(cleanup_task)
 
     async def _cache_cleanup_loop(self):
         """Background cache cleanup loop"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 
 dependencies = [
     # Core MCP dependencies
-    "mcp>=1.8.0,<2.0.0",
+    "mcp>=2.0.0,<2.1.0",
     # Database drivers
     "aiomysql>=0.2.0",
     "PyMySQL>=1.1.0",
@@ -152,13 +152,14 @@ Changelog = "https://github.com/apache/doris-mcp-server/blob/main/CHANGELOG.md"
 
 [project.scripts]
 doris-mcp-server = "doris_mcp_server.main:main_sync"
-doris-mcp-client = "doris_mcp_server.client:main"
+doris-mcp-client = "doris_mcp_client.client:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["doris_mcp_server"]
+packages = ["doris_mcp_server", "doris_mcp_client"]
 
 [tool.hatch.build.targets.sdist]
 include = [
+    "/doris_mcp_client",
     "/doris_mcp_server",
     "/README.md",
     "/LICENSE",
@@ -226,7 +227,7 @@ addopts = [
     "--cov-report=html",
     "--cov-report=xml",
 ]
-testpaths = ["tests"]
+testpaths = ["test"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
@@ -297,4 +298,3 @@ ignore = [
 dev = [
     "ruff>=0.11.13",
 ]
- 

--- a/test/integration/test_end_to_end.py
+++ b/test/integration/test_end_to_end.py
@@ -20,12 +20,16 @@ End-to-end integration tests
 """
 
 import json
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import Mock, patch
 
 from doris_mcp_server.main import DorisServer
-from doris_mcp_server.utils.config import DorisConfig
-from doris_mcp_server.utils.security import SecurityLevel, AuthContext
+from doris_mcp_server.utils.config import (
+    DorisConfig,
+    normalize_effective_auth_config,
+)
+from doris_mcp_server.utils.security import AuthContext, SecurityLevel
 
 
 class TestEndToEndIntegration:
@@ -34,12 +38,8 @@ class TestEndToEndIntegration:
     @pytest.fixture
     def mock_config(self):
         """Create mock configuration"""
-        from doris_mcp_server.utils.config import ADBCConfig, DatabaseConfig, SecurityConfig
-        
-        config = Mock(spec=DorisConfig)
-        
-        # Add database config
-        config.database = Mock(spec=DatabaseConfig)
+        config = DorisConfig()
+
         config.database.host = "localhost"
         config.database.port = 9030
         config.database.user = "test_user"
@@ -49,19 +49,12 @@ class TestEndToEndIntegration:
         config.database.max_connections = 20
         config.database.connection_timeout = 30
         config.database.max_connection_age = 3600
-        
-        # Add security config
-        config.security = Mock(spec=SecurityConfig)
+
         config.security.enable_masking = True
-        config.security.auth_type = "token"
-        config.security.token_secret = "test_secret"
-        config.security.token_expiry = 3600
         config.security.blocked_keywords = ["DROP"]
-        
-        # Add adbc config
-        config.adbc = Mock(spec=ADBCConfig)
         config.adbc.enabled = True
 
+        normalize_effective_auth_config(config, requested_workers=1)
         return config
 
     @pytest.fixture

--- a/test/protocol/test_mcp_v2_protocol.py
+++ b/test/protocol/test_mcp_v2_protocol.py
@@ -1,0 +1,328 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import logging
+
+import httpx2
+import pytest
+from mcp import Client
+from mcp.types import (
+    GetPromptResult,
+    Prompt,
+    PromptMessage,
+    Resource,
+    TextContent,
+    Tool,
+)
+
+from doris_mcp_server.protocol import (
+    create_doris_mcp_server,
+    create_transport_security,
+)
+
+
+class StubResourcesManager:
+    async def list_resources(self) -> list[Resource]:
+        return [
+            Resource(
+                uri="doris://table/orders",
+                name="orders",
+                mime_type="application/json",
+            )
+        ]
+
+    async def read_resource(self, uri: str) -> str:
+        return json.dumps({"uri": uri, "columns": 3})
+
+
+class StubToolsManager:
+    async def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="echo",
+                description="Echo structured input.",
+                input_schema={
+                    "type": "object",
+                    "properties": {"value": {"type": "string"}},
+                    "required": ["value"],
+                },
+            ),
+            Tool(
+                name="fail",
+                description="Return a model-readable tool error.",
+                input_schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+    async def call_tool(self, name: str, arguments: dict) -> str:
+        if name == "fail":
+            return json.dumps({"error": "expected failure"})
+        return json.dumps({"name": name, "arguments": arguments})
+
+
+class StubPromptsManager:
+    async def list_prompts(self) -> list[Prompt]:
+        return [Prompt(name="explain", description="Explain a query.")]
+
+    async def get_prompt(self, name: str, arguments: dict) -> GetPromptResult:
+        return GetPromptResult(
+            description=name,
+            messages=[
+                PromptMessage(
+                    role="user",
+                    content=TextContent(
+                        type="text",
+                        text=f"Explain {arguments.get('sql', '')}",
+                    ),
+                )
+            ],
+        )
+
+
+def create_test_server():
+    return create_doris_mcp_server(
+        resources_manager=StubResourcesManager(),
+        tools_manager=StubToolsManager(),
+        prompts_manager=StubPromptsManager(),
+        name="doris-mcp-server",
+        version="0.6.1",
+        logger=logging.getLogger(__name__),
+    )
+
+
+@pytest.mark.asyncio
+async def test_modern_and_legacy_clients_share_the_v2_protocol_core():
+    server = create_test_server()
+
+    async with Client(server) as modern:
+        assert modern.protocol_version == "2026-07-28"
+        assert modern.server_info is not None
+        assert modern.server_info.name == "doris-mcp-server"
+        assert modern.server_info.version == "0.6.1"
+        assert modern.session.discover_result is not None
+        assert modern.session.discover_result.result_type == "complete"
+
+        tools_result = await modern.list_tools(cache_mode="bypass")
+        assert [tool.name for tool in tools_result.tools] == ["echo", "fail"]
+        assert tools_result.result_type == "complete"
+        assert tools_result.ttl_ms == 0
+        assert tools_result.cache_scope == "private"
+
+        resources_result = await modern.list_resources(cache_mode="bypass")
+        assert [resource.name for resource in resources_result.resources] == ["orders"]
+        assert resources_result.result_type == "complete"
+        assert resources_result.ttl_ms == 0
+        assert resources_result.cache_scope == "private"
+
+        prompts_result = await modern.list_prompts(cache_mode="bypass")
+        assert [prompt.name for prompt in prompts_result.prompts] == ["explain"]
+        assert prompts_result.result_type == "complete"
+        assert prompts_result.ttl_ms == 0
+        assert prompts_result.cache_scope == "private"
+
+        tool_result = await modern.call_tool("echo", {"value": "hello"})
+        assert tool_result.result_type == "complete"
+        assert tool_result.is_error is False
+        assert tool_result.structured_content == {
+            "name": "echo",
+            "arguments": {"value": "hello"},
+        }
+
+        error_result = await modern.call_tool("fail", {})
+        assert error_result.is_error is True
+        assert error_result.structured_content == {"error": "expected failure"}
+
+        resource_result = await modern.read_resource(
+            "doris://table/orders",
+            cache_mode="bypass",
+        )
+        assert resource_result.result_type == "complete"
+        assert resource_result.cache_scope == "private"
+        assert resource_result.contents[0].uri == "doris://table/orders"
+
+        prompt_result = await modern.get_prompt("explain", {"sql": "SELECT 1"})
+        assert prompt_result.result_type == "complete"
+        assert prompt_result.messages[0].content.text == "Explain SELECT 1"
+
+    async with Client(server, mode="legacy") as legacy:
+        assert legacy.protocol_version == "2025-11-25"
+        assert [tool.name for tool in (await legacy.list_tools()).tools] == [
+            "echo",
+            "fail",
+        ]
+
+
+def modern_request(request_id: int, method: str) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "doris-mcp-test",
+                    "version": "1.0.0",
+                },
+            }
+        },
+    }
+
+
+def modern_headers(method: str) -> dict[str, str]:
+    return {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Mcp-Protocol-Version": "2026-07-28",
+        "Mcp-Method": method,
+    }
+
+
+@pytest.mark.asyncio
+async def test_http_discover_is_stateless_and_unknown_method_does_not_kill_server():
+    app = create_test_server().streamable_http_app(
+        json_response=True,
+        stateless_http=True,
+        host="127.0.0.1",
+        transport_security=create_transport_security("127.0.0.1"),
+    )
+
+    async with (
+        app.router.lifespan_context(app),
+        httpx2.ASGITransport(app) as transport,
+        httpx2.AsyncClient(
+            transport=transport,
+            base_url="http://127.0.0.1:3000",
+        ) as client,
+    ):
+        first = await client.post(
+            "/mcp",
+            json=modern_request(1, "server/discover"),
+            headers=modern_headers("server/discover"),
+        )
+        assert first.status_code == 200
+        assert "mcp-session-id" not in first.headers
+        assert first.json()["result"]["supportedVersions"] == ["2026-07-28"]
+
+        unknown = await client.post(
+            "/mcp",
+            json=modern_request(2, "vendor/unknown"),
+            headers=modern_headers("vendor/unknown"),
+        )
+        assert unknown.status_code == 404
+        assert unknown.json()["error"]["code"] == -32601
+
+        malformed = await client.post(
+            "/mcp",
+            content=b"{",
+            headers=modern_headers("server/discover"),
+        )
+        assert malformed.status_code == 400
+        assert malformed.json()["error"]["code"] == -32700
+
+        mismatched_header = await client.post(
+            "/mcp",
+            json=modern_request(3, "server/discover"),
+            headers=modern_headers("tools/list"),
+        )
+        assert mismatched_header.status_code == 400
+        assert mismatched_header.json()["error"]["code"] == -32020
+
+        unsupported_request = modern_request(4, "server/discover")
+        unsupported_request["params"]["_meta"][
+            "io.modelcontextprotocol/protocolVersion"
+        ] = "2099-01-01"
+        unsupported_headers = modern_headers("server/discover")
+        unsupported_headers["Mcp-Protocol-Version"] = "2099-01-01"
+        unsupported_version = await client.post(
+            "/mcp",
+            json=unsupported_request,
+            headers=unsupported_headers,
+        )
+        assert unsupported_version.status_code == 400
+        assert unsupported_version.json()["error"]["code"] == -32022
+
+        second = await client.post(
+            "/mcp",
+            json=modern_request(5, "server/discover"),
+            headers=modern_headers("server/discover"),
+        )
+        assert second.status_code == 200
+        assert second.json()["result"]["resultType"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_http_rejects_untrusted_origin_and_legacy_is_stateless():
+    app = create_test_server().streamable_http_app(
+        json_response=True,
+        stateless_http=True,
+        host="127.0.0.1",
+        transport_security=create_transport_security("127.0.0.1"),
+    )
+    legacy_initialize = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "legacy-test", "version": "1.0.0"},
+        },
+    }
+    legacy_headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+
+    async with (
+        app.router.lifespan_context(app),
+        httpx2.ASGITransport(app) as transport,
+        httpx2.AsyncClient(
+            transport=transport,
+            base_url="http://127.0.0.1:3000",
+        ) as client,
+    ):
+        rejected = await client.post(
+            "/mcp",
+            json=modern_request(1, "server/discover"),
+            headers={
+                **modern_headers("server/discover"),
+                "Origin": "https://evil.example",
+            },
+        )
+        assert rejected.status_code == 403
+
+        rejected_host = await client.post(
+            "/mcp",
+            json=modern_request(2, "server/discover"),
+            headers={
+                **modern_headers("server/discover"),
+                "Host": "evil.example",
+            },
+        )
+        assert rejected_host.status_code == 421
+
+        initialized = await client.post(
+            "/mcp",
+            json=legacy_initialize,
+            headers=legacy_headers,
+        )
+        assert initialized.status_code == 200
+        assert "mcp-session-id" not in initialized.headers
+        assert initialized.json()["result"]["protocolVersion"] == "2025-11-25"

--- a/test/protocol/test_multiworker_config.py
+++ b/test/protocol/test_multiworker_config.py
@@ -1,0 +1,35 @@
+from doris_mcp_server.main import _multiworker_environment
+from doris_mcp_server.utils.config import DorisConfig
+
+
+def test_multiworker_environment_preserves_resolved_parent_config(monkeypatch):
+    config = DorisConfig()
+    config.database.host = "127.0.0.1"
+    config.database.port = 19030
+    config.database.user = "loader"
+    config.database.password = "test-password"
+    config.database.database = "hhm_dt_sim"
+    config.server_name = "doris-mcp-server"
+    config.server_version = "0.6.1"
+
+    worker_env = _multiworker_environment(
+        config,
+        host="127.0.0.1",
+        port=31133,
+        workers=2,
+    )
+    for key, value in worker_env.items():
+        monkeypatch.setenv(key, value)
+
+    child_config = DorisConfig.from_env()
+    assert child_config.database.host == "127.0.0.1"
+    assert child_config.database.port == 19030
+    assert child_config.database.user == "loader"
+    assert child_config.database.password == "test-password"
+    assert child_config.database.database == "hhm_dt_sim"
+    assert child_config.server_host == "127.0.0.1"
+    assert child_config.server_port == 31133
+    assert child_config.server_name == "doris-mcp-server"
+    assert child_config.server_version == "0.6.1"
+    assert child_config.transport == "http"
+    assert child_config.workers == 2

--- a/test/security/test_mcp_auth_middleware.py
+++ b/test/security/test_mcp_auth_middleware.py
@@ -69,19 +69,15 @@ async def test_mcp_auth_middleware_sets_scope_and_resets_context():
 
 
 @pytest.mark.asyncio
-async def test_mcp_auth_middleware_accepts_legacy_query_string_token():
-    auth_context = AuthContext(token_id="t1", user_id="u1", auth_method="token")
-
+async def test_mcp_auth_middleware_rejects_query_string_token():
     class SecurityManager:
         async def authenticate_request(self, auth_info):
-            assert auth_info["token"] == "legacy-query-token"
             assert auth_info["authorization"] == ""
-            return auth_context
+            assert "token" not in auth_info
+            raise ValueError("missing bearer token")
 
     async def downstream(scope, receive, send):
-        assert scope["auth_context"] is auth_context
-        await send({"type": "http.response.start", "status": 200, "headers": []})
-        await send({"type": "http.response.body", "body": b"ok"})
+        raise AssertionError("query-string credentials must not reach downstream")
 
     messages = []
     middleware = MCPAuthASGIMiddleware(SecurityManager(), downstream, _effective())
@@ -97,7 +93,7 @@ async def test_mcp_auth_middleware_accepts_legacy_query_string_token():
         _send_collector(messages),
     )
 
-    assert messages[0]["status"] == 200
+    assert messages[0]["status"] == 401
     assert get_current_auth_context() is None
 
 

--- a/test/security/test_sql_injection_api.py
+++ b/test/security/test_sql_injection_api.py
@@ -34,16 +34,23 @@ Usage:
     pytest test/security/test_sql_injection_api.py -v --no-cov
 """
 
-import pytest
-import httpx
-import json
 import asyncio
-from typing import Optional
+import json
+import os
 
+import httpx
+import pytest
+from mcp import Client as SDKClient
 
-# Server configuration
-MCP_BASE_URL = "http://localhost:3000"
-MCP_ENDPOINT = f"{MCP_BASE_URL}/mcp"
+# This suite targets a separately managed, destructive-test-safe MCP instance.
+# It must never attach itself to an arbitrary process already using localhost:3000.
+_configured_mcp_endpoint = os.getenv("DORIS_MCP_INTEGRATION_URL", "").rstrip("/")
+pytestmark = pytest.mark.skipif(
+    not _configured_mcp_endpoint,
+    reason="set DORIS_MCP_INTEGRATION_URL to run the external MCP injection suite",
+)
+MCP_ENDPOINT = _configured_mcp_endpoint or "http://localhost:3000/mcp"
+MCP_BASE_URL = MCP_ENDPOINT.removesuffix("/mcp")
 HEALTH_ENDPOINT = f"{MCP_BASE_URL}/health"
 TIMEOUT = 30.0
 
@@ -54,83 +61,32 @@ class MCPClient:
     def __init__(self, base_url: str = MCP_BASE_URL):
         self.base_url = base_url
         self.mcp_endpoint = f"{base_url}/mcp"
-        self.session_id: Optional[str] = None
-        self.request_id = 0
-        self.client = httpx.AsyncClient(timeout=TIMEOUT)
     
     async def close(self):
-        await self.client.aclose()
-    
-    def _next_id(self) -> int:
-        self.request_id += 1
-        return self.request_id
+        """No-op: each request owns and closes its SDK client context."""
     
     async def initialize(self) -> dict:
-        """Initialize MCP session"""
-        response = await self.client.post(
+        """Connect using SDK 2.0 auto-negotiation."""
+        async with SDKClient(
             self.mcp_endpoint,
-            headers={
-                "Content-Type": "application/json",
-                "Accept": "application/json, text/event-stream"
-            },
-            json={
-                "jsonrpc": "2.0",
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {},
-                    "clientInfo": {
-                        "name": "sql-injection-test",
-                        "version": "1.0.0"
-                    }
-                },
-                "id": self._next_id()
-            }
-        )
-        
-        # Extract session ID from response header
-        self.session_id = response.headers.get("mcp-session-id")
-        return self._parse_response(response.text)
+            read_timeout_seconds=TIMEOUT,
+        ) as client:
+            return {"protocolVersion": client.protocol_version}
     
     async def call_tool(self, tool_name: str, arguments: dict) -> dict:
         """Call an MCP tool"""
-        if not self.session_id:
-            await self.initialize()
-        
-        response = await self.client.post(
+        async with SDKClient(
             self.mcp_endpoint,
-            headers={
-                "Content-Type": "application/json",
-                "Accept": "application/json, text/event-stream",
-                "mcp-session-id": self.session_id
-            },
-            json={
-                "jsonrpc": "2.0",
-                "method": "tools/call",
-                "params": {
-                    "name": tool_name,
-                    "arguments": arguments
-                },
-                "id": self._next_id()
-            }
-        )
-        
-        return self._parse_response(response.text)
-    
-    def _parse_response(self, text: str) -> dict:
-        """Parse JSON response"""
-        try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            # Try SSE format
-            lines = text.strip().split("\n")
-            for line in lines:
-                if line.startswith("data: "):
-                    try:
-                        return json.loads(line[6:])
-                    except json.JSONDecodeError:
-                        continue
-            return {"raw": text}
+            read_timeout_seconds=TIMEOUT,
+        ) as client:
+            response = await client.call_tool(tool_name, arguments)
+        return {
+            "result": response.model_dump(
+                by_alias=True,
+                mode="json",
+                exclude_none=True,
+            )
+        }
 
 
 def print_result(test_name: str, payload: dict, result: dict):
@@ -211,7 +167,7 @@ class TestSQLInjectionAPI:
         
         # Should return error, not execute the DROP
         assert self._is_blocked_or_error(result), \
-            f"DROP TABLE injection should be blocked"
+            "DROP TABLE injection should be blocked"
     
     @pytest.mark.asyncio
     async def test_exec_query_with_union_injection(self, mcp_client):
@@ -229,7 +185,7 @@ class TestSQLInjectionAPI:
         print_result("DELETE Injection", payload, result)
         
         assert self._is_blocked_or_error(result), \
-            f"DELETE injection should be blocked"
+            "DELETE injection should be blocked"
     
     @pytest.mark.asyncio
     async def test_exec_query_with_update_injection(self, mcp_client):
@@ -239,7 +195,7 @@ class TestSQLInjectionAPI:
         print_result("UPDATE Injection", payload, result)
         
         assert self._is_blocked_or_error(result), \
-            f"UPDATE injection should be blocked"
+            "UPDATE injection should be blocked"
     
     @pytest.mark.asyncio
     async def test_exec_query_db_name_injection(self, mcp_client):
@@ -250,7 +206,7 @@ class TestSQLInjectionAPI:
         print_result("db_name Parameter Injection", payload, result)
         
         assert self._is_blocked_or_error(result), \
-            f"db_name injection should be blocked"
+            "db_name injection should be blocked"
     
     @pytest.mark.asyncio
     async def test_exec_query_catalog_name_injection(self, mcp_client):
@@ -261,7 +217,7 @@ class TestSQLInjectionAPI:
         print_result("catalog_name Parameter Injection", payload, result)
         
         assert self._is_blocked_or_error(result), \
-            f"catalog_name injection should be blocked"
+            "catalog_name injection should be blocked"
     
     @pytest.mark.asyncio
     async def test_get_table_schema_injection(self, mcp_client):
@@ -272,7 +228,7 @@ class TestSQLInjectionAPI:
         print_result("table_name Injection (get_table_schema)", payload, result)
         
         assert self._is_blocked_or_error(result), \
-            f"table_name injection should be blocked"
+            "table_name injection should be blocked"
     
     @pytest.mark.asyncio
     async def test_get_table_schema_db_injection(self, mcp_client):
@@ -282,7 +238,7 @@ class TestSQLInjectionAPI:
         print_result("db_name Injection (get_table_schema)", payload, result)
         
         assert self._is_blocked_or_error(result), \
-            f"db_name injection in get_table_schema should be blocked"
+            "db_name injection in get_table_schema should be blocked"
     
     @pytest.mark.asyncio
     async def test_analyze_dependencies_injection(self, mcp_client):
@@ -293,7 +249,7 @@ class TestSQLInjectionAPI:
         print_result("analyze_dependencies Injection (Original Report)", payload, result)
         
         assert self._is_blocked_or_error(result), \
-            f"analyze_dependencies db_name injection should be blocked"
+            "analyze_dependencies db_name injection should be blocked"
     
     @pytest.mark.asyncio
     async def test_stacked_queries_injection(self, mcp_client):
@@ -304,7 +260,7 @@ class TestSQLInjectionAPI:
         print_result("Stacked Queries (INSERT) Injection", payload, result)
         
         assert self._is_blocked_or_error(result), \
-            f"Stacked queries with INSERT should be blocked"
+            "Stacked queries with INSERT should be blocked"
     
     @pytest.mark.asyncio
     async def test_comment_based_injection(self, mcp_client):
@@ -331,7 +287,7 @@ class TestSQLInjectionAPI:
         print_result("Backtick Escape Injection", payload, result)
         
         assert self._is_blocked_or_error(result), \
-            f"Backtick escape injection should be blocked"
+            "Backtick escape injection should be blocked"
     
     @pytest.mark.asyncio
     async def test_valid_query_succeeds(self, mcp_client):
@@ -417,7 +373,7 @@ class TestIdentifierInjectionAPI:
         
         # Should be blocked by identifier validation
         assert self._contains_error_indicator(result), \
-            f"Table name with semicolon should be rejected"
+            "Table name with semicolon should be rejected"
     
     @pytest.mark.asyncio
     async def test_table_name_with_quotes(self, mcp_client):
@@ -427,7 +383,7 @@ class TestIdentifierInjectionAPI:
         print_result("Table Name with Quotes", payload, result)
         
         assert self._contains_error_indicator(result), \
-            f"Table name with quotes should be rejected"
+            "Table name with quotes should be rejected"
     
     @pytest.mark.asyncio  
     async def test_db_name_with_special_chars(self, mcp_client):
@@ -501,7 +457,7 @@ class TestMultiStatementInjectionAPI:
         print_result("Hidden DROP after SELECT", payload, result)
         
         assert self._is_dangerous_blocked(result), \
-            f"Hidden DROP statement should be blocked"
+            "Hidden DROP statement should be blocked"
     
     @pytest.mark.asyncio
     async def test_hidden_truncate_after_select(self, mcp_client):
@@ -511,7 +467,7 @@ class TestMultiStatementInjectionAPI:
         print_result("Hidden TRUNCATE after SELECT", payload, result)
         
         assert self._is_dangerous_blocked(result), \
-            f"Hidden TRUNCATE should be blocked"
+            "Hidden TRUNCATE should be blocked"
     
     @pytest.mark.asyncio
     async def test_hidden_grant_after_select(self, mcp_client):
@@ -521,7 +477,7 @@ class TestMultiStatementInjectionAPI:
         print_result("Hidden GRANT after SELECT", payload, result)
         
         assert self._is_dangerous_blocked(result), \
-            f"Hidden GRANT should be blocked"
+            "Hidden GRANT should be blocked"
     
     @pytest.mark.asyncio
     async def test_multiple_safe_selects_allowed(self, mcp_client):
@@ -868,4 +824,3 @@ def event_loop():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short", "-x"])
-

--- a/test/test_config_loader.py
+++ b/test/test_config_loader.py
@@ -37,6 +37,8 @@ logger = logging.getLogger(__name__)
 
 class TestConfigLoader:
     """Test configuration loader and client factory"""
+
+    __test__ = False
     
     def __init__(self, config_path: Optional[str] = None):
         """Initialize with config file path"""

--- a/test/tools/test_tools_manager.py
+++ b/test/tools/test_tools_manager.py
@@ -20,8 +20,9 @@ Tools manager tests
 """
 
 import json
+from unittest.mock import AsyncMock, Mock, patch
+
 import pytest
-from unittest.mock import Mock, AsyncMock, patch
 
 from doris_mcp_server.tools.tools_manager import DorisToolsManager
 from doris_mcp_server.utils.config import DorisConfig
@@ -260,11 +261,11 @@ class TestDorisToolsManager:
             # Each tool should have required fields
             assert hasattr(tool, 'name')
             assert hasattr(tool, 'description')
-            assert hasattr(tool, 'inputSchema')
+            assert hasattr(tool, 'input_schema')
             
             # Input schema should have properties
-            assert 'properties' in tool.inputSchema
+            assert 'properties' in tool.input_schema
             
             # Required fields should be defined
-            if 'required' in tool.inputSchema:
-                assert isinstance(tool.inputSchema['required'], list) 
+            if 'required' in tool.input_schema:
+                assert isinstance(tool.input_schema['required'], list)

--- a/test/tools/test_tools_operation_guard.py
+++ b/test/tools/test_tools_operation_guard.py
@@ -5,8 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 import mcp.types as mcp_types
 import pytest
 
-from doris_mcp_server.auth.operation_policy import HIGH_RISK_TOOLS, OperationAuthorizationError, authorize_operation
-from doris_mcp_server.main import DorisServer, Server
+from doris_mcp_server.auth.operation_policy import (
+    HIGH_RISK_TOOLS,
+    OperationAuthorizationError,
+)
+from doris_mcp_server.protocol import create_doris_mcp_server
 from doris_mcp_server.tools.tools_manager import DorisToolsManager
 from doris_mcp_server.utils.analysis_tools import SQLAnalyzer
 from doris_mcp_server.utils.db import QueryResult
@@ -478,8 +481,7 @@ async def test_missing_auth_context_keeps_legacy_dispatch_compatible():
 
 
 def _server_with_mock_managers():
-    server = object.__new__(DorisServer)
-    server.server = Server("test-doris-mcp-server")
+    server = SimpleNamespace()
     server.resources_manager = MagicMock()
     server.resources_manager.list_resources = AsyncMock(return_value=[])
     server.resources_manager.read_resource = AsyncMock(return_value="{}")
@@ -487,23 +489,39 @@ def _server_with_mock_managers():
     server.prompts_manager.list_prompts = AsyncMock(return_value=[])
     server.prompts_manager.get_prompt = AsyncMock(return_value="prompt")
     server.tools_manager = MagicMock()
+    server.tools_manager.list_tools = AsyncMock(return_value=[])
+    server.tools_manager.call_tool = AsyncMock(return_value="{}")
     server.logger = MagicMock()
-    DorisServer._setup_handlers(server)
+    server.server = create_doris_mcp_server(
+        resources_manager=server.resources_manager,
+        tools_manager=server.tools_manager,
+        prompts_manager=server.prompts_manager,
+        name="test-doris-mcp-server",
+        version="0.6.1",
+        logger=server.logger,
+    )
     return server
 
 
-def _handler_request(operation):
-    if operation == "list_resources":
-        return mcp_types.ListResourcesRequest(method="resources/list")
-    if operation == "read_resource":
-        return SimpleNamespace(params=SimpleNamespace(uri="doris://tables"))
-    if operation == "list_prompts":
-        return mcp_types.ListPromptsRequest(method="prompts/list")
-    if operation == "get_prompt":
-        return SimpleNamespace(
-            params=SimpleNamespace(name="query_analysis", arguments={})
-        )
-    raise AssertionError(f"Unexpected operation: {operation}")
+async def _invoke_protocol_handler(server, operation):
+    method, params = {
+        "list_resources": ("resources/list", None),
+        "read_resource": (
+            "resources/read",
+            mcp_types.ReadResourceRequestParams(uri="doris://tables"),
+        ),
+        "list_prompts": ("prompts/list", None),
+        "get_prompt": (
+            "prompts/get",
+            mcp_types.GetPromptRequestParams(
+                name="query_analysis",
+                arguments={},
+            ),
+        ),
+    }[operation]
+    entry = server.server.get_request_handler(method)
+    assert entry is not None
+    return await entry.handler(None, params)
 
 
 def _manager_mock_for_operation(server, operation):
@@ -512,15 +530,6 @@ def _manager_mock_for_operation(server, operation):
         "read_resource": server.resources_manager.read_resource,
         "list_prompts": server.prompts_manager.list_prompts,
         "get_prompt": server.prompts_manager.get_prompt,
-    }[operation]
-
-
-def _handler_type_for_operation(operation):
-    return {
-        "list_resources": mcp_types.ListResourcesRequest,
-        "read_resource": mcp_types.ReadResourceRequest,
-        "list_prompts": mcp_types.ListPromptsRequest,
-        "get_prompt": mcp_types.GetPromptRequest,
     }[operation]
 
 
@@ -540,9 +549,7 @@ async def test_doris_oauth_resources_real_handler_calls_manager_with_matching_sc
     token = set_current_auth_context(doris_context([scope]))
 
     try:
-        await server.server.request_handlers[_handler_type_for_operation(operation)](
-            _handler_request(operation)
-        )
+        await _invoke_protocol_handler(server, operation)
     finally:
         reset_auth_context(token)
 
@@ -569,23 +576,18 @@ async def test_doris_oauth_resources_real_handler_propagates_manager_errors(
 
     try:
         with pytest.raises(RuntimeError, match=f"{operation} backend failed"):
-            await server.server.request_handlers[_handler_type_for_operation(operation)](
-                _handler_request(operation)
-            )
+            await _invoke_protocol_handler(server, operation)
     finally:
         reset_auth_context(token)
 
 
 @pytest.mark.asyncio
-async def test_legacy_list_resources_handler_keeps_empty_list_compatibility():
+async def test_list_resources_handler_propagates_backend_failure():
     server = _server_with_mock_managers()
     server.resources_manager.list_resources.side_effect = RuntimeError("legacy backend failed")
 
-    result = await server.server.request_handlers[mcp_types.ListResourcesRequest](
-        mcp_types.ListResourcesRequest(method="resources/list")
-    )
-
-    assert result.root.resources == []
+    with pytest.raises(RuntimeError, match="legacy backend failed"):
+        await _invoke_protocol_handler(server, "list_resources")
 
 
 @pytest.mark.parametrize(
@@ -608,9 +610,7 @@ async def test_doris_oauth_prompts_real_handler_rejected_before_manager(
 
     try:
         with pytest.raises(OperationAuthorizationError) as exc:
-            await server.server.request_handlers[_handler_type_for_operation(operation)](
-                _handler_request(operation)
-            )
+            await _invoke_protocol_handler(server, operation)
     finally:
         reset_auth_context(token)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 1
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version < '3.13'",
 ]
 
@@ -164,6 +165,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302 },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -176,14 +186,33 @@ wheels = [
 name = "anyio"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 dependencies = [
-    { name = "idna" },
-    { name = "sniffio" },
+    { name = "idna", marker = "python_full_version < '3.14'" },
+    { name = "sniffio", marker = "python_full_version < '3.14'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916 },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "idna", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813 },
 ]
 
 [[package]]
@@ -575,7 +604,8 @@ dependencies = [
     { name = "bcrypt" },
     { name = "click" },
     { name = "cryptography" },
-    { name = "fastapi" },
+    { name = "fastapi", version = "0.115.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "fastapi", version = "0.140.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "numpy" },
@@ -599,7 +629,8 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "sqlparse" },
-    { name = "starlette" },
+    { name = "starlette", version = "0.46.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "starlette", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "structlog" },
     { name = "toml" },
     { name = "tqdm" },
@@ -673,7 +704,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.26.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.13.0" },
     { name = "jaeger-client", marker = "extra == 'monitoring'", specifier = ">=4.8.0" },
-    { name = "mcp", specifier = ">=1.8.0,<2.0.0" },
+    { name = "mcp", specifier = ">=2.0.0,<2.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0" },
@@ -767,14 +798,37 @@ wheels = [
 name = "fastapi"
 version = "0.115.12"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 dependencies = [
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "starlette", version = "0.46.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/55/ae499352d82338331ca1e28c7f4a63bfd09479b16395dce38cf50a39e2c2/fastapi-0.115.12.tar.gz", hash = "sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681", size = 295236 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/b3/b51f09c2ba432a576fe63758bddc81f78f0c6309d9e5c10d194313bf021e/fastapi-0.115.12-py3-none-any.whl", hash = "sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d", size = 95164 },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.140.13"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "annotated-doc", marker = "python_full_version >= '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.14'" },
+    { name = "starlette", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.14'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/cb/7a4d2c2eb5a5d8a91763c05b7383d72917862e32f780daa0e27ffbb34cc6/fastapi-0.140.13.tar.gz", hash = "sha256:500172a08cf1459901f90b05c37d93060dada3b573fec8f0862445db52ba6b4b", size = 424843 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4e/f9e8c762ef5e05c40482131e3d5e8b36bca13fa127578261f1d6b35a25d4/fastapi-0.140.13-py3-none-any.whl", hash = "sha256:8b017110e1e9f30a95e8bdb8f71fbe2f0fe3af5717109e5b14f9e069df54f6d4", size = 131222 },
 ]
 
 [[package]]
@@ -896,6 +950,39 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
+dependencies = [
+    { name = "h11", marker = "python_full_version < '3.14'" },
+    { name = "truststore", marker = "python_full_version < '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/db/2ad49878b36af4cff7527c1158b083ad6d9350462f1a35685cc3ebfa7c2b/httpcore2-2.6.0.tar.gz", hash = "sha256:95b692b582402ec49b3d84c2343556e4ac4c0962c8b3d39c48d485b9ecc240ab", size = 65592 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/fa/08f483851a70ef10806e3b84240f2a8f923658035b794f7609795895d9ea/httpcore2-2.6.0-py3-none-any.whl", hash = "sha256:c237a45c7eef885cf032cb9b850d59fcf1fa7e00230307f08aab26486a6ed584", size = 81507 },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "h11", marker = "python_full_version >= '3.14'" },
+    { name = "truststore", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809 },
+]
+
+[[package]]
 name = "httptools"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -922,7 +1009,8 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "certifi" },
     { name = "httpcore" },
     { name = "idna" },
@@ -933,12 +1021,41 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.0"
+name = "httpx2"
+version = "2.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
+dependencies = [
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "httpcore2", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "idna", marker = "python_full_version < '3.14'" },
+    { name = "truststore", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/17/1e142bf3c76684232a092e1e4002be07fd3403b1c2dcb15d0012ea300c8f/httpx2-2.6.0.tar.gz", hash = "sha256:5d362fd59562cf2139a60c67bb016587a70b36156a517f176c7cbf1587d1ab22", size = 92736 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
+    { url = "https://files.pythonhosted.org/packages/47/86/7d82f7c6aac32433eaf0c914b8bc870ae25759413b9d7d52ea6aa15f2546/httpx2-2.6.0-py3-none-any.whl", hash = "sha256:6cccc3665d6bceb3c1c4f1422ae7e53fda67a853f0135f09b25ce0d4dcac01e3", size = 88541 },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "httpcore2", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "idna", marker = "python_full_version >= '3.14'" },
+    { name = "truststore", marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191 },
 ]
 
 [[package]]
@@ -952,11 +1069,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455 },
 ]
 
 [[package]]
@@ -1080,6 +1197,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630 },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1149,22 +1293,44 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.9.3"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "httpx2", version = "2.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "httpx2", version = "2.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "sse-starlette", version = "3.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "starlette", version = "0.46.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "starlette", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/df/8fefc0c6c7a5c66914763e3ff3893f9a03435628f6625d5e3b0dc45d73db/mcp-1.9.3.tar.gz", hash = "sha256:587ba38448e81885e5d1b84055cfcc0ca56d35cd0c58f50941cab01109405388", size = 333045 }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/45/823ad05504bea55cb0feb7470387f151252127ad5c72f8882e8fe6cf5c0e/mcp-1.9.3-py3-none-any.whl", hash = "sha256:69b0136d1ac9927402ed4cf221d4b8ff875e7132b0b06edd446448766f34f9b9", size = 131063 },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980 },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649 },
 ]
 
 [[package]]
@@ -1648,21 +1814,6 @@ wheels = [
 ]
 
 [[package]]
-name = "psutil"
-version = "6.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz", hash = "sha256:cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5", size = 508502 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/99/ca79d302be46f7bdd8321089762dd4476ee725fce16fc2b2e1dbba8cac17/psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8", size = 247511 },
-    { url = "https://files.pythonhosted.org/packages/0b/6b/73dbde0dd38f3782905d4587049b9be64d76671042fdcaf60e2430c6796d/psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377", size = 248985 },
-    { url = "https://files.pythonhosted.org/packages/17/38/c319d31a1d3f88c5b79c68b3116c129e5133f1822157dd6da34043e32ed6/psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003", size = 284488 },
-    { url = "https://files.pythonhosted.org/packages/9c/39/0f88a830a1c8a3aba27fededc642da37613c57cbff143412e3536f89784f/psutil-6.1.1-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97f7cb9921fbec4904f522d972f0c0e1f4fabbdd4e0287813b21215074a0f160", size = 287477 },
-    { url = "https://files.pythonhosted.org/packages/47/da/99f4345d4ddf2845cb5b5bd0d93d554e84542d116934fde07a0c50bd4e9f/psutil-6.1.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33431e84fee02bc84ea36d9e2c4a6d395d479c9dd9bba2376c1f6ee8f3a4e0b3", size = 289017 },
-    { url = "https://files.pythonhosted.org/packages/38/53/bd755c2896f4461fd4f36fa6a6dcb66a88a9e4b9fd4e5b66a77cf9d4a584/psutil-6.1.1-cp37-abi3-win32.whl", hash = "sha256:eaa912e0b11848c4d9279a93d7e2783df352b082f40111e078388701fd479e53", size = 250602 },
-    { url = "https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:f35cfccb065fff93529d2afb4a2e89e363fe63ca1e4a5da22b603a85833c2649", size = 254444 },
-]
-
-[[package]]
 name = "pyarrow"
 version = "20.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1726,51 +1877,92 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.9.2"
+version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz", hash = "sha256:d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f", size = 769917 }
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/e4/ba44652d562cbf0bf320e0f3810206149c8a4e99cdbf66da82e97ab53a15/pydantic-2.9.2-py3-none-any.whl", hash = "sha256:f048cec7b26778210e28a0459867920654d48e5e62db0958433636cde4254f12", size = 434928 },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262 },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.23.4"
+version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/aa/6b6a9b9f8537b872f552ddd46dd3da230367754b6f707b8e1e963f515ea3/pydantic_core-2.23.4.tar.gz", hash = "sha256:2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863", size = 402156 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/7b/8e315f80666194b354966ec84b7d567da77ad927ed6323db4006cf915f3f/pydantic_core-2.23.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f3e0da4ebaef65158d4dfd7d3678aad692f7666877df0002b8a522cdf088f231", size = 1856459 },
-    { url = "https://files.pythonhosted.org/packages/14/de/866bdce10ed808323d437612aca1ec9971b981e1c52e5e42ad9b8e17a6f6/pydantic_core-2.23.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f69a8e0b033b747bb3e36a44e7732f0c99f7edd5cea723d45bc0d6e95377ffee", size = 1770007 },
-    { url = "https://files.pythonhosted.org/packages/dc/69/8edd5c3cd48bb833a3f7ef9b81d7666ccddd3c9a635225214e044b6e8281/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:723314c1d51722ab28bfcd5240d858512ffd3116449c557a1336cbe3919beb87", size = 1790245 },
-    { url = "https://files.pythonhosted.org/packages/80/33/9c24334e3af796ce80d2274940aae38dd4e5676298b4398eff103a79e02d/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb2802e667b7051a1bebbfe93684841cc9351004e2badbd6411bf357ab8d5ac8", size = 1801260 },
-    { url = "https://files.pythonhosted.org/packages/a5/6f/e9567fd90104b79b101ca9d120219644d3314962caa7948dd8b965e9f83e/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d18ca8148bebe1b0a382a27a8ee60350091a6ddaf475fa05ef50dc35b5df6327", size = 1996872 },
-    { url = "https://files.pythonhosted.org/packages/2d/ad/b5f0fe9e6cfee915dd144edbd10b6e9c9c9c9d7a56b69256d124b8ac682e/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33e3d65a85a2a4a0dc3b092b938a4062b1a05f3a9abde65ea93b233bca0e03f2", size = 2661617 },
-    { url = "https://files.pythonhosted.org/packages/06/c8/7d4b708f8d05a5cbfda3243aad468052c6e99de7d0937c9146c24d9f12e9/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:128585782e5bfa515c590ccee4b727fb76925dd04a98864182b22e89a4e6ed36", size = 2071831 },
-    { url = "https://files.pythonhosted.org/packages/89/4d/3079d00c47f22c9a9a8220db088b309ad6e600a73d7a69473e3a8e5e3ea3/pydantic_core-2.23.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68665f4c17edcceecc112dfed5dbe6f92261fb9d6054b47d01bf6371a6196126", size = 1917453 },
-    { url = "https://files.pythonhosted.org/packages/e9/88/9df5b7ce880a4703fcc2d76c8c2d8eb9f861f79d0c56f4b8f5f2607ccec8/pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:20152074317d9bed6b7a95ade3b7d6054845d70584216160860425f4fbd5ee9e", size = 1968793 },
-    { url = "https://files.pythonhosted.org/packages/e3/b9/41f7efe80f6ce2ed3ee3c2dcfe10ab7adc1172f778cc9659509a79518c43/pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9261d3ce84fa1d38ed649c3638feefeae23d32ba9182963e465d58d62203bd24", size = 2116872 },
-    { url = "https://files.pythonhosted.org/packages/63/08/b59b7a92e03dd25554b0436554bf23e7c29abae7cce4b1c459cd92746811/pydantic_core-2.23.4-cp312-none-win32.whl", hash = "sha256:4ba762ed58e8d68657fc1281e9bb72e1c3e79cc5d464be146e260c541ec12d84", size = 1738535 },
-    { url = "https://files.pythonhosted.org/packages/88/8d/479293e4d39ab409747926eec4329de5b7129beaedc3786eca070605d07f/pydantic_core-2.23.4-cp312-none-win_amd64.whl", hash = "sha256:97df63000f4fea395b2824da80e169731088656d1818a11b95f3b173747b6cd9", size = 1917992 },
-    { url = "https://files.pythonhosted.org/packages/ad/ef/16ee2df472bf0e419b6bc68c05bf0145c49247a1095e85cee1463c6a44a1/pydantic_core-2.23.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7530e201d10d7d14abce4fb54cfe5b94a0aefc87da539d0346a484ead376c3cc", size = 1856143 },
-    { url = "https://files.pythonhosted.org/packages/da/fa/bc3dbb83605669a34a93308e297ab22be82dfb9dcf88c6cf4b4f264e0a42/pydantic_core-2.23.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df933278128ea1cd77772673c73954e53a1c95a4fdf41eef97c2b779271bd0bd", size = 1770063 },
-    { url = "https://files.pythonhosted.org/packages/4e/48/e813f3bbd257a712303ebdf55c8dc46f9589ec74b384c9f652597df3288d/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cb3da3fd1b6a5d0279a01877713dbda118a2a4fc6f0d821a57da2e464793f05", size = 1790013 },
-    { url = "https://files.pythonhosted.org/packages/b4/e0/56eda3a37929a1d297fcab1966db8c339023bcca0b64c5a84896db3fcc5c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c6dcb030aefb668a2b7009c85b27f90e51e6a3b4d5c9bc4c57631292015b0d", size = 1801077 },
-    { url = "https://files.pythonhosted.org/packages/04/be/5e49376769bfbf82486da6c5c1683b891809365c20d7c7e52792ce4c71f3/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:696dd8d674d6ce621ab9d45b205df149399e4bb9aa34102c970b721554828510", size = 1996782 },
-    { url = "https://files.pythonhosted.org/packages/bc/24/e3ee6c04f1d58cc15f37bcc62f32c7478ff55142b7b3e6d42ea374ea427c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2971bb5ffe72cc0f555c13e19b23c85b654dd2a8f7ab493c262071377bfce9f6", size = 2661375 },
-    { url = "https://files.pythonhosted.org/packages/c1/f8/11a9006de4e89d016b8de74ebb1db727dc100608bb1e6bbe9d56a3cbbcce/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8394d940e5d400d04cad4f75c0598665cbb81aecefaca82ca85bd28264af7f9b", size = 2071635 },
-    { url = "https://files.pythonhosted.org/packages/7c/45/bdce5779b59f468bdf262a5bc9eecbae87f271c51aef628d8c073b4b4b4c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0dff76e0602ca7d4cdaacc1ac4c005e0ce0dcfe095d5b5259163a80d3a10d327", size = 1916994 },
-    { url = "https://files.pythonhosted.org/packages/d8/fa/c648308fe711ee1f88192cad6026ab4f925396d1293e8356de7e55be89b5/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7d32706badfe136888bdea71c0def994644e09fff0bfe47441deaed8e96fdbc6", size = 1968877 },
-    { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814 },
-    { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360 },
-    { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411 },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158 },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724 },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742 },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418 },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274 },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940 },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516 },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854 },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306 },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044 },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133 },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464 },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823 },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919 },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604 },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306 },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906 },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802 },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446 },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757 },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275 },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467 },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417 },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782 },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782 },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334 },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986 },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693 },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819 },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411 },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079 },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179 },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926 },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785 },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733 },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534 },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732 },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627 },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141 },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325 },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990 },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978 },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354 },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238 },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251 },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593 },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226 },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605 },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777 },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641 },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404 },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219 },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594 },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542 },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146 },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309 },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736 },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575 },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624 },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325 },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527 },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024 },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696 },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590 },
 ]
 
 [[package]]
@@ -1812,6 +2004,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997 },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1960,6 +2157,25 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877 },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841 },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901 },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184 },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298 },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640 },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928 },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157 },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598 },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159 },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293 },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337 },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2020,6 +2236,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/ef/e73f0a690b3060923448bb2ce7c1eec8a4e5031d4dc9562a116a16eaef89/qh3-1.5.2-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:087bf1a4b3a6809112b1a22f50dd0dbd86eb991971b036d2f3a650c79d81fe29", size = 2509013 },
     { url = "https://files.pythonhosted.org/packages/31/48/9cb2f58fa1ae8d4f422f2605c982437be0b7e47bfcfda8ba6e4b656d40a0/qh3-1.5.2-cp37-abi3-win32.whl", hash = "sha256:548b31b6d1bec0b11813c74ed3c94664aeeeef4ba51a3ac312fe471962e58442", size = 1733642 },
     { url = "https://files.pythonhosted.org/packages/c8/19/3406932be14bd0fe22b755b74dbcd4a5ea82164d9438d7f30508da9a8b00/qh3-1.5.2-cp37-abi3-win_amd64.whl", hash = "sha256:4bb83c8437d7c43bda7006240fc95dc119d2569dab30a20b428dbf058f686a2b", size = 1979410 },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766 },
 ]
 
 [[package]]
@@ -2095,6 +2325,102 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/76/48fd56d17c5bdbdf65609abbc67288728a98ed4c02919428d4f52d23b24b/roman_numerals_py-3.1.0.tar.gz", hash = "sha256:be4bf804f083a4ce001b5eb7e3c0862479d10f94c936f6c4e5f250aa5ff5bd2d", size = 9017 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/97/d2cbbaa10c9b826af0e10fdf836e1bf344d9f0abb873ebc34d1f49642d3f/roman_numerals_py-3.1.0-py3-none-any.whl", hash = "sha256:9da2ad2fb670bcf24e81070ceb3be72f6c11c440d73bd579fbeca1e9f330954c", size = 7742 },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691 },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542 },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180 },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067 },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509 },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754 },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189 },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750 },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576 },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807 },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187 },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030 },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185 },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394 },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753 },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012 },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203 },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984 },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815 },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545 },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828 },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678 },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811 },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382 },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832 },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011 },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431 },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710 },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454 },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063 },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510 },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495 },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454 },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583 },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919 },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725 },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255 },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060 },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960 },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356 },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319 },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508 },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504 },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380 },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976 },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840 },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282 },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403 },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055 },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419 },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848 },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369 },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673 },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500 },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978 },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350 },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486 },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068 },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600 },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726 },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587 },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585 },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479 },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418 },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123 },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351 },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827 },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966 },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680 },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853 },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715 },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864 },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430 },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877 },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933 },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274 },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763 },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467 },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689 },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340 },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179 },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993 },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909 },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584 },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357 },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533 },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204 },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719 },
 ]
 
 [[package]]
@@ -2174,10 +2500,11 @@ wheels = [
 
 [[package]]
 name = "safety"
-version = "3.5.0"
+version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
+    { name = "certifi" },
     { name = "click" },
     { name = "dparse" },
     { name = "filelock" },
@@ -2186,25 +2513,23 @@ dependencies = [
     { name = "marshmallow" },
     { name = "nltk" },
     { name = "packaging" },
-    { name = "psutil" },
     { name = "pydantic" },
-    { name = "requests" },
     { name = "ruamel-yaml" },
     { name = "safety-schemas" },
-    { name = "setuptools" },
     { name = "tenacity" },
     { name = "tomlkit" },
+    { name = "truststore" },
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/31/e4875edebb8fd5885ff8e52d0522c44a4d9bc2abe26f11225b8e64b31868/safety-3.5.0.tar.gz", hash = "sha256:7223af388bde5323867eca5495f9817746289be9fd5b1896f168dc7082ea8ff1", size = 272371 }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/7b/8e1d580c5178f0736b806b7199827e61e2a2569eec5b49ec75da6273bbdf/safety-3.8.1.tar.gz", hash = "sha256:e646123b976bbb6707cfaacae8c926e2f886b744a60e0f410e8610a3a4eaf7be", size = 412947 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/02/e7ef5f2d3a206771e885c25376d4515da8d4adfdd59ed526e847ddeee245/safety-3.5.0-py3-none-any.whl", hash = "sha256:b002e863e6e6bf111a1aafdf60e3a0378f8bc66221a3628c2230c7f2617c522e", size = 270668 },
+    { url = "https://files.pythonhosted.org/packages/4b/f5/498db84333a644835e572c0d96cfa705bf9871f863289a7845082d54755e/safety-3.8.1-py3-none-any.whl", hash = "sha256:953c1c3c60c873f53a6cc250b2a9c4b38bb6ef45f0625990e43f20bff916c965", size = 340521 },
 ]
 
 [[package]]
 name = "safety-schemas"
-version = "0.0.14"
+version = "0.0.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dparse" },
@@ -2213,9 +2538,9 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/40/e5107b3e456ca4b78d1c0d5bd07be3377e673cc54949b18e5f3aed345067/safety_schemas-0.0.14.tar.gz", hash = "sha256:49953f7a59e919572be25595a8946f9cbbcd2066fe3e160c9467d9d1d6d7af6a", size = 53216 }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/ef/0e07dfdb4104c4e42ae9fc6e8a0da7be2d72ac2ee198b32f7500796de8f3/safety_schemas-0.0.16.tar.gz", hash = "sha256:3bb04d11bd4b5cc79f9fa183c658a6a8cf827a9ceec443a5ffa6eed38a50a24e", size = 54815 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/7f/f3d1ac7eb0a6546eda3e82c0487233cea0774e511239769945dbd1dd01de/safety_schemas-0.0.14-py3-none-any.whl", hash = "sha256:0bf6fc4aa5e474651b714cc9e427c862792946bf052b61d5c7bec4eac4c0f254", size = 39268 },
+    { url = "https://files.pythonhosted.org/packages/84/a2/7840cc32890ce4b84668d3d9dfe15a48355b683ae3fb627ac97ac5a4265f/safety_schemas-0.0.16-py3-none-any.whl", hash = "sha256:6760515d3fd1e6535b251cd73014bd431d12fe0bfb8b6e8880a9379b5ab7aa44", size = 39292 },
 ]
 
 [[package]]
@@ -2397,26 +2722,65 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "2.3.6"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/f4/989bc70cb8091eda43a9034ef969b25145291f3601703b82766e5172dfed/sse_starlette-2.3.6.tar.gz", hash = "sha256:0382336f7d4ec30160cf9ca0518962905e1b69b72d6c1c995131e0a703b436e3", size = 18284 }
+dependencies = [
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/3c/fa6517610dc641262b77cc7bf994ecd17465812c1b0585fe33e11be758ab/sse_starlette-3.0.3.tar.gz", hash = "sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971", size = 21943 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/05/78850ac6e79af5b9508f8841b0f26aa9fd329a1ba00bf65453c2d312bcc8/sse_starlette-2.3.6-py3-none-any.whl", hash = "sha256:d49a8285b182f6e2228e2609c350398b2ca2c36216c2675d875f81e93548f760", size = 10606 },
+    { url = "https://files.pythonhosted.org/packages/23/a0/984525d19ca5c8a6c33911a0c164b11490dd0f90ff7fd689f704f84e9a11/sse_starlette-3.0.3-py3-none-any.whl", hash = "sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431", size = 11765 },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "starlette", version = "1.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/10/a34c656829ffc1c4b22ef36d70d9ebb6b99c020e2aeb17cee5485099f028/sse_starlette-3.4.6.tar.gz", hash = "sha256:725f8a1bd6d26ae1b2c9610c0ef5065dfdd496f3988d28adcf8c4b49dc25c627", size = 32542 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/36/e10c1d1b7ca881d2625db2ec28508578499187bb1c389952c398474e1834/sse_starlette-3.4.6-py3-none-any.whl", hash = "sha256:56217ab4c9a9f9c5db7b21e08732d3e7c2b807f45231ad23de0551a24c4a41f6", size = 16516 },
 ]
 
 [[package]]
 name = "starlette"
 version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037 },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632 },
 ]
 
 [[package]]
@@ -2534,6 +2898,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660 },
+]
+
+[[package]]
 name = "typer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2550,23 +2923,23 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839 },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571 },
 ]
 
 [[package]]
 name = "typing-inspection"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726 }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552 },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611 },
 ]
 
 [[package]]
@@ -2713,7 +3086,8 @@ name = "watchfiles"
 version = "1.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", version = "4.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "anyio", version = "4.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/03/e2/8ed598c42057de7aa5d97c472254af4906ff0a59a66699d426fc9ef795d7/watchfiles-1.0.5.tar.gz", hash = "sha256:b7529b5dcc114679d43827d8c35a07c493ad6f083633d573d81c660abc5979e9", size = 94537 }
 wheels = [


### PR DESCRIPTION
## What changed

- upgrade the Python MCP SDK dependency to 2.0.x
- add one shared low-level protocol factory for tools, resources, and prompts
- migrate Streamable HTTP and STDIO to the SDK 2.0 dual-era runner
- keep modern `2026-07-28` and legacy `2025-11-25` clients interoperable
- make modern HTTP stateless and share the same handlers in single- and multi-worker modes
- migrate the packaged client to the SDK 2.0 high-level client
- reject query-string bearer tokens and tighten default Host/Origin handling
- add the protocol audit, implementation ledger, regression tests, and wheel packaging fix

## Why

The previous implementation was pinned to SDK 1.x and depended on duplicated handlers and private transport monkey patches. It could not complete a `2026-07-28` `server/discover` request and the process exited after the failure. This PR establishes the protocol core required for the 2026-07-28 migration without claiming that the remaining conformance and security ledger is complete.

## Validation

- `uv run pytest -q`: 331 passed, 57 skipped, 0 failed
- protocol regression: modern and legacy list/call/read/get paths passed
- Streamable HTTP: modern and legacy requests passed against a real Doris 4.0.5 environment
- STDIO: modern and legacy requests passed against the same real Doris environment
- multi-worker HTTP: two worker processes both served successful real Doris requests
- external SQL injection API suite: 45 passed
- `uv lock --check`, scoped Ruff, `compileall`, and `git diff --check` passed
- `uv build` produced sdist and wheel
- clean wheel install: both `doris-mcp-server --help` and `doris-mcp-client --help` passed

## Follow-up

The development ledger intentionally leaves official conformance, missing-capability `-32021`, typed Resource/Prompt errors, non-loopback fail-closed authentication, and the remaining security/release gates for separate PRs.
