### PR TITLE
fix: identify OAuth authorization responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ under **Unreleased** until a new version is selected and published.
   tokens issued for any other resource before per-user pool access.
 - Required Doris OAuth DCR clients to declare a persisted `application_type`
   and enforced type-matched redirect URI rules for native and web clients.
+- Added RFC 9207 `iss` identification to Doris OAuth authorization success and
+  redirectable error responses, with matching discovery metadata.
 - Released Doris connections on SQL profile, data freshness, and access
   analysis paths.
 - Improved Doris 4 role metadata compatibility and query recovery behavior.

--- a/README.md
+++ b/README.md
@@ -738,6 +738,12 @@ redirect URI or loopback HTTP URI; web clients must register a non-loopback
 HTTPS URI. The server persists the application type with the client and uses
 exact redirect URI matching during authorization.
 
+Authorization success and redirectable error responses include the exact
+authorization-server issuer in the RFC 9207 `iss` parameter. Discovery
+advertises `authorization_response_iss_parameter_supported=true`; clients must
+compare the returned value with the discovered issuer without URI
+normalization before accepting the response.
+
 #### Current Operational Limits
 
 Doris-backed OAuth is currently single-process and single-worker:

--- a/doris_mcp_server/auth/doris_oauth_handlers.py
+++ b/doris_mcp_server/auth/doris_oauth_handlers.py
@@ -89,9 +89,13 @@ def insufficient_scope_response(base_url: str, required_scope: str | None, body:
     )
 
 
-def authorize_error_response(error: AuthorizeError) -> Response:
+def authorize_error_response(error: AuthorizeError, issuer: str) -> Response:
     if error.redirect_allowed and error.redirect_uri:
-        params = {"error": error.error, "error_description": error.description}
+        params = {
+            "error": error.error,
+            "error_description": error.description,
+            "iss": issuer,
+        }
         if error.state:
             params["state"] = error.state
         separator = "&" if "?" in error.redirect_uri else "?"
@@ -166,7 +170,7 @@ class DorisOAuthHandlers:
             )
             return RedirectResponse(redirect_path, status_code=302)
         except AuthorizeError as exc:
-            return authorize_error_response(exc)
+            return authorize_error_response(exc, self.provider.issuer)
 
     async def login(self, request: Request) -> Response:
         if request.method == "GET":

--- a/doris_mcp_server/auth/doris_oauth_provider.py
+++ b/doris_mcp_server/auth/doris_oauth_provider.py
@@ -94,6 +94,7 @@ class DorisOAuthProvider:
             "grant_types_supported": ["authorization_code", "refresh_token"],
             "code_challenge_methods_supported": ["S256"],
             "token_endpoint_auth_methods_supported": ["none", "client_secret_post"],
+            "authorization_response_iss_parameter_supported": True,
         }
         if self.dcr_enabled():
             metadata["registration_endpoint"] = f"{self.issuer}/oauth/register"
@@ -267,7 +268,14 @@ class DorisOAuthProvider:
             ttl_seconds=getattr(self.security_config, "doris_oauth_auth_code_expire_seconds", 300),
         )
         self.store.delete_auth_transaction(txn_id)
-        return self._redirect_with_params(record.redirect_uri, {"code": code, "state": record.state})
+        return self._redirect_with_params(
+            record.redirect_uri,
+            {
+                "code": code,
+                "state": record.state,
+                "iss": self.issuer,
+            },
+        )
 
     async def exchange_code(self, payload: dict) -> dict:
         client = self._authenticate_token_client(payload)

--- a/test/auth/test_doris_oauth_routes.py
+++ b/test/auth/test_doris_oauth_routes.py
@@ -105,12 +105,31 @@ async def _client(app):
     return httpx.AsyncClient(transport=transport, base_url="http://localhost:3000", follow_redirects=False)
 
 
+def _authorization_response_query(response, expected_issuer):
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    assert query["iss"] == [expected_issuer]
+    return query
+
+
 def _native_registration(redirect_uri="http://localhost:7777/callback", **metadata):
     return {
         "application_type": "native",
         "redirect_uris": [redirect_uri],
         **metadata,
     }
+
+
+@pytest.mark.asyncio
+async def test_authorization_server_metadata_advertises_response_issuer():
+    provider, _cm, app = _provider_app()
+
+    async with await _client(app) as client:
+        response = await client.get("/.well-known/oauth-authorization-server")
+
+    assert response.status_code == 200
+    metadata = response.json()
+    assert metadata["issuer"] == provider.issuer
+    assert metadata["authorization_response_iss_parameter_supported"] is True
 
 
 @pytest.mark.parametrize(
@@ -662,9 +681,70 @@ async def test_authorize_invalid_redirect_is_direct_400_and_invalid_scope_redire
     assert response.status_code == 302
     location = response.headers["location"]
     assert location.startswith("http://localhost:7777/callback")
-    query = parse_qs(urlparse(location).query)
+    query = _authorization_response_query(response, provider.issuer)
     assert query["error"] == ["invalid_scope"]
     assert query["state"] == ["state-2"]
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_error"),
+    [
+        pytest.param(
+            {"response_type": "token"},
+            "unsupported_response_type",
+            id="unsupported-response-type",
+        ),
+        pytest.param(
+            {"code_challenge_method": "plain"},
+            "invalid_request",
+            id="invalid-pkce",
+        ),
+        pytest.param(
+            {"resource": "http://localhost:3000/not-the-mcp-resource"},
+            "invalid_target",
+            id="invalid-resource",
+        ),
+        pytest.param(
+            {"scope": "unknown"},
+            "invalid_scope",
+            id="invalid-scope",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_redirected_authorization_errors_identify_exact_issuer(
+    overrides,
+    expected_error,
+):
+    provider, _cm, app = _provider_app()
+    client_record = provider.store.add_client(
+        client_id="client-issuer-errors",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        application_type="native",
+        redirect_uris=("http://localhost:7777/callback",),
+        client_allowed_scopes=("tool:list",),
+        source="dcr",
+        expires_at=None,
+    )
+    challenge, _verifier = _pkce()
+    params = {
+        "response_type": "code",
+        "client_id": client_record.client_id,
+        "redirect_uri": "http://localhost:7777/callback",
+        "state": "state-issuer",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        **overrides,
+    }
+
+    async with await _client(app) as client:
+        response = await client.get("/oauth/authorize", params=params)
+
+    assert response.status_code == 302
+    query = _authorization_response_query(response, provider.issuer)
+    assert query["error"] == [expected_error]
+    assert query["state"] == ["state-issuer"]
 
 
 @pytest.mark.asyncio
@@ -712,7 +792,12 @@ async def test_full_login_code_exchange_auth_context_and_pool_missing_revocation
             },
         )
         assert cm.create_calls == [("alice", "correct")]
-        code = parse_qs(urlparse(login_post.headers["location"]).query)["code"][0]
+        authorization_response = _authorization_response_query(
+            login_post,
+            provider.issuer,
+        )
+        assert authorization_response["state"] == ["state-1"]
+        code = authorization_response["code"][0]
 
         token_response = await client.post(
             "/oauth/token",


### PR DESCRIPTION
## Summary

- advertise RFC 9207 authorization-response issuer support in authorization-server metadata
- include the exact authorization-server `iss` in successful and redirectable error responses
- validate the returned issuer with exact string comparison while keeping untrusted redirect failures direct

## Validation

- focused Doris OAuth tests: 58 passed
- auth/security suite: 316 passed, 45 skipped
- protocol matrix: 18 passed (Streamable HTTP, real subprocess stdio, multiworker)
- real Doris transport matrix: 4 passed; temporary tables/users cleaned up
- full suite: 497 passed, 61 skipped
- lock, compile, wheel/sdist build, isolated wheel version/help smoke passed
