### PR TITLE
feat: isolate legacy HTTP transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -453,6 +453,11 @@ SERVER_NAME=doris-mcp-server
 # Product version is defined by the installed package and is not configurable.
 SERVER_PORT=3000
 
+# Modern MCP is served only at POST /mcp. The isolated 2025-11-25 HTTP
+# migration adapter is disabled by default and, when enabled, uses
+# /mcp/legacy. Stdio compatibility is unaffected by this switch.
+ENABLE_LEGACY_HTTP_ADAPTER=false
+
 # Temporary files directory
 TEMP_FILES_DIR=tmp
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ under **Unreleased** until a new version is selected and published.
 
 - Consolidated tools, resources, and prompts on the Python SDK v2 protocol
   core.
+- Restricted the modern `/mcp` endpoint to 2026-07-28 POST requests and moved
+  legacy HTTP migration traffic to a default-off `/mcp/legacy` adapter.
 - Unified package metadata, CLI output, `server/discover`, legacy
   `serverInfo`, and health endpoints on one product version source.
 - Documented the modern request headers, migration steps, and deployment

--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ export DORIS_PORT="9030"
 export DORIS_USER="root"
 export DORIS_PASSWORD="your_password"
 
+# Keep the isolated legacy HTTP migration adapter disabled unless an
+# identified 2025-11-25 client still needs /mcp/legacy.
+export ENABLE_LEGACY_HTTP_ADAPTER=false
+
 # Token Management Interface (Security-Critical)
 export TOKEN_ADMIN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
 export TOKEN_MANAGEMENT_ADMIN_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
@@ -275,6 +279,10 @@ cp .env.example .env
     *   `DORIS_HTTP_MAX_RESPONSE_BYTES`: FE/BE HTTP response limit (default: 4 MiB; hard maximum: 16 MiB)
     *   `FE_ARROW_FLIGHT_SQL_PORT`: Frontend Arrow Flight SQL port for ADBC (New in v0.5.0)
     *   `BE_ARROW_FLIGHT_SQL_PORT`: Backend Arrow Flight SQL port for ADBC (New in v0.5.0)
+*   **MCP HTTP Configuration**:
+    *   `ENABLE_LEGACY_HTTP_ADAPTER`: Expose the isolated
+        `2025-11-25` migration adapter at `/mcp/legacy` (default: false);
+        modern traffic always uses `POST /mcp`
 *   **Authentication Configuration (Enhanced in v0.6.0)**:
     *   `ENABLE_TOKEN_AUTH`: Enable token-based authentication (default: false)
     *   `ENABLE_JWT_AUTH`: Enable JWT authentication (default: false)
@@ -464,12 +472,13 @@ and [Streamable HTTP transport specification](https://modelcontextprotocol.io/sp
 | Client protocol | Streamable HTTP | stdio | Connection behavior | Doris MCP Server status |
 |:----------------|:----------------|:------|:--------------------|:------------------------|
 | `2026-07-28` | Supported and preferred | Supported and preferred | Stateless, self-contained requests; no initialization handshake or protocol session | Covered by modern HTTP and real-process stdio tests |
-| `2025-11-25` | Supported for migration | Supported for migration | Legacy `initialize` is accepted, but the server remains stateless and does not issue `Mcp-Session-Id` | Covered by legacy HTTP and stdio tests |
+| `2025-11-25` | Opt-in at `/mcp/legacy` | Supported for migration | Legacy `initialize` is accepted, but the server remains stateless and does not issue `Mcp-Session-Id` | HTTP adapter is disabled by default; covered by legacy HTTP and stdio tests |
 | `2025-06-18` and older | Not guaranteed | Not guaranteed | Older negotiation and transport behavior is outside the supported compatibility contract | Upgrade the client before connecting |
 | HTTP+SSE (`2024-11-05`) | Not supported | Not applicable | The retired separate SSE endpoint is not exposed | Migrate to Streamable HTTP at `/mcp` |
 
-The compatibility path for `2025-11-25` exists to support migrations. New
-integrations should target `2026-07-28`.
+The HTTP compatibility path for `2025-11-25` is isolated from the modern
+endpoint and disabled by default. New integrations should target `2026-07-28`
+at `POST /mcp`.
 
 ### MCP 2026-07-28 Request Contract
 
@@ -551,8 +560,10 @@ stdio mode; stdout is reserved for MCP protocol messages.
    integration supports both transports.
 
 Clients that cannot migrate immediately may keep the `2025-11-25`
-`initialize` flow. Doris MCP Server accepts that flow on both supported
-transports, but does not create an HTTP protocol session.
+`initialize` flow over stdio. For Streamable HTTP, an operator must explicitly
+set `ENABLE_LEGACY_HTTP_ADAPTER=true` and point that client to
+`/mcp/legacy`; `/mcp` never falls back to the legacy transport. The adapter
+remains stateless and does not create an HTTP protocol session.
 
 ### Deployment Constraints
 
@@ -590,8 +601,9 @@ Interaction with the Doris MCP Server requires an **MCP Client**. The client con
     *   **Non-streaming**: The client receives a response containing `content` or `isError`.
     *   **Streaming**: The client receives a series of progress notifications, followed by a final response.
 
-Legacy `2025-11-25` clients initialize as before, subject to the stateless
-compatibility limits described above.
+Legacy `2025-11-25` stdio clients initialize as before. HTTP clients require
+the explicitly enabled `/mcp/legacy` adapter and remain subject to the
+stateless compatibility limits described above.
 
 ### Catalog Federation Support
 
@@ -1698,10 +1710,12 @@ workload before production use.
 
 ### Q: Which MCP protocol revisions are supported?
 
-**A:** New integrations should use MCP `2026-07-28`. Doris MCP Server also
-accepts the `2025-11-25` initialization flow as a migration bridge on both
-Streamable HTTP and stdio. Older revisions and the retired HTTP+SSE transport
-are not part of the supported compatibility contract.
+**A:** New integrations should use MCP `2026-07-28`. Doris MCP Server accepts
+the `2025-11-25` initialization flow over stdio and, when
+`ENABLE_LEGACY_HTTP_ADAPTER=true`, at the isolated `/mcp/legacy` HTTP
+endpoint. The modern `/mcp` endpoint is POST-only and never falls back to the
+legacy transport. Older revisions and the retired HTTP+SSE transport are not
+part of the supported compatibility contract.
 
 Do not infer wire-protocol support from the Doris MCP Server package version or
 the Python `mcp` dependency version. See

--- a/doris_mcp_server/auth/mcp_cors.py
+++ b/doris_mcp_server/auth/mcp_cors.py
@@ -36,7 +36,7 @@ def mcp_cors_header_pairs(scope: dict[str, Any]) -> list[tuple[bytes, bytes]]:
     cors_headers = [
         (b"access-control-allow-origin", origin),
         (b"access-control-allow-credentials", b"true"),
-        (b"access-control-expose-headers", b"mcp-session-id, www-authenticate"),
+        (b"access-control-expose-headers", b"www-authenticate"),
     ]
     if origin != b"*":
         cors_headers.append((b"vary", b"Origin"))
@@ -68,9 +68,13 @@ def mcp_cors_preflight_response(scope: dict[str, Any]) -> Response:
     response = Response("", status_code=204)
     response.headers["Access-Control-Allow-Origin"] = origin
     response.headers["Access-Control-Allow-Credentials"] = "true"
-    response.headers["Access-Control-Allow-Methods"] = "GET, POST, DELETE, OPTIONS"
+    response.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
     response.headers["Access-Control-Allow-Headers"] = (
-        request_headers or "authorization, content-type, mcp-session-id"
+        request_headers
+        or (
+            "authorization, content-type, mcp-protocol-version, "
+            "mcp-method, mcp-name"
+        )
     )
     response.headers["Access-Control-Max-Age"] = "86400"
     if origin != "*":

--- a/doris_mcp_server/http_transport.py
+++ b/doris_mcp_server/http_transport.py
@@ -1,0 +1,151 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Exact HTTP boundaries for the modern MCP core and legacy adapter."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, Final
+
+from mcp.server import Server
+
+# SDK 2.0 exposes only a dual-era public HTTP manager. Keep its modern-only
+# entry point isolated here so a future public API replacement is one edit.
+from mcp.server._streamable_http_modern import handle_modern_request
+from mcp.server.streamable_http_manager import (
+    DEFAULT_MAX_REQUEST_BODY_SIZE,
+    RequestBodyLimitMiddleware,
+    StreamableHTTPSessionManager,
+)
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.shared.inbound import MCP_PROTOCOL_VERSION_HEADER
+from mcp_types.version import HANDSHAKE_PROTOCOL_VERSIONS
+from starlette.datastructures import Headers
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+MODERN_MCP_PATH: Final = "/mcp"
+LEGACY_MCP_PATH: Final = "/mcp/legacy"
+
+
+class DorisMCPHTTPTransport:
+    """Expose a POST-only modern core and an opt-in legacy HTTP adapter.
+
+    The SDK's public session manager intentionally dispatches both protocol
+    eras. Doris MCP Server keeps that manager as the lifecycle owner and for
+    the optional legacy adapter, while routing the modern endpoint directly to
+    the SDK's 2026-07-28 handler. This prevents a missing or legacy protocol
+    header from silently selecting the old transport on ``/mcp``.
+    """
+
+    def __init__(
+        self,
+        *,
+        app: Server[Any],
+        security_settings: TransportSecuritySettings | None,
+        legacy_adapter_enabled: bool = False,
+        json_response: bool = True,
+        max_request_body_size: int = DEFAULT_MAX_REQUEST_BODY_SIZE,
+    ) -> None:
+        self._app = app
+        self._security_settings = security_settings
+        self._json_response = json_response
+        self._running = False
+        self.legacy_adapter_enabled = legacy_adapter_enabled
+        self._session_manager = StreamableHTTPSessionManager(
+            app=app,
+            json_response=json_response,
+            stateless=True,
+            security_settings=security_settings,
+            max_request_body_size=max_request_body_size,
+        )
+        self._modern_app: ASGIApp = RequestBodyLimitMiddleware(
+            self._handle_modern_request,
+            max_request_body_size,
+        )
+
+    @asynccontextmanager
+    async def run(self) -> AsyncIterator[None]:
+        """Own the shared SDK lifespan for both HTTP protocol eras."""
+        async with self._session_manager.run():
+            self._running = True
+            try:
+                yield
+            finally:
+                self._running = False
+
+    async def handle_request(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Route only exact MCP paths to their respective protocol boundary."""
+        path = scope.get("path", "")
+        if path == MODERN_MCP_PATH:
+            await self._modern_app(scope, receive, send)
+            return
+        if path == LEGACY_MCP_PATH and self.legacy_adapter_enabled:
+            await self._handle_legacy_request(scope, receive, send)
+            return
+        await Response("Not Found", status_code=404)(scope, receive, send)
+
+    async def _handle_modern_request(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Enter only the SDK's modern POST handler on the core endpoint."""
+        if not self._running:
+            raise RuntimeError(
+                "HTTP transport is not initialized. Make sure to use run()."
+            )
+        await handle_modern_request(
+            self._app,
+            self._security_settings,
+            self._json_response,
+            self._session_manager._lifespan_state,
+            scope,
+            receive,
+            send,
+        )
+
+    async def _handle_legacy_request(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        """Serve only handshake-era traffic on the explicit legacy endpoint."""
+        protocol_version = Headers(scope=scope).get(MCP_PROTOCOL_VERSION_HEADER)
+        if (
+            protocol_version is not None
+            and protocol_version not in HANDSHAKE_PROTOCOL_VERSIONS
+        ):
+            await JSONResponse(
+                {
+                    "error": "legacy_adapter_only",
+                    "message": (
+                        f"Use {MODERN_MCP_PATH} for modern MCP protocol requests"
+                    ),
+                },
+                status_code=400,
+            )(scope, receive, send)
+            return
+        await self._session_manager.handle_request(scope, receive, send)

--- a/doris_mcp_server/main.py
+++ b/doris_mcp_server/main.py
@@ -36,6 +36,11 @@ from starlette.types import Receive, Scope, Send
 
 from ._version import __version__
 from .health import liveness_payload, readiness_payload
+from .http_transport import (
+    LEGACY_MCP_PATH,
+    MODERN_MCP_PATH,
+    DorisMCPHTTPTransport,
+)
 from .protocol import create_doris_mcp_server, create_transport_security
 from .tools.prompts_manager import DorisPromptsManager
 from .tools.resources_manager import DorisResourcesManager
@@ -75,6 +80,9 @@ def _multiworker_environment(
         "SERVER_PORT": str(port),
         "MCP_ALLOWED_HOSTS": ",".join(config.mcp_allowed_hosts),
         "MCP_ALLOWED_ORIGINS": ",".join(config.mcp_allowed_origins),
+        "ENABLE_LEGACY_HTTP_ADAPTER": str(
+            config.enable_legacy_http_adapter
+        ).lower(),
         "SERVER_NAME": config.server_name,
         "TRANSPORT": "http",
         "WORKERS": str(workers),
@@ -239,25 +247,25 @@ class DorisServer:
             from collections.abc import AsyncIterator
 
             import uvicorn
-            from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
             from starlette.applications import Starlette
             from starlette.responses import JSONResponse
             from starlette.routing import Route
 
-            # Create session manager
-            session_manager = StreamableHTTPSessionManager(
+            # Create the exact modern/legacy HTTP boundary.
+            http_transport = DorisMCPHTTPTransport(
                 app=self.server,
-                json_response=True,
-                stateless=True,
                 security_settings=create_transport_security(
                     host,
                     allowed_hosts=self.config.mcp_allowed_hosts,
                     allowed_origins=self.config.mcp_allowed_origins,
                 ),
+                legacy_adapter_enabled=self.config.enable_legacy_http_adapter,
             )
 
             self.logger.info(
-                f"StreamableHTTP session manager created, will start at http://{host}:{port}"
+                "Streamable HTTP transport created at "
+                f"http://{host}:{port}{MODERN_MCP_PATH}; legacy adapter "
+                f"{'enabled' if self.config.enable_legacy_http_adapter else 'disabled'}"
             )
 
             # Health check endpoint
@@ -339,7 +347,7 @@ class DorisServer:
                     self.security_manager.auth_provider.doris_oauth_provider
                 )
 
-            # Lifecycle manager - simplified since we manage session_manager externally
+            # Lifecycle manager - the MCP transport lifespan is managed externally.
             @contextlib.asynccontextmanager
             async def lifespan(app: Starlette) -> AsyncIterator[None]:
                 """Context manager for managing application lifecycle"""
@@ -382,7 +390,7 @@ class DorisServer:
                 ]
             )
 
-            # Create ASGI application - use direct session manager as ASGI app
+            # Create the auxiliary ASGI application; MCP routing stays separate.
             starlette_app = Starlette(
                 debug=False,
                 routes=routes,
@@ -397,7 +405,7 @@ class DorisServer:
                 send: Send,
             ) -> None:
                 """Handle authenticated MCP request after auth context is set."""
-                await session_manager.handle_request(scope, receive, send)
+                await http_transport.handle_request(scope, receive, send)
 
             mcp_auth_middleware = MCPAuthASGIMiddleware(
                 self.security_manager,
@@ -445,7 +453,10 @@ class DorisServer:
                             await starlette_app(scope, receive, send)
                             return
 
-                        if path == "/mcp":
+                        if path == MODERN_MCP_PATH or (
+                            path == LEGACY_MCP_PATH
+                            and self.config.enable_legacy_http_adapter
+                        ):
                             self.logger.info(f"Handling MCP request for path: {path}")
                             await mcp_auth_middleware(scope, receive, send)
                             return
@@ -496,16 +507,16 @@ class DorisServer:
 
             else:
                 self.logger.info("Using single-process mode")
-                # Single worker mode, use original logic with session manager lifecycle
+                # Single worker mode, use the shared MCP transport lifecycle.
                 config = uvicorn.Config(
                     app=mcp_app, host=host, port=port, log_level="info"
                 )
                 server = uvicorn.Server(config)
 
-                # Run session manager and server together
-                async with session_manager.run():
+                # Run MCP transport and server together.
+                async with http_transport.run():
                     self.logger.info(
-                        "Session manager started, now starting HTTP server"
+                        "MCP HTTP transport started, now starting HTTP server"
                     )
                     await server.serve()
 

--- a/doris_mcp_server/multiworker_app.py
+++ b/doris_mcp_server/multiworker_app.py
@@ -19,7 +19,7 @@
 Multi-worker application module for doris-mcp-server
 
 This module provides full MCP functionality with multi-worker support.
-Each worker process creates its own MCP server and session manager using the same
+Each worker process creates its own MCP server and HTTP transport using the same
 robust architecture as the single-worker mode.
 """
 
@@ -31,7 +31,6 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import TYPE_CHECKING
 
 from mcp.server import Server
-from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
@@ -43,6 +42,11 @@ from .auth.doris_oauth_handlers import DorisOAuthHandlers
 from .auth.oauth_handlers import OAuthHandlers
 from .auth.token_handlers import TokenHandlers
 from .health import liveness_payload, readiness_payload
+from .http_transport import (
+    LEGACY_MCP_PATH,
+    MODERN_MCP_PATH,
+    DorisMCPHTTPTransport,
+)
 from .protocol import create_doris_mcp_server, create_transport_security
 from .tools.prompts_manager import DorisPromptsManager
 from .tools.resources_manager import DorisResourcesManager
@@ -63,11 +67,11 @@ if TYPE_CHECKING:
 
 # Global variables for worker-specific instances
 _worker_server: Server | None = None
-_worker_session_manager: StreamableHTTPSessionManager | None = None
+_worker_http_transport: DorisMCPHTTPTransport | None = None
 _worker_connection_manager: DorisConnectionManager | None = None
 _worker_security_manager: DorisSecurityManager | None = None
 _worker_tools_manager: DorisToolsManager | None = None
-_worker_session_manager_context: AbstractAsyncContextManager[None] | None = None
+_worker_http_transport_context: AbstractAsyncContextManager[None] | None = None
 _worker_initialized = False
 _worker_effective_auth: EffectiveAuthConfig | None = None
 _doris_oauth_handlers: DorisOAuthHandlers | None = None
@@ -79,11 +83,11 @@ async def initialize_worker() -> None:
     """Initialize MCP server and managers for this worker process"""
     global \
         _worker_server, \
-        _worker_session_manager, \
+        _worker_http_transport, \
         _worker_connection_manager, \
         _worker_security_manager, \
         _worker_tools_manager, \
-        _worker_session_manager_context, \
+        _worker_http_transport_context, \
         _worker_initialized, \
         _oauth_handlers, \
         _token_handlers, \
@@ -161,21 +165,20 @@ async def initialize_worker() -> None:
             logger=logger,
         )
 
-        # Create session manager for this worker
-        _worker_session_manager = StreamableHTTPSessionManager(
+        # Create the exact modern/legacy HTTP boundary for this worker.
+        _worker_http_transport = DorisMCPHTTPTransport(
             app=_worker_server,
-            json_response=True,
-            stateless=True,
             security_settings=create_transport_security(
                 config.server_host,
                 allowed_hosts=config.mcp_allowed_hosts,
                 allowed_origins=config.mcp_allowed_origins,
             ),
+            legacy_adapter_enabled=config.enable_legacy_http_adapter,
         )
 
-        # Start the session manager context
-        _worker_session_manager_context = _worker_session_manager.run()
-        await _worker_session_manager_context.__aenter__()
+        # Start the shared HTTP transport context.
+        _worker_http_transport_context = _worker_http_transport.run()
+        await _worker_http_transport_context.__aenter__()
 
         # Initialize OAuth and Token handlers
         _oauth_handlers = OAuthHandlers(_worker_security_manager)
@@ -420,7 +423,7 @@ async def root_info(request: Request) -> JSONResponse:
                 "health": "/health",
                 "live": "/live",
                 "ready": "/ready",
-                "mcp": "/mcp",
+                "mcp": MODERN_MCP_PATH,
             },
         }
     )
@@ -446,13 +449,13 @@ async def lifespan(app: Starlette) -> AsyncIterator[None]:
 
         logger = get_logger(__name__)
 
-        # Close session manager context
-        if _worker_session_manager_context:
+        # Close MCP HTTP transport context.
+        if _worker_http_transport_context:
             try:
-                await _worker_session_manager_context.__aexit__(None, None, None)
-                logger.info(f"Worker {os.getpid()} session manager context closed")
+                await _worker_http_transport_context.__aexit__(None, None, None)
+                logger.info(f"Worker {os.getpid()} MCP HTTP transport context closed")
             except Exception as e:
-                logger.error(f"Error closing worker session manager context: {e}")
+                logger.error(f"Error closing worker MCP HTTP transport context: {e}")
 
         if _worker_tools_manager:
             try:
@@ -537,8 +540,8 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
         authenticated_receive: Receive,
         authenticated_send: Send,
     ) -> None:
-        session_manager = _worker_session_manager
-        if session_manager is None:
+        http_transport = _worker_http_transport
+        if http_transport is None:
             await authenticated_send(
                 {
                     "type": "http.response.start",
@@ -549,11 +552,11 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
             await authenticated_send(
                 {
                     "type": "http.response.body",
-                    "body": b'{"error": "Worker session manager not initialized"}',
+                    "body": b'{"error": "Worker MCP HTTP transport not initialized"}',
                 }
             )
             return
-        await session_manager.handle_request(
+        await http_transport.handle_request(
             authenticated_scope, authenticated_receive, authenticated_send
         )
 
@@ -613,7 +616,13 @@ async def app(scope: Scope, receive: Receive, send: Send) -> None:
     """Main ASGI app that routes requests"""
     path = scope.get("path", "/")
 
-    if path == "/mcp":
+    legacy_adapter_enabled = bool(
+        _worker_http_transport
+        and _worker_http_transport.legacy_adapter_enabled
+    )
+    if path == MODERN_MCP_PATH or (
+        path == LEGACY_MCP_PATH and legacy_adapter_enabled
+    ):
         await mcp_asgi_app(scope, receive, send)
     elif (
         path.startswith("/auth/")

--- a/doris_mcp_server/utils/config.py
+++ b/doris_mcp_server/utils/config.py
@@ -602,6 +602,7 @@ class DorisConfig:
     server_port: int = 3000
     mcp_allowed_hosts: list[str] = field(default_factory=list)
     mcp_allowed_origins: list[str] = field(default_factory=list)
+    enable_legacy_http_adapter: bool = False
     transport: str = "stdio"
     workers: int = 1
 
@@ -1142,6 +1143,11 @@ class DorisConfig:
                 if value.strip()
             ]
             _mark_source(config, "mcp_allowed_origins", "env")
+        if "ENABLE_LEGACY_HTTP_ADAPTER" in os.environ:
+            config.enable_legacy_http_adapter = (
+                os.getenv("ENABLE_LEGACY_HTTP_ADAPTER", "false").lower() == "true"
+            )
+            _mark_source(config, "enable_legacy_http_adapter", "env")
         config.temp_files_dir = os.getenv("TEMP_FILES_DIR", config.temp_files_dir)
 
         return config
@@ -1158,6 +1164,7 @@ class DorisConfig:
             "server_port",
             "mcp_allowed_hosts",
             "mcp_allowed_origins",
+            "enable_legacy_http_adapter",
             "temp_files_dir",
             "transport",
             "workers",
@@ -1231,6 +1238,7 @@ class DorisConfig:
             "server_port": self.server_port,
             "mcp_allowed_hosts": self.mcp_allowed_hosts,
             "mcp_allowed_origins": self.mcp_allowed_origins,
+            "enable_legacy_http_adapter": self.enable_legacy_http_adapter,
             "temp_files_dir": self.temp_files_dir,
             "database": {
                 "host": self.database.host,

--- a/test/protocol/test_http_transport_boundaries.py
+++ b/test/protocol/test_http_transport_boundaries.py
@@ -1,0 +1,229 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Protocol boundary tests for modern and legacy Streamable HTTP."""
+
+import anyio
+import httpx2
+import pytest
+from mcp.server import Server
+
+from doris_mcp_server.http_transport import (
+    LEGACY_MCP_PATH,
+    MODERN_MCP_PATH,
+    DorisMCPHTTPTransport,
+)
+
+
+def _modern_request(request_id: int = 1) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "server/discover",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "http-boundary-test",
+                    "version": "1.0.0",
+                },
+            }
+        },
+    }
+
+
+def _modern_headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "Mcp-Protocol-Version": "2026-07-28",
+        "Mcp-Method": "server/discover",
+    }
+
+
+def _legacy_initialize() -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "legacy-http-boundary-test",
+                "version": "1.0.0",
+            },
+        },
+    }
+
+
+def _legacy_headers() -> dict[str, str]:
+    return {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+
+
+def _transport(*, legacy_adapter_enabled: bool = False) -> DorisMCPHTTPTransport:
+    return DorisMCPHTTPTransport(
+        app=Server("doris-mcp-server", version="test"),
+        security_settings=None,
+        legacy_adapter_enabled=legacy_adapter_enabled,
+    )
+
+
+@pytest.mark.asyncio
+async def test_modern_core_is_exact_post_only_and_never_falls_back_to_legacy():
+    app = _transport()
+
+    async with (
+        app.run(),
+        httpx2.ASGITransport(app.handle_request) as asgi_transport,
+        httpx2.AsyncClient(
+            transport=asgi_transport,
+            base_url="http://127.0.0.1:3000",
+        ) as client,
+    ):
+        modern = await client.post(
+            MODERN_MCP_PATH,
+            json=_modern_request(),
+            headers=_modern_headers(),
+        )
+        assert modern.status_code == 200
+        assert modern.json()["result"]["supportedVersions"] == ["2026-07-28"]
+        assert "mcp-session-id" not in modern.headers
+
+        get_response = await client.get(
+            MODERN_MCP_PATH,
+            headers=_modern_headers(),
+        )
+        assert get_response.status_code == 405
+        assert get_response.headers["allow"] == "POST"
+        assert get_response.headers.get("content-type") != "text/event-stream"
+
+        delete_response = await client.delete(
+            MODERN_MCP_PATH,
+            headers=_modern_headers(),
+        )
+        assert delete_response.status_code == 405
+        assert delete_response.headers["allow"] == "POST"
+
+        legacy_on_core = await client.post(
+            MODERN_MCP_PATH,
+            json=_legacy_initialize(),
+            headers=_legacy_headers(),
+        )
+        assert legacy_on_core.status_code == 400
+        assert legacy_on_core.json()["error"]["code"] == -32602
+
+        disabled_legacy = await client.post(
+            LEGACY_MCP_PATH,
+            json=_legacy_initialize(),
+            headers=_legacy_headers(),
+        )
+        assert disabled_legacy.status_code == 404
+
+        inexact_path = await client.post(
+            f"{MODERN_MCP_PATH}/",
+            json=_modern_request(2),
+            headers=_modern_headers(),
+        )
+        assert inexact_path.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_opt_in_legacy_adapter_accepts_only_handshake_era_traffic():
+    app = _transport(legacy_adapter_enabled=True)
+
+    async with (
+        app.run(),
+        httpx2.ASGITransport(app.handle_request) as asgi_transport,
+        httpx2.AsyncClient(
+            transport=asgi_transport,
+            base_url="http://127.0.0.1:3000",
+        ) as client,
+    ):
+        initialized = await client.post(
+            LEGACY_MCP_PATH,
+            json=_legacy_initialize(),
+            headers=_legacy_headers(),
+        )
+        assert initialized.status_code == 200
+        assert initialized.json()["result"]["protocolVersion"] == "2025-11-25"
+        assert "mcp-session-id" not in initialized.headers
+
+        modern_on_legacy = await client.post(
+            LEGACY_MCP_PATH,
+            json=_modern_request(),
+            headers=_modern_headers(),
+        )
+        assert modern_on_legacy.status_code == 400
+        assert modern_on_legacy.json() == {
+            "error": "legacy_adapter_only",
+            "message": f"Use {MODERN_MCP_PATH} for modern MCP protocol requests",
+        }
+
+        modern_on_core = await client.post(
+            MODERN_MCP_PATH,
+            json=_modern_request(2),
+            headers=_modern_headers(),
+        )
+        assert modern_on_core.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_legacy_get_sse_exists_only_inside_the_opt_in_adapter():
+    app = _transport(legacy_adapter_enabled=True)
+    response_started = anyio.Event()
+    messages: list[dict] = []
+
+    async def receive() -> dict:
+        await response_started.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict) -> None:
+        messages.append(message)
+        if message["type"] == "http.response.start":
+            response_started.set()
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": LEGACY_MCP_PATH,
+        "raw_path": LEGACY_MCP_PATH.encode(),
+        "query_string": b"",
+        "headers": [
+            (b"accept", b"text/event-stream"),
+            (b"host", b"127.0.0.1:3000"),
+        ],
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 3000),
+    }
+
+    async with app.run():
+        await app.handle_request(scope, receive, send)
+
+    response_start = next(
+        message for message in messages if message["type"] == "http.response.start"
+    )
+    assert response_start["status"] == 200
+    assert dict(response_start["headers"])[b"content-type"].startswith(
+        b"text/event-stream"
+    )

--- a/test/protocol/test_mcp_v2_protocol.py
+++ b/test/protocol/test_mcp_v2_protocol.py
@@ -37,6 +37,10 @@ from mcp.types import (
 )
 
 from doris_mcp_server import __version__
+from doris_mcp_server.http_transport import (
+    LEGACY_MCP_PATH,
+    DorisMCPHTTPTransport,
+)
 from doris_mcp_server.protocol import (
     create_doris_mcp_server,
     create_transport_security,
@@ -421,12 +425,11 @@ async def test_http_discover_is_stateless_and_unknown_method_does_not_kill_serve
 
 
 @pytest.mark.asyncio
-async def test_http_rejects_untrusted_origin_and_legacy_is_stateless():
-    app = create_test_server().streamable_http_app(
-        json_response=True,
-        stateless_http=True,
-        host="127.0.0.1",
-        transport_security=create_transport_security("127.0.0.1"),
+async def test_http_rejects_untrusted_origin_and_legacy_adapter_is_stateless():
+    app = DorisMCPHTTPTransport(
+        app=create_test_server(),
+        security_settings=create_transport_security("127.0.0.1"),
+        legacy_adapter_enabled=True,
     )
     legacy_initialize = {
         "jsonrpc": "2.0",
@@ -444,8 +447,8 @@ async def test_http_rejects_untrusted_origin_and_legacy_is_stateless():
     }
 
     async with (
-        app.router.lifespan_context(app),
-        httpx2.ASGITransport(app) as transport,
+        app.run(),
+        httpx2.ASGITransport(app.handle_request) as transport,
         httpx2.AsyncClient(
             transport=transport,
             base_url="http://127.0.0.1:3000",
@@ -472,7 +475,7 @@ async def test_http_rejects_untrusted_origin_and_legacy_is_stateless():
         assert rejected_host.status_code == 421
 
         initialized = await client.post(
-            "/mcp",
+            LEGACY_MCP_PATH,
             json=legacy_initialize,
             headers=legacy_headers,
         )

--- a/test/protocol/test_multiworker_config.py
+++ b/test/protocol/test_multiworker_config.py
@@ -2,7 +2,9 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
+from starlette.responses import Response
 
 from doris_mcp_server import __version__
 from doris_mcp_server.main import _multiworker_environment
@@ -15,6 +17,16 @@ from doris_mcp_server.multiworker_app import (
 from doris_mcp_server.utils.config import DorisConfig
 
 
+def test_legacy_http_adapter_is_default_off_and_requires_explicit_env(monkeypatch):
+    monkeypatch.delenv("ENABLE_LEGACY_HTTP_ADAPTER", raising=False)
+    assert DorisConfig.from_env().enable_legacy_http_adapter is False
+
+    monkeypatch.setenv("ENABLE_LEGACY_HTTP_ADAPTER", "true")
+    enabled = DorisConfig.from_env()
+    assert enabled.enable_legacy_http_adapter is True
+    assert enabled.to_dict()["enable_legacy_http_adapter"] is True
+
+
 def test_multiworker_environment_preserves_resolved_parent_config(monkeypatch):
     config = DorisConfig()
     config.database.host = "127.0.0.1"
@@ -25,6 +37,7 @@ def test_multiworker_environment_preserves_resolved_parent_config(monkeypatch):
     config.server_name = "doris-mcp-server"
     config.mcp_allowed_hosts = ["mcp.example.test", "mcp.example.test:*"]
     config.mcp_allowed_origins = ["https://client.example.test"]
+    config.enable_legacy_http_adapter = True
 
     worker_env = _multiworker_environment(
         config,
@@ -50,6 +63,7 @@ def test_multiworker_environment_preserves_resolved_parent_config(monkeypatch):
         "mcp.example.test:*",
     ]
     assert child_config.mcp_allowed_origins == ["https://client.example.test"]
+    assert child_config.enable_legacy_http_adapter is True
     assert child_config.server_name == "doris-mcp-server"
     assert child_config.server_version == __version__
     assert child_config.transport == "http"
@@ -100,3 +114,35 @@ async def test_multiworker_readiness_uses_worker_database_probe(monkeypatch):
     assert payload["status"] == "ready"
     assert payload["checks"]["doris"] == "ready"
     readiness_probe.assert_awaited_once_with(timeout_seconds=2.0)
+
+
+@pytest.mark.asyncio
+async def test_multiworker_routes_legacy_path_only_when_adapter_is_enabled(
+    monkeypatch,
+):
+    from doris_mcp_server import multiworker_app
+
+    async def fake_mcp_app(scope, receive, send):
+        await Response(status_code=204)(scope, receive, send)
+
+    monkeypatch.setattr(multiworker_app, "mcp_asgi_app", fake_mcp_app)
+    monkeypatch.setattr(
+        multiworker_app,
+        "_worker_http_transport",
+        SimpleNamespace(legacy_adapter_enabled=False),
+    )
+
+    transport = httpx.ASGITransport(app=multiworker_app.app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://127.0.0.1",
+    ) as client:
+        assert (await client.post("/mcp")).status_code == 204
+        assert (await client.post("/mcp/legacy")).status_code == 404
+
+        monkeypatch.setattr(
+            multiworker_app,
+            "_worker_http_transport",
+            SimpleNamespace(legacy_adapter_enabled=True),
+        )
+        assert (await client.post("/mcp/legacy")).status_code == 204

--- a/test/security/test_mcp_cors.py
+++ b/test/security/test_mcp_cors.py
@@ -41,7 +41,7 @@ async def test_send_with_mcp_cors_forwards_response_start_and_body():
     headers = dict(messages[0]["headers"])
     assert headers[b"access-control-allow-origin"] == b"https://client.example"
     assert headers[b"access-control-allow-credentials"] == b"true"
-    assert headers[b"access-control-expose-headers"] == b"mcp-session-id, www-authenticate"
+    assert headers[b"access-control-expose-headers"] == b"www-authenticate"
     assert messages[1]["body"] == b"ok"
 
 
@@ -72,7 +72,10 @@ def test_mcp_cors_preflight_response_uses_origin_and_requested_headers():
         _scope(
             [
                 (b"origin", b"https://client.example"),
-                (b"access-control-request-headers", b"authorization, mcp-session-id"),
+                (
+                    b"access-control-request-headers",
+                    b"authorization, mcp-protocol-version",
+                ),
             ]
         )
     )
@@ -80,6 +83,24 @@ def test_mcp_cors_preflight_response_uses_origin_and_requested_headers():
     assert response.status_code == 204
     assert response.headers["Access-Control-Allow-Origin"] == "https://client.example"
     assert response.headers["Access-Control-Allow-Credentials"] == "true"
-    assert response.headers["Access-Control-Allow-Methods"] == "GET, POST, DELETE, OPTIONS"
-    assert response.headers["Access-Control-Allow-Headers"] == "authorization, mcp-session-id"
+    assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
+    assert (
+        response.headers["Access-Control-Allow-Headers"]
+        == "authorization, mcp-protocol-version"
+    )
     assert response.headers["Vary"] == "Origin"
+
+
+def test_mcp_cors_preflight_defaults_advertise_only_modern_http_fields():
+    response = mcp_cors_preflight_response(_scope())
+
+    assert response.headers["Access-Control-Allow-Methods"] == "POST, OPTIONS"
+    allowed_headers = response.headers["Access-Control-Allow-Headers"].split(", ")
+    assert allowed_headers == [
+        "authorization",
+        "content-type",
+        "mcp-protocol-version",
+        "mcp-method",
+        "mcp-name",
+    ]
+    assert "mcp-session-id" not in response.headers["Access-Control-Allow-Headers"]


### PR DESCRIPTION
## Summary

- route the modern `/mcp` endpoint directly to the MCP 2026-07-28 POST-only handler, with no legacy header fallback
- isolate handshake-era HTTP/SSE compatibility behind a default-off `/mcp/legacy` adapter while preserving stdio migration support
- align single-worker and multi-worker routing, configuration, CORS, documentation, and protocol-boundary tests

## Validation

- `uv run pytest -q -W error`: 639 passed, 64 skipped
- focused protocol/config/CORS suite: 35 passed
- Ruff, Mypy, Bandit, and `uv lock --check`
- `uv build` plus clean Python 3.12 wheel smoke test
- official MCP Conformance: 25/25 passed
- real Doris dual-transport integration: 7 passed (Streamable HTTP and true subprocess stdio)
- cleanup audit: 0 temporary tables and 0 temporary users
