### PR TITLE
ci: comply with Apache action policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
-      - name: Set up uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
-        with:
-          version: "0.9.0"
-          enable-cache: true
+      - name: Install uv
+        run: >-
+          python -m pip install --disable-pip-version-check --no-deps
+          uv==0.9.0
       - name: Verify lock file
         run: uv lock --check
       - name: Sync development environment
@@ -52,18 +51,17 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
-      - name: Set up uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
-        with:
-          version: "0.9.0"
-          enable-cache: true
+      - name: Install uv
+        run: >-
+          python -m pip install --disable-pip-version-check --no-deps
+          uv==0.9.0
       - name: Sync development environment
         run: uv sync --frozen --group dev
       - name: Run full test suite
@@ -75,18 +73,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
-      - name: Set up uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
-        with:
-          version: "0.9.0"
-          enable-cache: true
+      - name: Install uv
+        run: >-
+          python -m pip install --disable-pip-version-check --no-deps
+          uv==0.9.0
       - name: Sync development environment
         run: uv sync --frozen --group dev
       - name: Build distributions
@@ -112,11 +109,11 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           persist-credentials: false
       - name: Check out official MCP Conformance
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           repository: modelcontextprotocol/conformance
           ref: 49103de6ed70804e940637bf3e9e29e4a3f54e64
@@ -126,11 +123,10 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.12"
-      - name: Set up uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
-        with:
-          version: "0.9.0"
-          enable-cache: true
+      - name: Install uv
+        run: >-
+          python -m pip install --disable-pip-version-check --no-deps
+          uv==0.9.0
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38
         with:

--- a/test/deployment/test_github_actions_contract.py
+++ b/test/deployment/test_github_actions_contract.py
@@ -23,6 +23,7 @@ import yaml
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "ci.yml"
 FULL_COMMIT_ACTION = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+CHECKOUT_ACTION = "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803"
 CONFORMANCE_COMMIT = "49103de6ed70804e940637bf3e9e29e4a3f54e64"
 
 
@@ -55,6 +56,13 @@ def test_ci_jobs_are_bounded_and_external_actions_are_commit_pinned():
             assert "continue-on-error" not in step
             if action := step.get("uses"):
                 assert FULL_COMMIT_ACTION.fullmatch(action), action
+                assert action.startswith("actions/"), action
+                if action.startswith("actions/checkout@"):
+                    assert action == CHECKOUT_ACTION
+        assert (
+            "python -m pip install --disable-pip-version-check --no-deps uv==0.9.0"
+            in " ".join(_commands(job).split())
+        )
 
 
 def test_quality_test_and_package_gates_cover_the_release_contract():


### PR DESCRIPTION
## Root cause

Apache's GitHub Actions policy rejected the third-party `astral-sh/setup-uv` Action before any job could start. The workflow syntax and project gates were valid, but the enterprise Action allowlist only permits GitHub-owned Actions or explicitly approved entries.

## Fix

- install the same pinned `uv==0.9.0` release through Python after the allowed GitHub-owned setup-python Action
- restrict every remaining `uses:` entry to a GitHub-owned Action pinned by full commit SHA
- extend the CI contract test so a disallowed third-party Action or an unpinned uv install cannot be reintroduced

## Validation

- actionlint: passed
- isolated Python 3.12 virtual environment installed and executed `uv 0.9.0`
- CI contract tests: 4 passed
- Ruff, Mypy (58 source files), and Bandit: passed
- pytest with warnings as errors: 633 passed, 64 skipped, 0 warnings
- build and clean-wheel CLI/import smoke: passed
- official MCP Conformance 0.2.0-alpha.10 at 49103de: server-stateless [2026-07-28], 25/25 passed, 0 failed, 0 warnings
- real Doris integration: 7/7 passed across Streamable HTTP and true subprocess Stdio; temporary tables/users and tunnels were cleaned
