### PR TITLE
fix: harden compose secrets and pin images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,16 @@ DORIS_HTTP_READ_TIMEOUT_SECONDS=15
 DORIS_HTTP_TOTAL_TIMEOUT_SECONDS=30
 DORIS_HTTP_MAX_RESPONSE_BYTES=4194304
 
+# Docker Compose reads sensitive values from ignored host files and mounts
+# them as container secrets. These variables are host paths, never secret
+# values. See the Docker deployment section in README.md before starting the
+# bundled stack.
+COMPOSE_DORIS_PASSWORD_FILE=./.secrets/doris_password
+COMPOSE_DORIS_FE_CUSTOM_CONFIG_FILE=./.secrets/doris_fe_custom.conf
+COMPOSE_MCP_STATIC_TOKEN_FILE=./.secrets/mcp_static_token
+COMPOSE_REDIS_PASSWORD_FILE=./.secrets/redis_password
+COMPOSE_GRAFANA_ADMIN_PASSWORD_FILE=./.secrets/grafana_admin_password
+
 # Connection pool configuration
 DORIS_MAX_CONNECTIONS=20
 DORIS_CONNECTION_TIMEOUT=30

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ venv.bak/
 .coverage.*
 coverage.xml
 tokens.json.lock
+/.secrets/
+/tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# Use Python 3.12 as base image
-FROM python:3.12-slim
+# Keep the runtime base reproducible across rebuilds. Upgrade the explicit
+# Python patch release and OCI digest together.
+FROM python:3.12.11-slim-bookworm@sha256:519591d6871b7bc437060736b9f7456b8731f1499a57e22e6c285135ae657bf7
 
 # Set working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -391,6 +391,35 @@ defaults with `MCP_HTTP_PORT` and `GRAFANA_HTTP_PORT`:
 MCP_HTTP_PORT=3100 GRAFANA_HTTP_PORT=3103 docker compose up -d
 ```
 
+Before starting the bundled stack, create the five ignored secret files used
+by Compose. No database, MCP, Redis, or Grafana credential is stored in
+`docker-compose.yml`, `.env.example`, or the rendered service environment:
+
+```bash
+mkdir -p .secrets
+chmod 700 .secrets
+python -c 'import secrets; print(secrets.token_urlsafe(32))' > .secrets/doris_password
+python -c 'import secrets; print(secrets.token_urlsafe(32))' > .secrets/mcp_static_token
+python -c 'import secrets; print(secrets.token_urlsafe(32))' > .secrets/redis_password
+python -c 'import secrets; print(secrets.token_urlsafe(32))' > .secrets/grafana_admin_password
+python -c 'import hashlib, pathlib; p=pathlib.Path(".secrets/doris_password").read_text().rstrip("\n").encode(); print("initial_root_password = *" + hashlib.sha1(hashlib.sha1(p).digest()).hexdigest().upper())' > .secrets/doris_fe_custom.conf
+chmod 0444 .secrets/*
+docker compose up -d
+```
+
+`doris_fe_custom.conf` contains Doris's two-stage SHA-1 password verifier, not
+the plaintext password, and is mounted as the FE initial-root configuration.
+The matching plaintext file is mounted only into the services that must
+authenticate to Doris. Treat both files as credentials. The parent directory
+remains mode `0700`, while the files are host-read-only and container-readable
+for the non-root MCP process. To keep secret files elsewhere, copy
+`.env.example` to `.env` and change only the `COMPOSE_*_FILE` host paths.
+
+All third-party images in the Compose model use an explicit upstream version
+and an immutable OCI digest. Upgrade them deliberately by changing both the
+version tag and digest, then rerun the deployment contract and transport tests;
+do not replace them with `latest` or another floating tag.
+
 The image-level Docker health check uses `/live`, so a temporary Doris outage
 does not cause the MCP process to be treated as dead. Compose overrides that
 probe with `/ready` and only marks the service ready after the bounded Doris

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - DORIS_HOST=doris-fe
       - DORIS_PORT=9030
       - DORIS_USER=root
-      - DORIS_PASSWORD=doris123
+      - DORIS_PASSWORD_FILE=/run/secrets/doris_password
       - DORIS_DATABASE=test_db
       
       # Connection pool configuration
@@ -40,7 +40,7 @@ services:
       - SERVER_PORT=3000
       - MCP_ALLOWED_HOSTS=${MCP_ALLOWED_HOSTS:-127.0.0.1:*,localhost:*}
       - ENABLE_TOKEN_AUTH=true
-      - TOKEN_ADMIN=${MCP_STATIC_TOKEN:?Set MCP_STATIC_TOKEN to a securely generated value of at least 32 characters}
+      - TOKEN_ADMIN_FILE=/run/secrets/mcp_static_token
       - MAX_RESULT_ROWS=10000
       
       # Performance configuration
@@ -57,6 +57,9 @@ services:
     volumes:
       - ./logs:/app/logs
       - ./config:/app/config
+    secrets:
+      - doris_password
+      - mcp_static_token
     depends_on:
       doris-fe:
         condition: service_healthy
@@ -74,7 +77,7 @@ services:
 
   # Apache Doris Frontend
   doris-fe:
-    image: apache/doris:2.0.3-fe-x86_64
+    image: apache/doris:fe-3.0.8@sha256:749afa2be75cd58d54a0bdb3edaa805d5974646f67500f094912f8dbc4a96b8f
     container_name: doris-fe
     ports:
       - "8030:8030"  # FE HTTP port
@@ -85,7 +88,11 @@ services:
     volumes:
       - doris-fe-data:/opt/apache-doris/fe/doris-meta
       - doris-fe-log:/opt/apache-doris/fe/log
-      - ./doris-config/fe.conf:/opt/apache-doris/fe/conf/fe.conf
+    secrets:
+      - source: doris_password
+        target: /etc/basic_auth/password
+      - source: doris_fe_custom_config
+        target: /opt/apache-doris/fe/conf/fe_custom.conf
     networks:
       - doris-network
     restart: unless-stopped
@@ -98,7 +105,7 @@ services:
 
   # Apache Doris Backend
   doris-be:
-    image: apache/doris:2.0.3-be-x86_64
+    image: apache/doris:be-3.0.8@sha256:a337e2b17a65c86c22a1205467a825d46dc3380c94ba8024e53eea033641f12e
     container_name: doris-be
     ports:
       - "8040:8040"  # BE HTTP port
@@ -109,7 +116,9 @@ services:
     volumes:
       - doris-be-data:/opt/apache-doris/be/storage
       - doris-be-log:/opt/apache-doris/be/log
-      - ./doris-config/be.conf:/opt/apache-doris/be/conf/be.conf
+    secrets:
+      - source: doris_password
+        target: /etc/basic_auth/password
     depends_on:
       - doris-fe
     networks:
@@ -124,25 +133,30 @@ services:
 
   # Redis cache (optional)
   redis:
-    image: redis:7-alpine
+    image: redis:7.4.10-alpine@sha256:e7723ff73d963f5cc6d9c4643ea3d989527a402a319239054e9472a7fb9219a2
     container_name: doris-redis
     ports:
       - "6379:6379"
-    command: redis-server --appendonly yes --requirepass redis123
+    command:
+      - /bin/sh
+      - -ec
+      - exec redis-server --appendonly yes --requirepass "$$(cat /run/secrets/redis_password)"
     volumes:
       - redis-data:/data
+    secrets:
+      - redis_password
     networks:
       - doris-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      test: ["CMD-SHELL", "REDISCLI_AUTH=\"$$(cat /run/secrets/redis_password)\" redis-cli --no-auth-warning ping | grep -qx PONG"]
       interval: 30s
       timeout: 10s
       retries: 3
 
   # Prometheus monitoring
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.13.0@sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7
     container_name: doris-prometheus
     ports:
       - "9090:9090"
@@ -162,16 +176,18 @@ services:
 
   # Grafana visualization
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:13.1.0@sha256:121a7a9ece6dc10b969f1f96eed64b4f07dfac0d0b8abc070f7cb83bbde86f63
     container_name: doris-grafana
     ports:
       - "${GRAFANA_HTTP_PORT:-3003}:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin123
+      - GF_SECURITY_ADMIN_PASSWORD__FILE=/run/secrets/grafana_admin_password
     volumes:
       - grafana-data:/var/lib/grafana
       - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
       - ./monitoring/grafana/datasources:/etc/grafana/provisioning/datasources
+    secrets:
+      - grafana_admin_password
     depends_on:
       - prometheus
     networks:
@@ -180,7 +196,7 @@ services:
 
   # Nginx load balancer
   nginx:
-    image: nginx:alpine
+    image: nginx:1.30.4-alpine@sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46
     container_name: doris-nginx
     ports:
       - "80:80"
@@ -215,6 +231,15 @@ volumes:
 networks:
   doris-network:
     driver: bridge
-    ipam:
-      config:
-        - subnet: 172.20.0.0/16
+
+secrets:
+  doris_password:
+    file: ${COMPOSE_DORIS_PASSWORD_FILE:-./.secrets/doris_password}
+  doris_fe_custom_config:
+    file: ${COMPOSE_DORIS_FE_CUSTOM_CONFIG_FILE:-./.secrets/doris_fe_custom.conf}
+  mcp_static_token:
+    file: ${COMPOSE_MCP_STATIC_TOKEN_FILE:-./.secrets/mcp_static_token}
+  redis_password:
+    file: ${COMPOSE_REDIS_PASSWORD_FILE:-./.secrets/redis_password}
+  grafana_admin_password:
+    file: ${COMPOSE_GRAFANA_ADMIN_PASSWORD_FILE:-./.secrets/grafana_admin_password}

--- a/doris_mcp_server/utils/security.py
+++ b/doris_mcp_server/utils/security.py
@@ -20,7 +20,6 @@ Doris Security Management Module
 Implements enterprise-level authentication, authorization, SQL security validation and data masking functionality
 """
 
-import logging
 import re
 from collections.abc import Mapping
 from contextvars import ContextVar
@@ -641,11 +640,16 @@ class AuthenticationProvider:
         auth_type = str(auth_info.get("type") or "").strip().lower()
         credentials = normalize_bearer_credentials(auth_info)
         if auth_type == "token":
-            if self.effective_auth.enable_token_auth and self.token_manager:
-                return await self.authenticate_token(credentials)
-            return await self._authenticate_legacy_token(credentials)
+            if not self.effective_auth.enable_token_auth:
+                raise ValueError("Token authentication is not enabled")
+            if not self.token_manager:
+                raise ValueError("Token manager is not initialized")
+            return await self.authenticate_token(credentials)
         if auth_type == "basic":
-            return await self._authenticate_basic(auth_info)
+            raise ValueError(
+                "Basic authentication is not supported; use a configured "
+                "Bearer or OAuth authentication provider"
+            )
         if auth_type == "jwt":
             return await self.authenticate_jwt(credentials)
         if auth_type == "oauth":
@@ -790,105 +794,6 @@ class AuthenticationProvider:
         except Exception as e:
             self.logger.error(f"Token authentication failed: {e}")
             raise ValueError(f"Token authentication failed: {str(e)}")
-
-    async def _authenticate_legacy_token(
-        self,
-        credentials: BearerCredentials,
-    ) -> AuthContext:
-        """Token authentication for legacy direct callers without TokenManager."""
-        if not credentials.is_static_token:
-            raise ValueError("Missing authentication token")
-        token = credentials.token
-
-        user_info = await self._validate_token(token)
-        return AuthContext(
-            token_id=token,
-            user_id=user_info["user_id"],
-            roles=user_info["roles"],
-            permissions=user_info["permissions"],
-            security_level=user_info["security_level"],
-            client_ip=credentials.client_ip,
-            session_id=credentials.session_id or f"session_{user_info['user_id']}",
-            login_time=datetime.utcnow(),
-            auth_method="token",
-            token=token,
-            pool_key=f"static_token:{token}",
-        )
-
-    async def _authenticate_basic(self, auth_info: dict[str, Any]) -> AuthContext:
-        """Basic authentication (username password)"""
-        username = auth_info.get("username")
-        password = auth_info.get("password")
-
-        if not username or not password:
-            raise ValueError("Missing username or password")
-
-        # Validate username password (simplified implementation)
-        user_info = await self._validate_credentials(username, password)
-
-        return AuthContext(
-            user_id=user_info["user_id"],
-            roles=user_info["roles"],
-            permissions=user_info["permissions"],
-            session_id=auth_info.get("session_id", "default"),
-            login_time=datetime.utcnow(),
-            security_level=SecurityLevel(user_info.get("security_level", "internal")),
-            auth_method="basic",
-            pool_key="global",
-        )
-
-    async def _validate_token(self, token: str) -> dict[str, Any]:
-        """Validate token validity"""
-        # Simplified implementation for testing, should parse JWT or query authentication service in practice
-        valid_tokens = {
-            "valid_token_123": {
-                "user_id": "test_user",
-                "roles": ["data_analyst"],
-                "permissions": ["read_data"],
-                "security_level": SecurityLevel.INTERNAL,
-            },
-            "admin_token_456": {
-                "user_id": "admin_user",
-                "roles": ["data_admin"],
-                "permissions": ["admin"],
-                "security_level": SecurityLevel.SECRET,
-            }
-        }
-        
-        if token in valid_tokens:
-            return valid_tokens[token]
-        else:
-            raise ValueError("Invalid token")
-
-    async def _validate_credentials(
-        self, username: str, password: str
-    ) -> dict[str, Any]:
-        """Validate user credentials"""
-        # Simplified implementation for testing, should query user database in practice
-        valid_users = {
-            "admin": {
-                "password": "admin123",
-                "user_id": "admin_user",
-                "roles": ["data_admin"],
-                "permissions": ["admin", "read_data", "write_data"],
-                "security_level": SecurityLevel.SECRET,
-            },
-            "analyst": {
-                "password": "analyst123",
-                "user_id": "analyst_user",
-                "roles": ["data_analyst"],
-                "permissions": ["read_data"],
-                "security_level": SecurityLevel.INTERNAL,
-            }
-        }
-
-        if username in valid_users and valid_users[username]["password"] == password:
-            user_info = valid_users[username].copy()
-            del user_info["password"]  # Remove password from returned info
-            return user_info
-        else:
-            raise ValueError("Incorrect username or password")
-
 
 class AuthorizationProvider:
     """Authorization provider"""

--- a/start_server.sh
+++ b/start_server.sh
@@ -63,6 +63,43 @@ else
     echo -e "${YELLOW}Warning: .env file not found${NC}"
 fi
 
+# Load sensitive values from Docker/Compose secret files without placing them
+# in the Compose model or a tracked environment file. Direct values and *_FILE
+# values are mutually exclusive so deployment configuration cannot be
+# ambiguous.
+load_secret_file() {
+    local variable_name="$1"
+    local file_variable_name="${variable_name}_FILE"
+    local secret_file="${!file_variable_name:-}"
+    local direct_value="${!variable_name:-}"
+    local secret_value
+
+    if [ -z "${secret_file}" ]; then
+        return
+    fi
+    if [ -n "${direct_value}" ]; then
+        echo -e "${RED}Both ${variable_name} and ${file_variable_name} are set${NC}" >&2
+        exit 1
+    fi
+    if [ ! -f "${secret_file}" ] || [ ! -r "${secret_file}" ]; then
+        echo -e "${RED}${file_variable_name} is not a readable file${NC}" >&2
+        exit 1
+    fi
+
+    secret_value="$(<"${secret_file}")"
+    if [ -z "${secret_value}" ] || [[ "${secret_value}" == *$'\n'* ]] || [[ "${secret_value}" == *$'\r'* ]]; then
+        echo -e "${RED}${file_variable_name} must contain one non-empty line${NC}" >&2
+        exit 1
+    fi
+
+    printf -v "${variable_name}" '%s' "${secret_value}"
+    export "${variable_name}"
+    unset "${file_variable_name}"
+}
+
+load_secret_file DORIS_PASSWORD
+load_secret_file TOKEN_ADMIN
+
 # Set HTTP-specific environment variables
 # FIX for Issue #62 Bug 4: Use SERVER_PORT instead of MCP_PORT for consistency with code
 export MCP_TRANSPORT_TYPE="http"

--- a/test/deployment/test_compose_contract.py
+++ b/test/deployment/test_compose_contract.py
@@ -26,7 +26,34 @@ DOCKERFILE_PATH = REPOSITORY_ROOT / "Dockerfile"
 DOCKERIGNORE_PATH = REPOSITORY_ROOT / ".dockerignore"
 START_SCRIPT_PATH = REPOSITORY_ROOT / "start_server.sh"
 REQUIREMENTS_PATH = REPOSITORY_ROOT / "requirements.txt"
+RUNTIME_SECURITY_PATH = REPOSITORY_ROOT / "doris_mcp_server" / "utils" / "security.py"
 DEFAULT_VARIABLE = re.compile(r"^\$\{[^}:]+:-([^}]+)\}$")
+PINNED_IMAGES = {
+    "doris-fe": (
+        "apache/doris:fe-3.0.8@"
+        "sha256:749afa2be75cd58d54a0bdb3edaa805d5974646f67500f094912f8dbc4a96b8f"
+    ),
+    "doris-be": (
+        "apache/doris:be-3.0.8@"
+        "sha256:a337e2b17a65c86c22a1205467a825d46dc3380c94ba8024e53eea033641f12e"
+    ),
+    "redis": (
+        "redis:7.4.10-alpine@"
+        "sha256:e7723ff73d963f5cc6d9c4643ea3d989527a402a319239054e9472a7fb9219a2"
+    ),
+    "prometheus": (
+        "prom/prometheus:v3.13.0@"
+        "sha256:c6b27ea434f8389bfe233fbc7be381cf50587c286e871bc842008f5a1b1908a7"
+    ),
+    "grafana": (
+        "grafana/grafana:13.1.0@"
+        "sha256:121a7a9ece6dc10b969f1f96eed64b4f07dfac0d0b8abc070f7cb83bbde86f63"
+    ),
+    "nginx": (
+        "nginx:1.30.4-alpine@"
+        "sha256:97d490c12ba55b4946b01546d1c3ed324e8d41ab1c9fcb2a616aa470620e5b46"
+    ),
+}
 
 
 def _compose() -> dict:
@@ -50,6 +77,12 @@ def test_default_compose_host_ports_are_unique() -> None:
         )
 
     assert len(published) == len(set(published))
+
+
+def test_compose_does_not_reserve_a_fixed_bridge_subnet() -> None:
+    network = _compose()["networks"]["doris-network"]
+
+    assert network == {"driver": "bridge"}
 
 
 def test_mcp_service_uses_one_real_listener_and_readiness_probe() -> None:
@@ -82,9 +115,108 @@ def test_grafana_default_port_does_not_conflict_with_mcp() -> None:
     assert grafana["ports"] == ["${GRAFANA_HTTP_PORT:-3003}:3000"]
 
 
+def test_external_images_are_versioned_and_digest_pinned() -> None:
+    services = _compose()["services"]
+
+    assert {
+        service: services[service]["image"] for service in PINNED_IMAGES
+    } == PINNED_IMAGES
+    assert all(":latest" not in image for image in PINNED_IMAGES.values())
+
+
+def test_compose_credentials_are_file_backed_secrets() -> None:
+    compose = _compose()
+    services = compose["services"]
+    secret_files = {
+        name: value["file"] for name, value in compose["secrets"].items()
+    }
+
+    assert secret_files == {
+        "doris_password": (
+            "${COMPOSE_DORIS_PASSWORD_FILE:-./.secrets/doris_password}"
+        ),
+        "doris_fe_custom_config": (
+            "${COMPOSE_DORIS_FE_CUSTOM_CONFIG_FILE:"
+            "-./.secrets/doris_fe_custom.conf}"
+        ),
+        "mcp_static_token": (
+            "${COMPOSE_MCP_STATIC_TOKEN_FILE:-./.secrets/mcp_static_token}"
+        ),
+        "redis_password": (
+            "${COMPOSE_REDIS_PASSWORD_FILE:-./.secrets/redis_password}"
+        ),
+        "grafana_admin_password": (
+            "${COMPOSE_GRAFANA_ADMIN_PASSWORD_FILE:"
+            "-./.secrets/grafana_admin_password}"
+        ),
+    }
+    assert services["doris-mcp-server"]["secrets"] == [
+        "doris_password",
+        "mcp_static_token",
+    ]
+    assert "DORIS_PASSWORD_FILE=/run/secrets/doris_password" in (
+        services["doris-mcp-server"]["environment"]
+    )
+    assert "TOKEN_ADMIN_FILE=/run/secrets/mcp_static_token" in (
+        services["doris-mcp-server"]["environment"]
+    )
+    assert services["redis"]["secrets"] == ["redis_password"]
+    assert services["grafana"]["secrets"] == ["grafana_admin_password"]
+    assert (
+        "GF_SECURITY_ADMIN_PASSWORD__FILE=/run/secrets/grafana_admin_password"
+        in services["grafana"]["environment"]
+    )
+
+    compose_text = COMPOSE_PATH.read_text(encoding="utf-8")
+    for weak_value in ("doris123", "redis123", "admin123", "analyst123"):
+        assert weak_value not in compose_text
+
+
+def test_doris_nodes_mount_password_and_initial_root_config_secrets() -> None:
+    services = _compose()["services"]
+
+    assert services["doris-fe"]["secrets"] == [
+        {
+            "source": "doris_password",
+            "target": "/etc/basic_auth/password",
+        },
+        {
+            "source": "doris_fe_custom_config",
+            "target": "/opt/apache-doris/fe/conf/fe_custom.conf",
+        },
+    ]
+    assert services["doris-be"]["secrets"] == [
+        {
+            "source": "doris_password",
+            "target": "/etc/basic_auth/password",
+        }
+    ]
+
+
+def test_redis_password_is_not_exposed_in_command_or_healthcheck() -> None:
+    redis = _compose()["services"]["redis"]
+
+    assert redis["command"][-1] == (
+        'exec redis-server --appendonly yes --requirepass '
+        '"$$(cat /run/secrets/redis_password)"'
+    )
+    assert redis["healthcheck"]["test"] == [
+        "CMD-SHELL",
+        (
+            'REDISCLI_AUTH="$$(cat /run/secrets/redis_password)" '
+            "redis-cli --no-auth-warning ping | grep -qx PONG"
+        ),
+    ]
+
+
 def test_image_healthcheck_uses_liveness_on_the_real_listener() -> None:
     dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
 
+    assert (
+        "FROM python:3.12.11-slim-bookworm@"
+        "sha256:519591d6871b7bc437060736b9f7456b8731f1499a57e22e6c285135ae657bf7"
+        in dockerfile
+    )
     assert "http://127.0.0.1:3000/live" in dockerfile
     assert "EXPOSE 3000\n" in dockerfile
     assert "EXPOSE 3000 3001 3002" not in dockerfile
@@ -115,5 +247,23 @@ def test_start_script_uses_canonical_server_host_and_documents_both_probes() -> 
 
     assert 'SERVER_HOST="${SERVER_HOST:-${MCP_HOST:-127.0.0.1}}"' in script
     assert '--host "${SERVER_HOST}" --port "${SERVER_PORT}"' in script
+    assert "load_secret_file DORIS_PASSWORD" in script
+    assert "load_secret_file TOKEN_ADMIN" in script
+    assert "Both ${variable_name} and ${file_variable_name} are set" in script
+    assert 'unset "${file_variable_name}"' in script
     assert "/live" in script
     assert "/ready" in script
+
+
+def test_runtime_has_no_fixed_legacy_credentials() -> None:
+    security = RUNTIME_SECURITY_PATH.read_text(encoding="utf-8")
+
+    for fixed_credential in (
+        "valid_token_123",
+        "admin_token_456",
+        '"password": "admin123"',
+        '"password": "analyst123"',
+    ):
+        assert fixed_credential not in security
+    assert "_authenticate_legacy_token" not in security
+    assert "Basic authentication is not supported" in security

--- a/test/integration/test_real_doris_transports.py
+++ b/test/integration/test_real_doris_transports.py
@@ -40,7 +40,7 @@ import tempfile
 import time
 from collections.abc import AsyncIterator
 from contextlib import AsyncExitStack, asynccontextmanager, suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -69,7 +69,7 @@ class RealDorisSettings:
     host: str
     port: int
     user: str
-    password: str
+    password: str = field(repr=False)
     database: str
 
 
@@ -79,7 +79,7 @@ class DorisSandbox:
     admin_connection: pymysql.Connection
     table: str
     readonly_user: str
-    readonly_password: str
+    readonly_password: str = field(repr=False)
     marker: str
 
     @property

--- a/test/security/test_authentication.py
+++ b/test/security/test_authentication.py
@@ -20,13 +20,8 @@ Authentication module tests
 """
 
 import pytest
-from datetime import datetime
 
-from doris_mcp_server.utils.security import (
-    AuthenticationProvider,
-    AuthContext,
-    SecurityLevel
-)
+from doris_mcp_server.utils.security import AuthenticationProvider
 
 
 class TestAuthenticationProvider:
@@ -38,57 +33,45 @@ class TestAuthenticationProvider:
         return AuthenticationProvider(test_config)
 
     @pytest.mark.asyncio
-    async def test_token_authentication_success(self, auth_provider):
-        """Test successful token authentication"""
+    async def test_token_authentication_has_no_fixed_legacy_fallback(
+        self, auth_provider
+    ):
+        """Direct token auth fails closed without a configured token manager."""
+        auth_provider.token_manager = None
         auth_info = {
             "type": "token",
-            "token": "valid_token_123"
+            "token": "repository-must-not-accept-this-token",
         }
-        
-        result = await auth_provider.authenticate(auth_info)
-        
-        assert isinstance(result, AuthContext)
-        assert result.user_id == "test_user"
-        assert "data_analyst" in result.roles
-        assert result.security_level == SecurityLevel.INTERNAL
+
+        with pytest.raises(
+            ValueError,
+            match="Token authentication is not enabled|Token manager is not initialized",
+        ):
+            await auth_provider.authenticate(auth_info)
 
     @pytest.mark.asyncio
     async def test_token_authentication_failure(self, auth_provider):
         """Test failed token authentication"""
         auth_info = {
             "type": "token",
-            "token": "invalid_token"
+            "token": "invalid_token",
         }
-        
-        with pytest.raises(Exception):
+
+        with pytest.raises(ValueError):
             await auth_provider.authenticate(auth_info)
 
     @pytest.mark.asyncio
-    async def test_basic_authentication_success(self, auth_provider):
-        """Test successful basic authentication"""
+    async def test_basic_authentication_is_not_backed_by_fixed_credentials(
+        self, auth_provider
+    ):
+        """Legacy direct Basic auth is explicitly unsupported."""
         auth_info = {
             "type": "basic",
             "username": "admin",
-            "password": "admin123"
+            "password": "any-value",
         }
-        
-        result = await auth_provider.authenticate(auth_info)
-        
-        assert isinstance(result, AuthContext)
-        assert result.user_id == "admin_user"
-        assert "data_admin" in result.roles
-        assert result.security_level == SecurityLevel.SECRET
 
-    @pytest.mark.asyncio
-    async def test_basic_authentication_failure(self, auth_provider):
-        """Test failed basic authentication"""
-        auth_info = {
-            "type": "basic",
-            "username": "admin",
-            "password": "wrong_password"
-        }
-        
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="Basic authentication is not supported"):
             await auth_provider.authenticate(auth_info)
 
     @pytest.mark.asyncio
@@ -96,8 +79,8 @@ class TestAuthenticationProvider:
         """Test unsupported authentication type"""
         auth_info = {
             "type": "oauth",
-            "token": "oauth_token"
+            "token": "oauth_token",
         }
-        
-        with pytest.raises(Exception):
-            await auth_provider.authenticate(auth_info) 
+
+        with pytest.raises(ValueError):
+            await auth_provider.authenticate(auth_info)

--- a/test/security/test_real_doris_secret_repr.py
+++ b/test/security/test_real_doris_secret_repr.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import cast
+
+import pymysql
+
+from test.integration.test_real_doris_transports import (
+    DorisSandbox,
+    RealDorisSettings,
+)
+
+
+def test_real_doris_fixture_repr_redacts_passwords() -> None:
+    admin_password = "admin-secret-that-must-not-be-rendered"
+    readonly_password = "readonly-secret-that-must-not-be-rendered"
+    settings = RealDorisSettings(
+        host="127.0.0.1",
+        port=9030,
+        user="admin",
+        password=admin_password,
+        database="test",
+    )
+    sandbox = DorisSandbox(
+        settings=settings,
+        admin_connection=cast(pymysql.Connection, object()),
+        table="fixture",
+        readonly_user="readonly",
+        readonly_password=readonly_password,
+        marker="marker",
+    )
+
+    rendered = repr(sandbox)
+    assert admin_password not in rendered
+    assert readonly_password not in rendered

--- a/test/security/test_security_manager.py
+++ b/test/security/test_security_manager.py
@@ -20,13 +20,16 @@ Security manager integration tests
 """
 
 import pytest
+import pytest_asyncio
 
+from doris_mcp_server.utils.config import normalize_effective_auth_config
 from doris_mcp_server.utils.security import (
-    DorisSecurityManager,
     AuthContext,
+    DorisSecurityManager,
     SecurityLevel,
-    ValidationResult
 )
+
+STATIC_TOKEN = "3e5f98dbed994130b60186dbe83fb0c76c5e6d0da81a4441a4615fbe7bdc7562"
 
 
 class TestDorisSecurityManager:
@@ -34,114 +37,152 @@ class TestDorisSecurityManager:
 
     @pytest.fixture
     def security_manager(self, test_config):
-        """Create security manager instance"""
+        """Create a security manager for non-authentication behavior."""
         return DorisSecurityManager(test_config)
 
+    @pytest_asyncio.fixture
+    async def token_security_manager(self, test_config, monkeypatch, tmp_path):
+        """Create a manager with an explicit high-entropy static token."""
+        monkeypatch.setenv("TOKEN_SECURITY_MANAGER", STATIC_TOKEN)
+        test_config.security.enable_token_auth = True
+        test_config.security.token_file_path = str(tmp_path / "tokens.json")
+        normalize_effective_auth_config(test_config)
+        manager = DorisSecurityManager(test_config)
+        try:
+            yield manager
+        finally:
+            manager.auth_provider.token_manager.stop_hot_reload()
+
     @pytest.mark.asyncio
-    async def test_complete_security_workflow(self, security_manager, sample_data):
+    async def test_complete_security_workflow(
+        self,
+        token_security_manager,
+        sample_data,
+    ):
         """Test complete security workflow"""
         # 1. Authentication
         auth_info = {
             "type": "token",
-            "token": "valid_token_123"
+            "token": STATIC_TOKEN,
         }
-        
-        auth_context = await security_manager.authenticate_request(auth_info)
+
+        auth_context = await token_security_manager.authenticate_request(auth_info)
         assert isinstance(auth_context, AuthContext)
         assert auth_context.security_level == SecurityLevel.INTERNAL
-        
+        auth_context.roles.append("data_analyst")
+
         # 2. Authorization
         resource_uri = "/api/table/public_reports"
-        has_access = await security_manager.authorize_resource_access(auth_context, resource_uri)
+        has_access = await token_security_manager.authorize_resource_access(
+            auth_context,
+            resource_uri,
+        )
         assert has_access is True
-        
+
         # 3. SQL Validation
         safe_sql = "SELECT name, email FROM users WHERE department = 'sales'"
-        validation_result = await security_manager.validate_sql_security(safe_sql, auth_context)
+        validation_result = await token_security_manager.validate_sql_security(
+            safe_sql,
+            auth_context,
+        )
         assert validation_result.is_valid is True
-        
+
         # 4. Data Masking
-        masked_data = await security_manager.apply_data_masking(sample_data, auth_context)
+        masked_data = await token_security_manager.apply_data_masking(
+            sample_data,
+            auth_context,
+        )
         assert masked_data[0]["phone"] == "138****5678"  # Should be masked
 
     @pytest.mark.asyncio
-    async def test_admin_workflow(self, security_manager, sample_data):
-        """Test admin user workflow"""
-        # Admin authentication
-        auth_info = {
-            "type": "basic",
-            "username": "admin",
-            "password": "admin123"
-        }
-        
-        auth_context = await security_manager.authenticate_request(auth_info)
-        assert auth_context.security_level == SecurityLevel.SECRET
-        
-        # Admin should access secret resources
+    async def test_secret_level_authorization_and_masking(
+        self,
+        security_manager,
+        sample_data,
+    ):
+        """Test authorization and masking with a trusted secret-level context."""
+        auth_context = AuthContext(
+            token_id="trusted-admin",
+            user_id="trusted-admin",
+            roles=["data_admin"],
+            permissions=["admin"],
+            security_level=SecurityLevel.SECRET,
+            auth_method="test",
+        )
+
         resource_uri = "/api/table/payment_records"
-        has_access = await security_manager.authorize_resource_access(auth_context, resource_uri)
+        has_access = await security_manager.authorize_resource_access(
+            auth_context, resource_uri
+        )
         assert has_access is True
-        
-        # Admin should see original data (no masking)
-        masked_data = await security_manager.apply_data_masking(sample_data, auth_context)
-        assert masked_data[0]["phone"] == "13812345678"  # Original data
+
+        masked_data = await security_manager.apply_data_masking(
+            sample_data, auth_context
+        )
+        assert masked_data[0]["phone"] == "13812345678"
 
     @pytest.mark.asyncio
-    async def test_security_violation_detection(self, security_manager):
+    async def test_security_violation_detection(self, token_security_manager):
         """Test security violation detection"""
         # Authenticate as regular user
         auth_info = {
             "type": "token",
-            "token": "valid_token_123"
+            "token": STATIC_TOKEN,
         }
-        
-        auth_context = await security_manager.authenticate_request(auth_info)
-        
+
+        auth_context = await token_security_manager.authenticate_request(auth_info)
+
         # Try to access confidential resource (user_info is CONFIDENTIAL, user is INTERNAL)
         # INTERNAL(1) should not access CONFIDENTIAL(2) resource
         resource_uri = "/api/table/user_info"
-        has_access = await security_manager.authorize_resource_access(auth_context, resource_uri)
+        has_access = await token_security_manager.authorize_resource_access(
+            auth_context,
+            resource_uri,
+        )
         assert has_access is False
-        
+
         # Try dangerous SQL
         dangerous_sql = "DROP TABLE users"
-        validation_result = await security_manager.validate_sql_security(dangerous_sql, auth_context)
+        validation_result = await token_security_manager.validate_sql_security(
+            dangerous_sql,
+            auth_context,
+        )
         assert validation_result.is_valid is False
         assert "DROP" in validation_result.blocked_operations
 
     @pytest.mark.asyncio
-    async def test_sql_injection_prevention(self, security_manager):
+    async def test_sql_injection_prevention(self, token_security_manager):
         """Test SQL injection prevention"""
         auth_info = {
             "type": "token",
-            "token": "valid_token_123"
+            "token": STATIC_TOKEN,
         }
-        
-        auth_context = await security_manager.authenticate_request(auth_info)
-        
+
+        auth_context = await token_security_manager.authenticate_request(auth_info)
+
         # Test various injection attempts
         injection_attempts = [
             "SELECT * FROM users WHERE id = 1; DROP TABLE users;",
             "SELECT * FROM users UNION SELECT password FROM admin_users",
             "SELECT * FROM users WHERE id = 1 OR 1=1",
-            "SELECT * FROM users WHERE name = 'test' -- AND password = 'secret'"
+            "SELECT * FROM users WHERE name = 'test' -- AND password = 'secret'",
         ]
-        
+
         for sql in injection_attempts:
-            result = await security_manager.validate_sql_security(sql, auth_context)
+            result = await token_security_manager.validate_sql_security(
+                sql,
+                auth_context,
+            )
             assert result.is_valid is False
             assert result.risk_level in ["medium", "high"]
 
     @pytest.mark.asyncio
-    async def test_authentication_failure_handling(self, security_manager):
+    async def test_authentication_failure_handling(self, token_security_manager):
         """Test authentication failure handling"""
-        invalid_auth_info = {
-            "type": "token",
-            "token": "invalid_token"
-        }
-        
-        with pytest.raises(Exception):
-            await security_manager.authenticate_request(invalid_auth_info)
+        invalid_auth_info = {"type": "token", "token": "invalid_token"}
+
+        with pytest.raises(ValueError, match="Authentication failed"):
+            await token_security_manager.authenticate_request(invalid_auth_info)
 
     @pytest.mark.asyncio
     async def test_configuration_loading(self, security_manager):
@@ -149,24 +190,31 @@ class TestDorisSecurityManager:
         # Test blocked keywords loading
         assert "DROP" in security_manager.blocked_keywords
         assert "DELETE" in security_manager.blocked_keywords
-        
+
         # Test sensitive tables loading
         assert SecurityLevel.CONFIDENTIAL in security_manager.sensitive_tables.values()
         assert SecurityLevel.SECRET in security_manager.sensitive_tables.values()
-        
+
         # Test masking rules loading
         assert len(security_manager.masking_rules) > 0
-        phone_rules = [rule for rule in security_manager.masking_rules 
-                      if "phone" in rule.column_pattern]
+        phone_rules = [
+            rule
+            for rule in security_manager.masking_rules
+            if "phone" in rule.column_pattern
+        ]
         assert len(phone_rules) > 0
 
     def test_security_level_hierarchy(self, security_manager):
         """Test security level hierarchy"""
         # Test that hierarchy is correctly defined
-        levels = [SecurityLevel.PUBLIC, SecurityLevel.INTERNAL, 
-                 SecurityLevel.CONFIDENTIAL, SecurityLevel.SECRET]
-        
+        levels = [
+            SecurityLevel.PUBLIC,
+            SecurityLevel.INTERNAL,
+            SecurityLevel.CONFIDENTIAL,
+            SecurityLevel.SECRET,
+        ]
+
         # Each level should be properly defined
         for level in levels:
             assert isinstance(level, SecurityLevel)
-            assert level.value in ["public", "internal", "confidential", "secret"] 
+            assert level.value in ["public", "internal", "confidential", "secret"]


### PR DESCRIPTION
## Summary

- replace inline Compose passwords with ignored host-backed secrets and fail closed on missing or ambiguous secret configuration
- remove fixed legacy token and Basic credentials from runtime authentication
- pin Python, Doris, Redis, Prometheus, Grafana, and nginx images to explicit versions and immutable digests
- update the bundled Doris images and mounts, and let Docker allocate a non-conflicting bridge subnet
- redact real-integration passwords from pytest object representations and document secure Compose setup

## Testing

- `uv run pytest -q`: 622 passed, 64 skipped
- real Doris matrix: 7 passed across Streamable HTTP and true subprocess Stdio, including independent FE/BE HTTP endpoints
- built and ran the pinned Docker image against real Doris; `/live` and `/ready` passed
- unauthenticated MCP request returned 401; secret-backed Bearer token completed `SELECT 1`
- verified fail-closed startup for missing and conflicting secret configuration
- verified Compose secret mounts, Redis authentication, and automatic non-conflicting network allocation
- `uv lock --check`, compileall, Bandit, dependency consistency, and `uv build` passed
- audited wheel, sdist, and image contents for local reports, ledgers, secrets, tokens, and coverage artifacts
