### PR TITLE
fix: return Doris column comments in table schema

### DIFF
--- a/doris_mcp_server/utils/schema_extractor.py
+++ b/doris_mcp_server/utils/schema_extractor.py
@@ -1667,9 +1667,12 @@ class MetadataExtractor:
 
             if effective_catalog and effective_catalog != "internal":
                 safe_catalog = quote_identifier(effective_catalog, "catalog name")
-                query = f"DESCRIBE {safe_catalog}.{safe_db}.{safe_table}"
+                query = (
+                    "SHOW FULL COLUMNS FROM "
+                    f"{safe_catalog}.{safe_db}.{safe_table}"
+                )
             else:
-                query = f"DESCRIBE {safe_db}.{safe_table}"
+                query = f"SHOW FULL COLUMNS FROM {safe_db}.{safe_table}"
 
             # Execute async query
             result = await self._execute_query_async(query, db_name)

--- a/test/integration/test_real_doris_transports.py
+++ b/test/integration/test_real_doris_transports.py
@@ -148,7 +148,7 @@ def doris_sandbox() -> DorisSandbox:
                 f"""
                 CREATE TABLE {qualified_table} (
                     id BIGINT,
-                    marker VARCHAR(64)
+                    marker VARCHAR(64) COMMENT 'Integration marker'
                 )
                 DUPLICATE KEY(id)
                 DISTRIBUTED BY HASH(id) BUCKETS 1
@@ -813,6 +813,20 @@ async def test_real_doris_tool_regression_paths(
         assert isinstance(basic_info_result.structured_content, dict)
         assert basic_info_result.structured_content["row_count"] == 1
         assert basic_info_result.structured_content["column_count"] == 2
+
+        schema_result = await client.call_tool(
+            "get_table_schema",
+            {
+                "table_name": doris_sandbox.table,
+                "db_name": doris_sandbox.settings.database,
+            },
+        )
+        assert schema_result.is_error is False
+        assert isinstance(schema_result.structured_content, dict)
+        schema_columns = schema_result.structured_content["result"]
+        assert next(
+            column for column in schema_columns if column["column_name"] == "marker"
+        )["comment"] == "Integration marker"
 
         column_analysis_result = await client.call_tool(
             "analyze_columns",

--- a/test/utils/test_schema_extractor_doris_oauth_metadata_errors.py
+++ b/test/utils/test_schema_extractor_doris_oauth_metadata_errors.py
@@ -79,6 +79,54 @@ async def _call_tool(method_name, args, connection_manager):
         reset_auth_context(token)
 
 
+@pytest.mark.parametrize(
+    ("catalog_name", "expected_query"),
+    [
+        (None, "SHOW FULL COLUMNS FROM `db1`.`tbl1`"),
+        ("internal", "SHOW FULL COLUMNS FROM `db1`.`tbl1`"),
+        ("hive", "SHOW FULL COLUMNS FROM `hive`.`db1`.`tbl1`"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_table_schema_uses_full_columns_and_preserves_comments(
+    catalog_name,
+    expected_query,
+):
+    connection_manager = FakeConnectionManager(
+        rows=[
+            {
+                "Field": "customer_id",
+                "Type": "bigint",
+                "Null": "NO",
+                "Key": "YES",
+                "Default": None,
+                "Extra": "",
+                "Comment": "Customer identifier",
+            }
+        ]
+    )
+    extractor = MetadataExtractor(db_name="db1", connection_manager=connection_manager)
+
+    schema = await extractor.get_table_schema_async(
+        "tbl1",
+        "db1",
+        catalog_name,
+    )
+
+    assert connection_manager.calls[0][1] == expected_query
+    assert schema == [
+        {
+            "column_name": "customer_id",
+            "data_type": "bigint",
+            "is_nullable": False,
+            "default_value": None,
+            "comment": "Customer identifier",
+            "key": "YES",
+            "extra": "",
+        }
+    ]
+
+
 @pytest.mark.parametrize(("tool_name", "method_name", "args"), METADATA_TOOL_CASES)
 @pytest.mark.parametrize(
     ("error", "error_code", "status_code"),


### PR DESCRIPTION
## Summary

- use `SHOW FULL COLUMNS` for the MCP table-schema path
- preserve existing safe two-part and catalog-qualified identifier handling
- map Doris column comments into the existing `comment` response field
- add unit coverage for internal and external catalogs
- add a real Doris regression through HTTP and subprocess stdio transports

## Root cause

The active `get_table_schema` MCP path queried Doris with `DESCRIBE` but then
attempted to read a `Comment` field. Doris `DESCRIBE` does not return that
field, so column comments were always empty even when they existed.

`SHOW FULL COLUMNS` returns the same schema fields used by the current response
mapping plus the actual `Comment` value.

## Validation

- `uv run pytest -q`: 1088 passed, 68 skipped; coverage 57.95%
- focused metadata tests: 41 passed
- real Doris HTTP and subprocess stdio suite: 9 passed, 2 optional monitoring tests skipped
- real Doris regression creates a commented column and verifies the MCP result
- `uv run ruff check .`
- `uv run mypy doris_mcp_server`
- CI-equivalent Bandit scan

Fixes #81
