### PR TITLE
ci: enforce release quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,180 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          version: "0.9.0"
+          enable-cache: true
+      - name: Verify lock file
+        run: uv lock --check
+      - name: Sync development environment
+        run: uv sync --frozen --group dev
+      - name: Ruff
+        run: uv run ruff check .
+      - name: Mypy
+        run: uv run mypy doris_mcp_server
+      - name: Bandit
+        run: >-
+          uv run bandit -q -c pyproject.toml -r
+          doris_mcp_server doris_mcp_client generate_requirements.py
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          version: "0.9.0"
+          enable-cache: true
+      - name: Sync development environment
+        run: uv sync --frozen --group dev
+      - name: Run full test suite
+        run: uv run pytest -q -W error
+
+  package:
+    name: Build and wheel smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          version: "0.9.0"
+          enable-cache: true
+      - name: Sync development environment
+        run: uv sync --frozen --group dev
+      - name: Build distributions
+        run: uv build
+      - name: Install and smoke-test clean wheel
+        run: |
+          set -euo pipefail
+          wheel_count="$(find dist -maxdepth 1 -type f -name '*.whl' | wc -l | tr -d ' ')"
+          test "$wheel_count" = "1"
+          wheel_path="$(find dist -maxdepth 1 -type f -name '*.whl' -print -quit)"
+          smoke_root="$RUNNER_TEMP/doris-mcp-wheel-smoke"
+          python -m venv "$smoke_root/venv"
+          "$smoke_root/venv/bin/python" -m pip install "$GITHUB_WORKSPACE/$wheel_path"
+          cd "$smoke_root"
+          "$smoke_root/venv/bin/doris-mcp-server" --version
+          "$smoke_root/venv/bin/doris-mcp-client" --help
+          "$smoke_root/venv/bin/python" -c \
+            "import doris_mcp_client, doris_mcp_server"
+
+  conformance:
+    name: MCP 2026-07-28 conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+      - name: Check out official MCP Conformance
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          repository: modelcontextprotocol/conformance
+          ref: 49103de6ed70804e940637bf3e9e29e4a3f54e64
+          path: .conformance
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: "3.12"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        with:
+          version: "0.9.0"
+          enable-cache: true
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: .conformance/package-lock.json
+      - name: Sync development environment
+        run: uv sync --frozen --group dev
+      - name: Install and build official Conformance
+        working-directory: .conformance
+        run: |
+          npm ci
+          npm run build
+      - name: Run official server-stateless scenario
+        run: |
+          set -euo pipefail
+          server_log="$RUNNER_TEMP/doris-mcp-conformance-server.log"
+          uv run python test/protocol/conformance_server.py \
+            --transport http \
+            --host 127.0.0.1 \
+            --port 39124 \
+            >"$server_log" 2>&1 &
+          server_pid="$!"
+          cleanup() {
+            kill "$server_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          ready=false
+          for _ in $(seq 1 30); do
+            if python -c \
+              'import socket; s = socket.create_connection(("127.0.0.1", 39124), 1); s.close()'
+            then
+              ready=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" != "true" ]; then
+            cat "$server_log"
+            exit 1
+          fi
+
+          node .conformance/dist/index.js server \
+            --url http://127.0.0.1:39124/mcp \
+            --scenario server-stateless \
+            --verbose

--- a/test/deployment/test_github_actions_contract.py
+++ b/test/deployment/test_github_actions_contract.py
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml"
+FULL_COMMIT_ACTION = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+CONFORMANCE_COMMIT = "49103de6ed70804e940637bf3e9e29e4a3f54e64"
+
+
+def _workflow() -> dict:
+    return yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _commands(job: dict) -> str:
+    return "\n".join(step.get("run", "") for step in job["steps"])
+
+
+def test_ci_runs_on_pull_requests_and_master_pushes_with_read_only_permissions():
+    workflow = _workflow()
+
+    assert set(workflow["on"]) == {"pull_request", "push", "workflow_dispatch"}
+    assert workflow["on"]["push"]["branches"] == ["master"]
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"]["cancel-in-progress"] == "true"
+
+
+def test_ci_jobs_are_bounded_and_external_actions_are_commit_pinned():
+    jobs = _workflow()["jobs"]
+
+    assert set(jobs) == {"quality", "test", "package", "conformance"}
+    for job in jobs.values():
+        assert job["runs-on"] == "ubuntu-latest"
+        assert int(job["timeout-minutes"]) <= 30
+        assert "continue-on-error" not in job
+        for step in job["steps"]:
+            assert "continue-on-error" not in step
+            if action := step.get("uses"):
+                assert FULL_COMMIT_ACTION.fullmatch(action), action
+
+
+def test_quality_test_and_package_gates_cover_the_release_contract():
+    jobs = _workflow()["jobs"]
+    quality = _commands(jobs["quality"])
+    tests = _commands(jobs["test"])
+    package = _commands(jobs["package"])
+
+    assert "uv lock --check" in quality
+    assert "uv sync --frozen --group dev" in quality
+    assert "uv run ruff check ." in quality
+    assert "uv run mypy doris_mcp_server" in quality
+    assert (
+        "uv run bandit -q -c pyproject.toml -r "
+        "doris_mcp_server doris_mcp_client generate_requirements.py"
+    ) in " ".join(quality.split())
+
+    assert "uv sync --frozen --group dev" in tests
+    assert "uv run pytest -q -W error" in tests
+
+    assert "uv sync --frozen --group dev" in package
+    assert "uv build" in package
+    assert "test \"$wheel_count\" = \"1\"" in package
+    assert 'cd "$smoke_root"' in package
+    assert "doris-mcp-server\" --version" in package
+    assert "doris-mcp-client\" --help" in package
+    assert "import doris_mcp_client, doris_mcp_server" in package
+
+
+def test_conformance_gate_is_official_pinned_and_has_no_failure_baseline():
+    job = _workflow()["jobs"]["conformance"]
+    commands = _commands(job)
+    checkout = next(
+        step
+        for step in job["steps"]
+        if step.get("with", {}).get("repository")
+        == "modelcontextprotocol/conformance"
+    )
+
+    assert checkout["with"]["ref"] == CONFORMANCE_COMMIT
+    assert "uv sync --frozen --group dev" in commands
+    assert "npm ci" in commands
+    assert "npm run build" in commands
+    assert "test/protocol/conformance_server.py" in commands
+    assert "--transport http" in commands
+    assert "--scenario server-stateless" in commands
+    assert "--url http://127.0.0.1:39124/mcp" in commands
+    assert "expected-failures" not in commands


### PR DESCRIPTION
## Summary

- add read-only GitHub Actions gates for lock/sync, Ruff, Mypy, Bandit, the full test suite, package build, clean-wheel smoke, and MCP conformance
- pin every third-party Action and the official MCP Conformance checkout to immutable commits
- add repository contract tests that prevent required gates, timeouts, or pinning from being removed silently

## Why

The release checks were reproducible locally but were not enforced for pull requests. This makes the existing release contract visible and repeatable in GitHub Actions without exposing private Doris infrastructure or credentials.

## Validation

- uv 0.9.0 lock check and frozen development sync
- Ruff: passed
- Mypy: 58 source files, no issues
- Bandit: no findings
- pytest with warnings as errors: 633 passed, 64 skipped, 0 warnings
- source distribution and wheel build: passed
- clean wheel install: both CLI smokes and package imports passed
- official MCP Conformance 0.2.0-alpha.10 at 49103de: server-stateless [2026-07-28], 25/25 passed, 0 failed, 0 warnings
- real Doris integration: 7/7 passed across Streamable HTTP and true subprocess Stdio; temporary tables/users and tunnels were cleaned
