### PR TITLE
fix: bind Doris OAuth tokens to MCP resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ under **Unreleased** until a new version is selected and published.
 - Preserved external OAuth token failures through the authentication boundary
   and returned RFC 6750/RFC 9728 Bearer challenges, protected-resource
   metadata, and operation-specific insufficient-scope responses.
+- Bound Doris OAuth access tokens to the canonical MCP resource and rejected
+  tokens issued for any other resource before per-user pool access.
 - Released Doris connections on SQL profile, data freshness, and access
   analysis paths.
 - Improved Doris 4 role metadata compatibility and query recovery behavior.

--- a/README.md
+++ b/README.md
@@ -679,6 +679,12 @@ Doris-backed OAuth is a separate OAuth mode where Doris itself is the authorizat
 
 This mode is not the same as external OAuth/OIDC. `ENABLE_DORIS_OAUTH_AUTH=true` conflicts with `ENABLE_OAUTH_AUTH=true`, `OAUTH_ENABLED=true`, and legacy `AUTH_TYPE=oauth`; startup fails fast if both modes are configured. A standard MCP agent enters one MCP URL and should discover exactly one OAuth behavior for that URL, so the existing `/auth/*` external OAuth login flow is not used in Doris-backed OAuth mode.
 
+Each Doris OAuth token record is bound to the resource selected during
+authorization. The protected MCP endpoint accepts only the exact canonical
+resource `${DORIS_OAUTH_BASE_URL}/mcp`; a token issued for the authorization
+server or any other resource is rejected with an `invalid_token` challenge
+before a per-user Doris pool is used.
+
 #### Minimal Local Configuration
 
 The following example is for local development on a single worker:

--- a/doris_mcp_server/auth/doris_oauth_provider.py
+++ b/doris_mcp_server/auth/doris_oauth_provider.py
@@ -367,6 +367,15 @@ class DorisOAuthProvider:
         record = self.store.get_access_token(token)
         if not record or record.revoked_at is not None:
             raise ProtectedResourceAuthError("authentication_required", "Invalid Doris OAuth access token")
+        if record.resource != self.resource:
+            raise ProtectedResourceAuthError(
+                "authentication_required",
+                "Doris OAuth access token is not valid for this MCP resource",
+                status_code=401,
+                required_scope="tool:list",
+                challenge_error="invalid_token",
+                error_code="DORIS_OAUTH_RESOURCE_MISMATCH",
+            )
         if not self.connection_manager or not self.connection_manager.has_doris_user_pool(record.doris_user):
             async with self._lock:
                 self.store.revoke_family_by_access_token_id(record.token_id)
@@ -397,6 +406,9 @@ class DorisOAuthProvider:
             oauth_client_id=updated.client_id,
             oauth_scopes=list(updated.scopes),
             oauth_token_id=updated.token_id,
+            oauth_issuer=self.issuer,
+            oauth_resource=updated.resource,
+            oauth_audiences=[updated.resource],
             pool_key=f"doris_user:{updated.doris_user}",
         )
         auth_context.doris_oauth_db_tools_enabled = bool(

--- a/test/auth/test_doris_oauth_routes.py
+++ b/test/auth/test_doris_oauth_routes.py
@@ -47,6 +47,7 @@ class FakeConnectionManager:
         self.pools = {}
         self.create_calls = []
         self.cleanup_calls = []
+        self.has_pool_calls = []
         self.global_acquire_calls = 0
 
     async def create_or_replace_doris_user_pool(self, username, password):
@@ -56,6 +57,7 @@ class FakeConnectionManager:
         self.pools[username] = True
 
     def has_doris_user_pool(self, username):
+        self.has_pool_calls.append(username)
         return self.pools.get(username, False)
 
     async def cleanup_idle_doris_user_pools(self, active_users):
@@ -541,6 +543,9 @@ async def test_full_login_code_exchange_auth_context_and_pool_missing_revocation
     assert auth_context.doris_user == "alice"
     assert auth_context.oauth_client_id == client_id
     assert auth_context.oauth_scopes == ["resource:list", "resource:read", "tool:list"]
+    assert auth_context.oauth_issuer == provider.issuer
+    assert auth_context.oauth_resource == provider.resource
+    assert auth_context.oauth_audiences == [provider.resource]
     assert auth_context.pool_key == "doris_user:alice"
     assert auth_context.token == ""
 
@@ -554,6 +559,34 @@ async def test_full_login_code_exchange_auth_context_and_pool_missing_revocation
     cm.pools["alice"] = True
     with pytest.raises(ProtectedResourceAuthError):
         await provider.authenticate_access_token(credentials)
+
+
+@pytest.mark.asyncio
+async def test_access_token_for_other_resource_is_rejected_before_pool_access():
+    provider, cm, _app = _provider_app()
+    pair = provider.store.issue_token_pair(
+        client_id="resource-bound-client",
+        doris_user="alice",
+        scopes=("tool:list",),
+        resource=provider.issuer,
+        access_ttl_seconds=900,
+        refresh_ttl_seconds=86400,
+    )
+    cm.pools["alice"] = True
+    credentials = BearerCredentials(
+        scheme="bearer",
+        token=pair.access_token,
+    )
+
+    with pytest.raises(ProtectedResourceAuthError) as exc_info:
+        await provider.authenticate_access_token(credentials)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.challenge_error == "invalid_token"
+    assert exc_info.value.error_code == "DORIS_OAUTH_RESOURCE_MISMATCH"
+    assert cm.has_pool_calls == []
+    assert provider.store.get_access_token(pair.access_token).revoked_at is None
+    assert provider.store.get_access_token(pair.access_token).last_used_at is None
 
 
 @pytest.mark.asyncio

--- a/test/security/test_mcp_auth_middleware.py
+++ b/test/security/test_mcp_auth_middleware.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 import doris_mcp_server.auth.mcp_auth_middleware as middleware_module
+from doris_mcp_server.auth.doris_oauth_types import ProtectedResourceAuthError
 from doris_mcp_server.auth.mcp_auth_middleware import MCPAuthASGIMiddleware
 from doris_mcp_server.auth.oauth_token_validation import (
     OAuthAccessTokenValidationError,
@@ -149,6 +150,53 @@ async def test_mcp_auth_middleware_returns_doris_oauth_challenge_on_401():
     assert b"https://mcp.example.test/.well-known/oauth-protected-resource" in headers[b"www-authenticate"]
     body = json.loads(messages[1]["body"])
     assert body["error"] == "authentication_required"
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_resource_mismatch_returns_invalid_token_challenge():
+    class SecurityManager:
+        async def authenticate_request(self, credentials):
+            assert credentials.token == "wrong-resource-token"
+            raise ProtectedResourceAuthError(
+                "authentication_required",
+                "Doris OAuth access token is not valid for this MCP resource",
+                error_code="DORIS_OAUTH_RESOURCE_MISMATCH",
+            )
+
+    async def downstream(scope, receive, send):
+        raise AssertionError("downstream must not be called")
+
+    messages = []
+    middleware = MCPAuthASGIMiddleware(
+        SecurityManager(),
+        downstream,
+        _effective(
+            auth_methods=("doris_oauth",),
+            discovery_mode="doris_oauth",
+            base_url="https://mcp.example.test",
+        ),
+    )
+    await middleware(
+        {
+            "type": "http",
+            "path": "/mcp",
+            "headers": [
+                (b"authorization", b"Bearer wrong-resource-token")
+            ],
+            "client": ("127.0.0.1", 1),
+        },
+        _receive,
+        _send_collector(messages),
+    )
+
+    assert messages[0]["status"] == 401
+    challenge = dict(messages[0]["headers"])[b"www-authenticate"]
+    assert b'error="invalid_token"' in challenge
+    assert b"oauth-protected-resource" in challenge
+    assert b'scope="tool:list"' in challenge
+    body = json.loads(messages[1]["body"])
+    assert body["error"] == "authentication_required"
+    assert body["error_code"] == "DORIS_OAUTH_RESOURCE_MISMATCH"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- reject Doris OAuth access tokens whose recorded resource does not exactly match the canonical MCP resource
- perform the resource check before per-user pool lookup or token last-used mutation
- propagate issuer, resource, and audience into the authenticated context for downstream auditability
- return a stable invalid-token challenge with `DORIS_OAUTH_RESOURCE_MISMATCH` and document the binding boundary

## Validation

- focused Doris OAuth and middleware tests: 37 passed
- auth/security suite: 287 passed, 45 skipped
- MCP transport matrix: 18 passed (10 Streamable HTTP, 6 real subprocess stdio, 2 multi-worker)
- real Doris integration: 4 passed across Streamable HTTP and stdio; temporary tables/users after cleanup: 0/0
- full test suite: 468 passed, 61 skipped
- changed-file Ruff baseline has no new findings; `uv lock --check`, compileall, package build, and artifact inspection passed
