### PR TITLE
test: eliminate runtime and UTC warnings

### DIFF
--- a/doris_mcp_server/auth/auth_middleware.py
+++ b/doris_mcp_server/auth/auth_middleware.py
@@ -20,13 +20,14 @@ Authentication Middleware Module
 Provides middleware for JWT authentication in HTTP and MCP contexts
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from ..utils.auth_credentials import (
     BearerCredentials,
     normalize_bearer_credentials,
 )
 from ..utils.logger import get_logger
+from ..utils.datetime_utils import utc_now
 from ..utils.security import AuthContext, SecurityLevel
 from .jwt_manager import JWTManager
 
@@ -110,8 +111,8 @@ class AuthMiddleware:
                 permissions=payload.get('permissions', []),
                 security_level=SecurityLevel(payload.get('security_level', 'internal')),
                 session_id=payload.get('jti'),  # Use JWT ID as session ID
-                login_time=datetime.fromtimestamp(payload.get('iat', 0)),
-                last_activity=datetime.utcnow(),
+                login_time=datetime.fromtimestamp(payload.get('iat', 0), UTC),
+                last_activity=utc_now(),
                 token="",
                 auth_method="jwt",
                 pool_key="global",

--- a/doris_mcp_server/auth/key_manager.py
+++ b/doris_mcp_server/auth/key_manager.py
@@ -25,12 +25,13 @@ import time
 import secrets
 from pathlib import Path
 from typing import Optional, Tuple, Union
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa, ec
 from cryptography.hazmat.backends import default_backend
 
 from ..utils.logger import get_logger
+from ..utils.datetime_utils import utc_now
 
 logger = get_logger(__name__)
 
@@ -96,7 +97,7 @@ class KeyManager:
             self._secret_key = await self.generate_symmetric_key()
             logger.info("Generated new symmetric key")
         
-        self._key_generated_at = datetime.utcnow()
+        self._key_generated_at = utc_now()
     
     async def _initialize_asymmetric_keys(self):
         """Initialize asymmetric key pair (RS256/ES256)"""
@@ -141,7 +142,10 @@ class KeyManager:
             )
             
             # Get key generation time (using file modification time)
-            self._key_generated_at = datetime.fromtimestamp(private_path.stat().st_mtime)
+            self._key_generated_at = datetime.fromtimestamp(
+                private_path.stat().st_mtime,
+                UTC,
+            )
             
             return True
             
@@ -168,7 +172,7 @@ class KeyManager:
                 public_key_env.encode(), backend=default_backend()
             )
             
-            self._key_generated_at = datetime.utcnow()
+            self._key_generated_at = utc_now()
             return True
             
         except Exception as e:
@@ -225,7 +229,7 @@ class KeyManager:
             # Store keys
             self._private_key = private_key
             self._public_key = public_key
-            self._key_generated_at = datetime.utcnow()
+            self._key_generated_at = utc_now()
             
             # If file paths are configured, save to files
             if self.private_key_path and self.public_key_path:
@@ -288,7 +292,7 @@ class KeyManager:
             return True
         
         expiry_time = self._key_generated_at + timedelta(seconds=self.key_rotation_interval)
-        return datetime.utcnow() > expiry_time
+        return utc_now() > expiry_time
     
     async def rotate_keys(self) -> bool:
         """Rotate keys"""
@@ -298,7 +302,7 @@ class KeyManager:
             if self.algorithm == "HS256":
                 # Generate new symmetric key
                 self._secret_key = await self.generate_symmetric_key()
-                self._key_generated_at = datetime.utcnow()
+                self._key_generated_at = utc_now()
             else:
                 # Generate new asymmetric key pair
                 await self.generate_key_pair()

--- a/doris_mcp_server/auth/oauth_client.py
+++ b/doris_mcp_server/auth/oauth_client.py
@@ -45,6 +45,7 @@ from .oauth_token_validation import (
     OAuthAccessTokenContext,
 )
 from ..utils.logger import get_logger
+from ..utils.datetime_utils import utc_now
 
 logger = get_logger(__name__)
 
@@ -107,8 +108,8 @@ class OAuthStateManager:
             pkce_verifier=pkce_verifier,
             pkce_challenge=pkce_challenge,
             redirect_uri=redirect_uri,
-            created_at=datetime.utcnow(),
-            expires_at=datetime.utcnow() + timedelta(seconds=self.state_expiry)
+            created_at=utc_now(),
+            expires_at=utc_now() + timedelta(seconds=self.state_expiry)
         )
         
         self._states[state] = oauth_state
@@ -125,7 +126,7 @@ class OAuthStateManager:
             OAuth state object or None if not found/expired
         """
         oauth_state = self._states.get(state)
-        if oauth_state and oauth_state.expires_at > datetime.utcnow():
+        if oauth_state and oauth_state.expires_at > utc_now():
             return oauth_state
         elif oauth_state:
             # Remove expired state
@@ -153,7 +154,7 @@ class OAuthStateManager:
         while True:
             try:
                 await asyncio.sleep(300)  # Clean up every 5 minutes
-                current_time = datetime.utcnow()
+                current_time = utc_now()
                 expired_states = [
                     state for state, oauth_state in self._states.items()
                     if oauth_state.expires_at <= current_time
@@ -332,7 +333,7 @@ class OAuthClient:
         try:
             # Check cache first
             if (self._discovery_cache and self._discovery_cache_time and 
-                datetime.utcnow() - self._discovery_cache_time < timedelta(hours=1)):
+                utc_now() - self._discovery_cache_time < timedelta(hours=1)):
                 return self._discovery_cache
             
             logger.info(f"Discovering OIDC endpoints: {self.provider_config.discovery_url}")
@@ -376,7 +377,7 @@ class OAuthClient:
             
             # Cache discovery result
             self._discovery_cache = discovery
-            self._discovery_cache_time = datetime.utcnow()
+            self._discovery_cache_time = utc_now()
             
             logger.info("OIDC endpoint discovery completed successfully")
             return discovery

--- a/doris_mcp_server/auth/oauth_provider.py
+++ b/doris_mcp_server/auth/oauth_provider.py
@@ -21,8 +21,6 @@ Integrates OAuth 2.0/OIDC authentication with the existing authentication framew
 """
 
 from typing import Dict, Any, Optional, Tuple
-from datetime import datetime
-
 from .oauth_client import OAuthClient
 from .oauth_token_validation import (
     OAuthAccessTokenContext,
@@ -31,6 +29,7 @@ from .oauth_token_validation import (
 from .oauth_types import OAuthTokens, OAuthUserInfo, OAuthState
 from ..utils.security import AuthContext, SecurityLevel
 from ..utils.logger import get_logger
+from ..utils.datetime_utils import utc_now
 
 logger = get_logger(__name__)
 
@@ -240,7 +239,8 @@ class OAuthAuthenticationProvider:
         permissions = await self._map_permissions(user_info.roles)
         
         # Generate session ID
-        session_id = f"oauth_{user_info.sub}_{datetime.utcnow().timestamp()}"
+        now = utc_now()
+        session_id = f"oauth_{user_info.sub}_{now.timestamp()}"
         
         return AuthContext(
             token_id=token_context.token_id or f"oauth_{user_info.sub}",
@@ -249,8 +249,8 @@ class OAuthAuthenticationProvider:
             permissions=permissions,
             security_level=security_level,
             session_id=session_id,
-            login_time=datetime.utcnow(),
-            last_activity=datetime.utcnow(),
+            login_time=now,
+            last_activity=now,
             token="",  # OAuth doesn't have raw token, use empty string
             auth_method="external_oauth",
             oauth_client_id=token_context.client_id,

--- a/doris_mcp_server/auth/oauth_types.py
+++ b/doris_mcp_server/auth/oauth_types.py
@@ -25,6 +25,8 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, Any, Optional, List
 
+from ..utils.datetime_utils import utc_now
+
 
 class OAuthProvider(Enum):
     """OAuth provider enumeration"""
@@ -53,7 +55,7 @@ class OAuthState:
     
     def __post_init__(self):
         if self.created_at is None:
-            self.created_at = datetime.utcnow()
+            self.created_at = utc_now()
 
 
 @dataclass
@@ -69,7 +71,7 @@ class OAuthTokens:
     
     def __post_init__(self):
         if self.created_at is None:
-            self.created_at = datetime.utcnow()
+            self.created_at = utc_now()
 
 
 @dataclass

--- a/doris_mcp_server/auth/token_manager.py
+++ b/doris_mcp_server/auth/token_manager.py
@@ -29,13 +29,14 @@ import secrets
 import tempfile
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
 from filelock import FileLock
 
 from ..utils.logger import get_logger
+from ..utils.datetime_utils import as_utc, format_rfc3339, utc_now
 from ..utils.secret_policy import (
     build_token_digest,
     is_static_token_environment_variable,
@@ -64,7 +65,7 @@ class TokenInfo:
     """Token information structure with optional database binding"""
     
     token_id: str  # Unique token identifier for audit and management
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=utc_now)
     expires_at: Optional[datetime] = None
     last_used: Optional[datetime] = None
     description: str = ""  # Optional description for token purpose
@@ -222,7 +223,7 @@ class TokenManager:
 
     @staticmethod
     def _parse_datetime(value: Any, *, setting: str) -> Optional[datetime]:
-        """Parse an RFC 3339 timestamp into the manager's naive UTC form."""
+        """Parse an RFC 3339 timestamp into timezone-aware UTC."""
         if value in (None, ""):
             return None
         if not isinstance(value, str):
@@ -232,9 +233,7 @@ class TokenManager:
             parsed = datetime.fromisoformat(normalized)
         except ValueError as exc:
             raise ValueError(f"{setting} must be an RFC 3339 timestamp") from exc
-        if parsed.tzinfo is not None:
-            parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
-        return parsed
+        return as_utc(parsed)
 
     def _add_token_from_config(
         self,
@@ -249,7 +248,7 @@ class TokenManager:
             created_at = self._parse_datetime(
                 token_config.get('created_at'),
                 setting=f"static token '{token_id}' created_at",
-            ) or datetime.utcnow()
+            ) or utc_now()
 
             # Calculate expiration time
             if 'expires_at' in token_config:
@@ -541,14 +540,14 @@ class TokenManager:
                 )
             
             # Check expiration
-            if token_info.expires_at and datetime.utcnow() > token_info.expires_at:
+            if token_info.expires_at and utc_now() > token_info.expires_at:
                 return TokenValidationResult(
                     is_valid=False,
                     error_message="Token has expired"
                 )
             
             # Update last used time
-            token_info.last_used = datetime.utcnow()
+            token_info.last_used = utc_now()
             
             return TokenValidationResult(
                 is_valid=True,
@@ -593,9 +592,9 @@ class TokenManager:
             # Calculate expiration
             expires_at = None
             if expires_hours is not None:
-                expires_at = datetime.utcnow() + timedelta(hours=expires_hours)
+                expires_at = utc_now() + timedelta(hours=expires_hours)
             elif self.enable_token_expiry:
-                expires_at = datetime.utcnow() + timedelta(hours=self.default_token_expiry_hours)
+                expires_at = utc_now() + timedelta(hours=self.default_token_expiry_hours)
             
             # Create token info
             token_info = TokenInfo(
@@ -779,7 +778,7 @@ class TokenManager:
             "description": (
                 "Doris MCP Server digest-only shared token state"
             ),
-            "updated_at": datetime.utcnow().isoformat() + "Z",
+            "updated_at": format_rfc3339(utc_now()),
             "tokens": tokens,
             "revoked_tokens": sorted(
                 revoked_tokens or [],
@@ -904,7 +903,7 @@ class TokenManager:
         return {
             "token_id": token_id,
             "token_digest": token_digest,
-            "revoked_at": revoked_at.isoformat() + "Z",
+            "revoked_at": format_rfc3339(revoked_at),
         }
 
     def _token_info_to_config(
@@ -919,14 +918,14 @@ class TokenManager:
                 token_hash,
                 setting=f"static token '{token_info.token_id}' token_digest",
             ),
-            "created_at": token_info.created_at.isoformat() + "Z",
+            "created_at": format_rfc3339(token_info.created_at),
             "expires_at": (
-                token_info.expires_at.isoformat() + "Z"
+                format_rfc3339(token_info.expires_at)
                 if token_info.expires_at
                 else None
             ),
             "last_used": (
-                token_info.last_used.isoformat() + "Z"
+                format_rfc3339(token_info.last_used)
                 if token_info.last_used
                 else None
             ),
@@ -992,7 +991,7 @@ class TokenManager:
                 {
                     "token_id": token_id,
                     "token_digest": token_hash,
-                    "revoked_at": datetime.utcnow().isoformat() + "Z",
+                    "revoked_at": format_rfc3339(utc_now()),
                 }
             )
             sanitized_revocations = [
@@ -1032,7 +1031,11 @@ class TokenManager:
                 'last_used': token_info.last_used.isoformat() if token_info.last_used else None,
                 'is_active': token_info.is_active,
                 'description': token_info.description,
-                'is_expired': token_info.expires_at and datetime.utcnow() > token_info.expires_at if token_info.expires_at else False
+                'is_expired': (
+                    utc_now() > token_info.expires_at
+                    if token_info.expires_at
+                    else False
+                ),
             }
             
             # Add database binding info (without sensitive data)
@@ -1061,7 +1064,7 @@ class TokenManager:
 
         with self._shared_state_lock():
             self._reload_tokens_from_sources()
-            now = datetime.utcnow()
+            now = utc_now()
             expired_tokens = [
                 (token_hash, token_info.token_id)
                 for token_hash, token_info in self._tokens.items()
@@ -1123,7 +1126,7 @@ class TokenManager:
                 return None
                 
             # Check expiration
-            if token_info.expires_at and datetime.utcnow() > token_info.expires_at:
+            if token_info.expires_at and utc_now() > token_info.expires_at:
                 return None
                 
             return token_info.database_config
@@ -1135,7 +1138,7 @@ class TokenManager:
     def get_token_stats(self) -> Dict[str, Any]:
         """Get token statistics"""
         self._synchronize_shared_state()
-        now = datetime.utcnow()
+        now = utc_now()
         total_tokens = len(self._tokens)
         active_tokens = sum(1 for info in self._tokens.values() if info.is_active)
         expired_tokens = sum(1 for info in self._tokens.values() 
@@ -1151,7 +1154,11 @@ class TokenManager:
             'expiry_enabled': self.enable_token_expiry,
             'default_expiry_hours': self.default_token_expiry_hours,
             'hot_reload_enabled': self.enable_hot_reload,
-            'last_file_check': datetime.fromtimestamp(self._file_last_modified).isoformat() if self._file_last_modified else None
+            'last_file_check': (
+                datetime.fromtimestamp(self._file_last_modified, UTC).isoformat()
+                if self._file_last_modified
+                else None
+            ),
         }
     
     def _start_hot_reload(self) -> None:

--- a/doris_mcp_server/main.py
+++ b/doris_mcp_server/main.py
@@ -126,6 +126,7 @@ class DorisServer:
             # For stdio mode, we must establish a working database connection
             # Use the dedicated stdio mode initialization method
             await self.connection_manager.initialize_for_stdio_mode()
+            await self.tools_manager.start()
 
             from mcp.server.stdio import stdio_server
             
@@ -204,6 +205,7 @@ class DorisServer:
                         "to initialize successfully in Phase 3"
                     )
                 self.logger.info("HTTP mode running without global database pool, will use token-bound configurations")
+            await self.tools_manager.start()
 
             # Use the SDK v2 dual-era Streamable HTTP manager.
             import contextlib
@@ -474,6 +476,8 @@ class DorisServer:
         """Shutdown server"""
         self.logger.info("Shutting down Doris MCP Server")
         try:
+            await self.tools_manager.close()
+
             # Shutdown security manager first (includes JWT cleanup)
             await self.security_manager.shutdown()
             self.logger.info("Security manager shutdown completed")

--- a/doris_mcp_server/multiworker_app.py
+++ b/doris_mcp_server/multiworker_app.py
@@ -51,6 +51,7 @@ _worker_server = None
 _worker_session_manager = None
 _worker_connection_manager = None
 _worker_security_manager = None
+_worker_tools_manager = None
 _worker_session_manager_context = None
 _worker_initialized = False
 _worker_effective_auth = None
@@ -58,7 +59,7 @@ _doris_oauth_handlers = None
 
 async def initialize_worker():
     """Initialize MCP server and managers for this worker process"""
-    global _worker_server, _worker_session_manager, _worker_connection_manager, _worker_security_manager, _worker_session_manager_context, _worker_initialized, _oauth_handlers, _token_handlers, _worker_effective_auth, _doris_oauth_handlers
+    global _worker_server, _worker_session_manager, _worker_connection_manager, _worker_security_manager, _worker_tools_manager, _worker_session_manager_context, _worker_initialized, _oauth_handlers, _token_handlers, _worker_effective_auth, _doris_oauth_handlers
     
     if _worker_initialized:
         return
@@ -110,12 +111,13 @@ async def initialize_worker():
         
         # Create managers
         resources_manager = DorisResourcesManager(_worker_connection_manager)
-        tools_manager = DorisToolsManager(_worker_connection_manager)
+        _worker_tools_manager = DorisToolsManager(_worker_connection_manager)
+        await _worker_tools_manager.start()
         prompts_manager = DorisPromptsManager(_worker_connection_manager)
 
         _worker_server = create_doris_mcp_server(
             resources_manager=resources_manager,
-            tools_manager=tools_manager,
+            tools_manager=_worker_tools_manager,
             prompts_manager=prompts_manager,
             name=config.server_name,
             version=config.server_version,
@@ -385,6 +387,13 @@ async def lifespan(app):
                 logger.info(f"Worker {os.getpid()} session manager context closed")
             except Exception as e:
                 logger.error(f"Error closing worker session manager context: {e}")
+
+        if _worker_tools_manager:
+            try:
+                await _worker_tools_manager.close()
+                logger.info(f"Worker {os.getpid()} tools manager closed")
+            except Exception as e:
+                logger.error(f"Error closing worker tools manager: {e}")
         
         if _worker_connection_manager:
             try:

--- a/doris_mcp_server/tools/tools_manager.py
+++ b/doris_mcp_server/tools/tools_manager.py
@@ -76,6 +76,14 @@ class DorisToolsManager:
         self.adbc_query_tools = DorisADBCQueryTools(connection_manager)
         
         logger.info("DorisToolsManager initialized with business logic processors, v0.5.0 analytics tools, and ADBC query tools")
+
+    async def start(self) -> None:
+        """Start runtime resources owned by the tools manager."""
+        await self.query_executor.start()
+
+    async def close(self) -> None:
+        """Stop runtime resources owned by the tools manager."""
+        await self.query_executor.close()
     
     async def register_tools_with_mcp(self, mcp):
         """Register all tools to MCP server"""

--- a/doris_mcp_server/utils/datetime_utils.py
+++ b/doris_mcp_server/utils/datetime_utils.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Timezone-aware UTC helpers used by runtime state and wire timestamps."""
+
+from datetime import UTC, datetime
+
+
+def utc_now() -> datetime:
+    """Return the current time as a timezone-aware UTC datetime."""
+    return datetime.now(UTC)
+
+
+def as_utc(value: datetime) -> datetime:
+    """Normalize aware or legacy-naive UTC values to aware UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def format_rfc3339(value: datetime) -> str:
+    """Serialize a datetime as an RFC 3339 UTC timestamp ending in ``Z``."""
+    return as_utc(value).isoformat().replace("+00:00", "Z")

--- a/doris_mcp_server/utils/db.py
+++ b/doris_mcp_server/utils/db.py
@@ -38,6 +38,7 @@ from typing import Any, Dict, Optional
 import aiomysql
 from aiomysql import Connection, Pool
 
+from .datetime_utils import utc_now
 from .logger import get_logger
 
 
@@ -136,8 +137,8 @@ class DorisConnection:
     ):
         self.connection = connection
         self.session_id = session_id
-        self.created_at = datetime.utcnow()
-        self.last_used = datetime.utcnow()
+        self.created_at = utc_now()
+        self.last_used = utc_now()
         self.query_count = 0
         self.is_healthy = True
         self.security_manager = security_manager
@@ -189,7 +190,7 @@ class DorisConnection:
                     row_count = cursor.rowcount
 
                 execution_time = time.time() - start_time
-                self.last_used = datetime.utcnow()
+                self.last_used = utc_now()
                 self.query_count += 1
 
                 # Get column information
@@ -663,7 +664,7 @@ class DorisConnectionManager:
                 and meta
                 and meta.credential_fingerprint == fingerprint
             ):
-                meta.last_used = datetime.utcnow()
+                meta.last_used = utc_now()
                 self.logger.debug("Reusing Doris user pool for %s", normalized_user)
                 return
 
@@ -674,7 +675,7 @@ class DorisConnectionManager:
             old_meta = meta
             generation = (old_meta.generation + 1) if old_meta else 1
             owner_id = f"doris_user:{normalized_user}:gen:{generation}:{uuid.uuid4().hex}"
-            now = datetime.utcnow()
+            now = utc_now()
             new_meta = DorisUserPoolMeta(
                 user=normalized_user,
                 pool_key=self._doris_user_route_key(normalized_user),
@@ -720,7 +721,7 @@ class DorisConnectionManager:
                 raise DorisUserPoolMissingError(f"Doris user pool missing for {normalized_user}")
 
             raw_conn = await asyncio.wait_for(pool.acquire(), timeout=self.connect_timeout)
-            meta.last_used = datetime.utcnow()
+            meta.last_used = utc_now()
             return DorisConnection(
                 raw_conn,
                 session_id,
@@ -779,7 +780,7 @@ class DorisConnectionManager:
         """Close Doris-user pools that are not in active_users and are optionally idle."""
         active_users = active_users or set()
         normalized_active_users = {u for u in active_users if isinstance(u, str)}
-        now = datetime.utcnow()
+        now = utc_now()
         users_to_remove: list[str] = []
 
         async with self._doris_user_pools_lock:
@@ -1686,7 +1687,7 @@ class DorisConnectionManager:
             
             if health_ok:
                 self.logger.debug("✅ Pool health check passed")
-                self.metrics.last_health_check = datetime.utcnow()
+                self.metrics.last_health_check = utc_now()
             else:
                 self.logger.warning("❌ Pool health check failed, attempting recovery")
                 await self._recover_pool()
@@ -2143,7 +2144,7 @@ class DorisConnectionManager:
     async def diagnose_connection_health(self) -> Dict[str, Any]:
         """Diagnose connection pool health - Simplified Strategy"""
         diagnosis = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_now().isoformat(),
             "pool_status": "unknown",
             "pool_info": {},
             "recommendations": []
@@ -2230,7 +2231,7 @@ class ConnectionPoolMonitor:
         pool_utilization = 1.0 - (pool_status["free_connections"] / pool_status["pool_size"]) if pool_status["pool_size"] > 0 else 0.0
         
         report = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_now().isoformat(),
             "pool_status": pool_status,
             "pool_utilization": pool_utilization,
             "recommendations": [],

--- a/doris_mcp_server/utils/query_executor.py
+++ b/doris_mcp_server/utils/query_executor.py
@@ -36,6 +36,7 @@ from decimal import Decimal
 import sqlparse
 
 from .db import DorisConnectionManager, QueryResult, get_first_sql_keyword
+from .datetime_utils import utc_now
 from .logger import get_logger
 from .sql_security_utils import (
     SQLSecurityError,
@@ -71,12 +72,12 @@ class CachedQuery:
         """Check if cache is expired"""
         if self.ttl <= 0:
             return False
-        return (datetime.utcnow() - self.created_at).total_seconds() > self.ttl
+        return (utc_now() - self.created_at).total_seconds() > self.ttl
 
     def access(self):
         """Record access"""
         self.access_count += 1
-        self.last_accessed = datetime.utcnow()
+        self.last_accessed = utc_now()
 
 
 @dataclass
@@ -146,7 +147,7 @@ class QueryCache:
             await self._evict_oldest()
 
         cached_query = CachedQuery(
-            result=result, created_at=datetime.utcnow(), ttl=ttl or self.default_ttl
+            result=result, created_at=utc_now(), ttl=ttl or self.default_ttl
         )
 
         self.cache[cache_key] = cached_query
@@ -349,8 +350,7 @@ class DorisQueryExecutor:
         ) if hasattr(self.config, 'performance') else 50
 
         # Background tasks
-        self._background_tasks = []
-        self._start_background_tasks()
+        self._background_tasks: list[asyncio.Task[None]] = []
 
     def _create_default_config(self):
         """Create default configuration"""
@@ -366,16 +366,14 @@ class DorisQueryExecutor:
 
         return DefaultConfig()
 
-    def _start_background_tasks(self):
-        """Start background tasks"""
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # No event loop running (e.g., in tests), skip background tasks
-            self.logger.debug("No event loop running, skipping background tasks")
+    async def start(self) -> None:
+        """Start owned background tasks within an explicit runtime lifecycle."""
+        if any(not task.done() for task in self._background_tasks):
             return
-
-        cleanup_task = loop.create_task(self._cache_cleanup_loop())
+        self._background_tasks = [
+            task for task in self._background_tasks if not task.done()
+        ]
+        cleanup_task = asyncio.create_task(self._cache_cleanup_loop())
         self._background_tasks.append(cleanup_task)
 
     async def _cache_cleanup_loop(self):
@@ -1030,10 +1028,9 @@ class DorisQueryExecutor:
         # Cancel background tasks
         for task in self._background_tasks:
             task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+        if self._background_tasks:
+            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+        self._background_tasks.clear()
 
         # Clear cache
         await self.query_cache.clear_all()
@@ -1054,7 +1051,7 @@ class QueryPerformanceMonitor:
     ):
         """Record query performance"""
         record = {
-            "timestamp": datetime.utcnow(),
+            "timestamp": utc_now(),
             "sql": query_request.sql,
             "user_id": query_request.user_id,
             "session_id": query_request.session_id,
@@ -1073,7 +1070,7 @@ class QueryPerformanceMonitor:
         self, time_range_minutes: int = 60
     ) -> dict[str, Any]:
         """Get performance report"""
-        cutoff_time = datetime.utcnow() - timedelta(minutes=time_range_minutes)
+        cutoff_time = utc_now() - timedelta(minutes=time_range_minutes)
 
         recent_records = [
             record

--- a/doris_mcp_server/utils/security.py
+++ b/doris_mcp_server/utils/security.py
@@ -39,6 +39,7 @@ from .config import (
     get_effective_auth_config,
 )
 from .logger import get_logger
+from .datetime_utils import utc_now
 
 # Global ContextVar for auth_context - must be a single instance shared across all modules
 # This allows token-bound database configuration to work correctly in concurrent requests
@@ -67,7 +68,7 @@ class AuthContext:
     security_level: 'SecurityLevel' = field(default_factory=lambda: SecurityLevel.INTERNAL)  # Security level
     client_ip: str = "unknown"  # Client IP address
     session_id: str = ""  # Session identifier
-    login_time: datetime = field(default_factory=datetime.utcnow)
+    login_time: datetime = field(default_factory=utc_now)
     last_activity: datetime | None = None
     token: str = ""  # Raw token for token-bound database configuration
     auth_method: str = ""  # anonymous, token, jwt, external_oauth, doris_oauth
@@ -784,7 +785,7 @@ class AuthenticationProvider:
                 security_level=SecurityLevel.INTERNAL,
                 client_ip=credentials.client_ip,
                 session_id=credentials.session_id or f"session_{token_info.token_id}",
-                login_time=datetime.utcnow(),
+                login_time=utc_now(),
                 last_activity=token_info.last_used,
                 token=token,  # Store raw token for token-bound database configuration
                 auth_method="token",

--- a/test/auth/test_key_manager.py
+++ b/test/auth/test_key_manager.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import UTC
+from types import SimpleNamespace
+
+import pytest
+
+from doris_mcp_server.auth.key_manager import KeyManager
+
+
+@pytest.mark.asyncio
+async def test_existing_key_files_load_with_timezone_aware_generation_time(
+    tmp_path,
+):
+    security = SimpleNamespace(
+        jwt_algorithm="RS256",
+        key_rotation_interval=3600,
+        jwt_private_key_path=str(tmp_path / "private.pem"),
+        jwt_public_key_path=str(tmp_path / "public.pem"),
+        jwt_secret_key=None,
+    )
+    config = SimpleNamespace(security=security)
+
+    generated = KeyManager(config)
+    await generated.generate_key_pair()
+
+    loaded = KeyManager(config)
+    assert await loaded.initialize() is True
+    assert loaded._key_generated_at.tzinfo is UTC
+    assert await loaded.is_key_expired() is False

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,7 +19,6 @@
 Pytest configuration and fixtures for Doris MCP Server tests
 """
 
-import asyncio
 import logging
 import sys
 from pathlib import Path
@@ -35,14 +34,6 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
-
-
-@pytest.fixture(scope="session")
-def event_loop():
-    """Create an instance of the default event loop for the test session."""
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
 
 
 @pytest.fixture

--- a/test/integration/test_end_to_end.py
+++ b/test/integration/test_end_to_end.py
@@ -272,7 +272,8 @@ class TestEndToEndIntegration:
             # Accept either success result or error (due to mock environment)
             assert "result" in result_data or "error" in result_data
 
-    def test_server_initialization(self, doris_server):
+    @pytest.mark.asyncio
+    async def test_server_initialization(self, doris_server):
         """Test server initialization"""
         # Verify all components are initialized
         assert doris_server.config is not None
@@ -280,6 +281,5 @@ class TestEndToEndIntegration:
         assert doris_server.security_manager is not None
         
         # Verify tools are available - use list_tools instead
-        import asyncio
-        tools = asyncio.run(doris_server.tools_manager.list_tools())
+        tools = await doris_server.tools_manager.list_tools()
         assert len(tools) > 0 

--- a/test/protocol/stdio_capability_server.py
+++ b/test/protocol/stdio_capability_server.py
@@ -75,10 +75,9 @@ class ProfileConnection:
 
 
 class ProfileConnectionManager:
-    def __init__(self) -> None:
-        self._temp_dir = tempfile.TemporaryDirectory(prefix="doris-mcp-profile-")
+    def __init__(self, temp_files_dir: str) -> None:
         self.config = SimpleNamespace(
-            temp_files_dir=self._temp_dir.name,
+            temp_files_dir=temp_files_dir,
             performance=SimpleNamespace(max_response_content_size=20_000),
         )
         self.connection = ProfileConnection()
@@ -210,8 +209,8 @@ class RoleSecurityAnalyticsTools(SecurityAnalyticsTools):
 
 
 class OneToolManager:
-    def __init__(self) -> None:
-        connection_manager = ProfileConnectionManager()
+    def __init__(self, temp_files_dir: str) -> None:
+        connection_manager = ProfileConnectionManager(temp_files_dir)
         self.profile_analyzer = ProfileAnalyzer(connection_manager)
         self.freshness_router = object.__new__(DorisToolsManager)
         self.freshness_router.data_governance_tools = FreshnessGovernanceTools(
@@ -394,26 +393,27 @@ class EmptyPromptsManager:
 
 
 async def main() -> None:
-    server = create_doris_mcp_server(
-        resources_manager=EmptyResourcesManager(),
-        tools_manager=OneToolManager(),
-        prompts_manager=EmptyPromptsManager(),
-        name="doris-mcp-stdio-capability-test",
-        version=__version__,
-        logger=logging.getLogger(__name__),
-        required_client_capabilities={
-            "tools/list": ClientCapabilities(
-                extensions={REQUIRED_EXTENSION: {}},
-            )
-        },
-    )
-
-    async with stdio_server() as (read_stream, write_stream):
-        await server.run(
-            read_stream,
-            write_stream,
-            server.create_initialization_options(),
+    with tempfile.TemporaryDirectory(prefix="doris-mcp-profile-") as temp_files_dir:
+        server = create_doris_mcp_server(
+            resources_manager=EmptyResourcesManager(),
+            tools_manager=OneToolManager(temp_files_dir),
+            prompts_manager=EmptyPromptsManager(),
+            name="doris-mcp-stdio-capability-test",
+            version=__version__,
+            logger=logging.getLogger(__name__),
+            required_client_capabilities={
+                "tools/list": ClientCapabilities(
+                    extensions={REQUIRED_EXTENSION: {}},
+                )
+            },
         )
+
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+            )
 
 
 if __name__ == "__main__":

--- a/test/protocol/test_health_endpoints.py
+++ b/test/protocol/test_health_endpoints.py
@@ -47,26 +47,26 @@ def _free_tcp_port() -> int:
         return int(sock.getsockname()[1])
 
 
-async def _stop_process(process: asyncio.subprocess.Process) -> None:
-    if process.returncode is not None:
+async def _stop_process(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is not None:
         return
     process.terminate()
     try:
-        await asyncio.wait_for(process.wait(), timeout=10)
-    except TimeoutError:
+        await asyncio.to_thread(process.wait, 10)
+    except subprocess.TimeoutExpired:
         process.kill()
-        await process.wait()
+        await asyncio.to_thread(process.wait)
 
 
 async def _wait_for_live(
-    process: asyncio.subprocess.Process,
+    process: subprocess.Popen[bytes],
     port: int,
     log_file,
 ) -> None:
     deadline = time.monotonic() + 15
     async with httpx.AsyncClient(timeout=0.5) as client:
         while time.monotonic() < deadline:
-            if process.returncode is not None:
+            if process.poll() is not None:
                 log_file.seek(0)
                 pytest.fail(
                     "HTTP process exited before liveness became available:\n"
@@ -204,18 +204,20 @@ async def test_http_process_stays_live_when_doris_is_unavailable(
     )
 
     with tempfile.TemporaryFile() as log_file:
-        process = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-m",
-            "doris_mcp_server",
-            "--transport",
-            "http",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(server_port),
-            "--workers",
-            str(workers),
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "doris_mcp_server",
+                "--transport",
+                "http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(server_port),
+                "--workers",
+                str(workers),
+            ],
             cwd=PROJECT_ROOT,
             env=environment,
             stdout=log_file,
@@ -245,6 +247,6 @@ async def test_http_process_stays_live_when_doris_is_unavailable(
                 tools = await client.list_tools(cache_mode="bypass")
                 assert tools.tools
 
-            assert process.returncode is None
+            assert process.poll() is None
         finally:
             await _stop_process(process)

--- a/test/protocol/test_mcp_v2_protocol.py
+++ b/test/protocol/test_mcp_v2_protocol.py
@@ -744,9 +744,11 @@ async def test_http_prompt_errors_are_typed_and_server_recovers():
 
 
 @pytest.mark.asyncio
-async def test_http_sql_profile_without_catalog_uses_production_analyzer_path():
+async def test_http_sql_profile_without_catalog_uses_production_analyzer_path(
+    tmp_path,
+):
     app = create_test_server(
-        tools_manager=ProfileToolManager(),
+        tools_manager=ProfileToolManager(str(tmp_path)),
     ).streamable_http_app(
         json_response=True,
         stateless_http=True,
@@ -786,9 +788,9 @@ async def test_http_sql_profile_without_catalog_uses_production_analyzer_path():
 
 
 @pytest.mark.asyncio
-async def test_http_unknown_freshness_uses_default_threshold():
+async def test_http_unknown_freshness_uses_default_threshold(tmp_path):
     app = create_test_server(
-        tools_manager=ProfileToolManager(),
+        tools_manager=ProfileToolManager(str(tmp_path)),
     ).streamable_http_app(
         json_response=True,
         stateless_http=True,
@@ -823,9 +825,9 @@ async def test_http_unknown_freshness_uses_default_threshold():
 
 
 @pytest.mark.asyncio
-async def test_http_doris4_role_metadata_uses_public_grants_command():
+async def test_http_doris4_role_metadata_uses_public_grants_command(tmp_path):
     app = create_test_server(
-        tools_manager=ProfileToolManager(),
+        tools_manager=ProfileToolManager(str(tmp_path)),
     ).streamable_http_app(
         json_response=True,
         stateless_http=True,
@@ -855,9 +857,9 @@ async def test_http_doris4_role_metadata_uses_public_grants_command():
 
 
 @pytest.mark.asyncio
-async def test_http_rejects_injected_sql_identifier_and_recovers():
+async def test_http_rejects_injected_sql_identifier_and_recovers(tmp_path):
     app = create_test_server(
-        tools_manager=ProfileToolManager(),
+        tools_manager=ProfileToolManager(str(tmp_path)),
     ).streamable_http_app(
         json_response=True,
         stateless_http=True,
@@ -902,9 +904,9 @@ async def test_http_rejects_injected_sql_identifier_and_recovers():
 
 
 @pytest.mark.asyncio
-async def test_http_monitoring_rejects_metadata_endpoint_and_recovers():
+async def test_http_monitoring_rejects_metadata_endpoint_and_recovers(tmp_path):
     app = create_test_server(
-        tools_manager=ProfileToolManager(),
+        tools_manager=ProfileToolManager(str(tmp_path)),
     ).streamable_http_app(
         json_response=True,
         stateless_http=True,

--- a/test/security/test_auth_context.py
+++ b/test/security/test_auth_context.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 
@@ -40,7 +40,7 @@ async def test_jwt_auth_context_does_not_store_raw_token():
                     "roles": ["reader"],
                     "permissions": ["read_data"],
                     "security_level": "internal",
-                    "iat": int(datetime.utcnow().timestamp()),
+                    "iat": int(datetime.now(UTC).timestamp()),
                 }
             }
 

--- a/test/security/test_bearer_credentials.py
+++ b/test/security/test_bearer_credentials.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
@@ -174,7 +174,7 @@ async def test_security_manager_preserves_external_oauth_challenge_error():
 async def test_static_token_provider_uses_canonical_credentials():
     token_info = SimpleNamespace(
         token_id="static-id",
-        last_used=datetime.utcnow(),
+        last_used=datetime.now(UTC),
     )
 
     class TokenManager:

--- a/test/security/test_sql_injection_api.py
+++ b/test/security/test_sql_injection_api.py
@@ -34,7 +34,6 @@ Usage:
     pytest test/security/test_sql_injection_api.py -v --no-cov
 """
 
-import asyncio
 import json
 import os
 
@@ -811,15 +810,6 @@ class TestPerformanceToolsInjectionAPI:
             return True
         result_str = json.dumps(result).lower()
         return any(kw in result_str for kw in ["error", "blocked", "invalid", "security", "injection"])
-
-
-# Pytest configuration for async tests
-@pytest.fixture(scope="session")
-def event_loop():
-    """Create event loop for async tests"""
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
 
 
 if __name__ == "__main__":

--- a/test/security/test_token_digest_storage.py
+++ b/test/security/test_token_digest_storage.py
@@ -18,7 +18,7 @@
 import json
 import os
 import stat
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -145,8 +145,8 @@ async def test_legacy_plaintext_file_is_atomically_migrated_without_expiry_exten
     try:
         result = await reloaded.validate_token(STATIC_TOKEN)
         assert result.is_valid is True
-        assert result.token_info.created_at == datetime(2026, 7, 1)
-        assert result.token_info.expires_at == datetime(2026, 7, 31)
+        assert result.token_info.created_at == datetime(2026, 7, 1, tzinfo=UTC)
+        assert result.token_info.expires_at == datetime(2026, 7, 31, tzinfo=UTC)
     finally:
         reloaded.stop_hot_reload()
 

--- a/test/tools/test_tools_operation_guard.py
+++ b/test/tools/test_tools_operation_guard.py
@@ -15,7 +15,6 @@ from doris_mcp_server.tools.tools_manager import DorisToolsManager
 from doris_mcp_server.utils.analysis_tools import SQLAnalyzer
 from doris_mcp_server.utils.data_governance_tools import DataGovernanceTools
 from doris_mcp_server.utils.db import QueryResult
-from doris_mcp_server.utils.query_executor import DorisQueryExecutor
 from doris_mcp_server.utils.schema_extractor import MetadataExtractor
 from doris_mcp_server.utils.security import (
     AuthContext,
@@ -318,8 +317,7 @@ async def test_doris_oauth_exec_query_dispatches_when_query_gate_enabled():
 
 
 @pytest.mark.asyncio
-async def test_doris_oauth_exec_query_real_tool_path_uses_doris_user_route(tmp_path, monkeypatch):
-    monkeypatch.setattr(DorisQueryExecutor, "_start_background_tasks", lambda self: None)
+async def test_doris_oauth_exec_query_real_tool_path_uses_doris_user_route(tmp_path):
     manager, connection_manager = _real_tool_manager_for_routing(tmp_path)
     token = set_current_auth_context(
         doris_context(
@@ -345,8 +343,9 @@ async def test_doris_oauth_exec_query_real_tool_path_uses_doris_user_route(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_doris_oauth_exec_query_with_db_catalog_uses_one_routed_connection(tmp_path, monkeypatch):
-    monkeypatch.setattr(DorisQueryExecutor, "_start_background_tasks", lambda self: None)
+async def test_doris_oauth_exec_query_with_db_catalog_uses_one_routed_connection(
+    tmp_path,
+):
     manager, connection_manager = _real_tool_manager_for_routing(tmp_path)
     token = set_current_auth_context(
         doris_context(

--- a/test/utils/test_datetime_utils.py
+++ b/test/utils/test_datetime_utils.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from doris_mcp_server.utils.datetime_utils import (
+    as_utc,
+    format_rfc3339,
+    utc_now,
+)
+
+
+def test_utc_now_is_timezone_aware_utc():
+    current = utc_now()
+
+    assert current.tzinfo is UTC
+    assert current.utcoffset() == timedelta(0)
+
+
+def test_as_utc_accepts_legacy_naive_and_non_utc_values():
+    assert as_utc(datetime(2026, 7, 30, 1, 2, 3)) == datetime(
+        2026,
+        7,
+        30,
+        1,
+        2,
+        3,
+        tzinfo=UTC,
+    )
+    assert as_utc(
+        datetime(2026, 7, 30, 9, 2, 3, tzinfo=timezone(timedelta(hours=8)))
+    ) == datetime(2026, 7, 30, 1, 2, 3, tzinfo=UTC)
+
+
+def test_format_rfc3339_emits_one_utc_designator():
+    assert format_rfc3339(datetime(2026, 7, 30, 1, 2, 3, tzinfo=UTC)) == (
+        "2026-07-30T01:02:03Z"
+    )

--- a/test/utils/test_query_executor.py
+++ b/test/utils/test_query_executor.py
@@ -20,7 +20,7 @@ Query executor tests
 """
 
 import pytest
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import Mock, AsyncMock, patch
 
 from doris_mcp_server.utils.query_executor import CachedQuery, DorisQueryExecutor, QueryRequest
@@ -66,6 +66,22 @@ class TestDorisQueryExecutor:
         # Create a mock connection manager
         mock_connection_manager = Mock()
         return DorisQueryExecutor(mock_connection_manager, mock_config)
+
+    @pytest.mark.asyncio
+    async def test_background_cleanup_has_explicit_lifecycle(self, query_executor):
+        assert query_executor._background_tasks == []
+
+        await query_executor.start()
+        cleanup_task = query_executor._background_tasks[0]
+        await query_executor.start()
+
+        assert query_executor._background_tasks == [cleanup_task]
+        assert cleanup_task.done() is False
+
+        await query_executor.close()
+
+        assert cleanup_task.done() is True
+        assert query_executor._background_tasks == []
 
     @pytest.mark.asyncio
     async def test_execute_query_success(self, query_executor):
@@ -324,7 +340,7 @@ class TestDorisQueryExecutor:
         query_executor.query_cache.get = AsyncMock(
             return_value=CachedQuery(
                 result=cached_result,
-                created_at=datetime.utcnow(),
+                created_at=datetime.now(UTC),
                 ttl=300,
             )
         )


### PR DESCRIPTION
## Summary

- use timezone-aware UTC values and canonical RFC 3339 serialization across authentication, connection, and query runtime state
- give the query executor an explicit start/close lifecycle in Stdio, HTTP, and multi-worker modes
- close temporary directories, child processes, and test event loops cleanly so the suite runs without resource warnings

## Validation

- `uv run pytest -q -W error` — 627 passed, 64 skipped, zero warnings
- real Doris transport suite — 7 passed across Streamable HTTP and true subprocess Stdio
- `uv run ruff check --select F821 doris_mcp_server test`
- `uv run python -m compileall doris_mcp_server test`
- `uv build` plus clean-wheel CLI/import smoke test
