### PR TITLE
docs: declare MCP 2026-07-28 protocol GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ under **Unreleased** until a new version is selected and published.
 
 - Consolidated tools, resources, and prompts on the Python SDK v2 protocol
   core.
+- Declared MCP `2026-07-28` protocol compatibility generally available on
+  Streamable HTTP and stdio after the full release gate passed; the project
+  package classification and documented deployment constraints remain
+  unchanged.
 - Restricted the modern `/mcp` endpoint to 2026-07-28 POST requests and moved
   legacy HTTP migration traffic to a default-off `/mcp/legacy` adapter.
 - Unified package metadata, CLI output, `server/discover`, legacy

--- a/README.md
+++ b/README.md
@@ -28,8 +28,16 @@ branch also contains changes made after that tag; those changes are recorded
 under [Unreleased](CHANGELOG.md#unreleased) until the next version is selected
 and published.
 
-The project is currently classified as **Beta**. Review the
-[changelog](CHANGELOG.md), the
+MCP `2026-07-28` protocol compatibility on `master` is **Generally Available
+(GA)** for Streamable HTTP and stdio. The supported protocol contract has
+passed the full test suite with warnings treated as errors, the official
+stateless conformance suite, clean wheel installation, and real Apache Doris
+tests over both transports.
+
+This GA statement is scoped to protocol compatibility on the supported
+transports. The project package metadata remains **Beta**, and it does not
+expand the supported deployment shapes or remove the documented operational
+constraints. Review the [changelog](CHANGELOG.md), the
 [protocol support matrix](#protocol-and-transport-matrix), and the
 [deployment constraints](#deployment-constraints) before deploying it outside
 a controlled environment.

--- a/test/test_product_identity.py
+++ b/test/test_product_identity.py
@@ -57,6 +57,7 @@ def test_configuration_cannot_override_product_version(monkeypatch):
 
 def test_release_docs_and_commands_match_product_version():
     readme = (PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    normalized_readme = " ".join(readme.split())
     changelog = (PROJECT_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     makefile = (PROJECT_ROOT / "Makefile").read_text(encoding="utf-8")
     pyproject = tomllib.loads(
@@ -65,6 +66,15 @@ def test_release_docs_and_commands_match_product_version():
 
     assert f"pip install doris-mcp-server=={__version__}" in readme
     assert f"## [{__version__}]" in changelog
+    assert (
+        "MCP `2026-07-28` protocol compatibility on `master` is **Generally "
+        "Available (GA)**"
+    ) in normalized_readme
+    assert "This GA statement is scoped to protocol compatibility" in readme
+    assert (
+        "Development Status :: 4 - Beta"
+        in pyproject["project"]["classifiers"]
+    )
     assert "the two commands are not interchangeable" in readme
     assert pyproject["project"]["scripts"] == {
         "doris-mcp-server": "doris_mcp_server.main:main_sync",


### PR DESCRIPTION
## Summary

- declare MCP 2026-07-28 protocol compatibility generally available on Streamable HTTP and stdio
- scope the GA statement to the supported protocol contract while retaining the package Beta classification and documented deployment limits
- add a release-document contract test so the GA scope and package status cannot drift silently
- keep package version 0.6.1 under Unreleased; this PR does not publish a tag or package

## Validation

- product identity/release contract: 5 passed
- full pytest with warnings as errors: 999 passed, 66 skipped
- Ruff, Mypy (63 source files), Bandit: passed
- clean sdist/wheel build and fresh Python 3.12 install/CLI/import smoke: passed
- local-only ledger/audit documents in sdist: 0
- official MCP 2026-07-28 server-stateless conformance: 25/25 passed
- real Doris hhm_dt_sim: Streamable HTTP + true subprocess stdio, 9 passed
- real Doris cleanup audit: 0 temporary tables, 0 temporary users
