### PR TITLE
test: lock token-bound database routing priority

### DIFF
--- a/test/utils/test_doris_user_pool_manager.py
+++ b/test/utils/test_doris_user_pool_manager.py
@@ -311,6 +311,45 @@ async def test_get_connection_context_uses_owner_based_release(manager, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_token_database_config_takes_priority_over_valid_global_config(
+    manager,
+    monkeypatch,
+):
+    token = "tenant-token"
+    token_db_config = SimpleNamespace(
+        host="tenant-fe",
+        port=19030,
+        user="tenant_reader",
+        password="tenant_pw",
+        database="tenant_db",
+        charset="utf8mb4",
+    )
+    manager.token_manager = SimpleNamespace(
+        get_database_config_by_token=lambda raw: (
+            token_db_config if raw == token else None
+        )
+    )
+    token_pool = FakePool("tenant")
+    create_pool = AsyncMock(return_value=token_pool)
+    monkeypatch.setattr(manager, "_create_pool_with_config", create_pool)
+
+    pool, selected_config = await manager.get_pool_for_token(token)
+
+    assert pool is token_pool
+    assert selected_config == {
+        "host": "tenant-fe",
+        "port": 19030,
+        "user": "tenant_reader",
+        "password": "tenant_pw",
+        "database": "tenant_db",
+        "charset": "utf8mb4",
+    }
+    create_pool.assert_awaited_once_with(selected_config)
+    assert manager.original_db_config["user"] == "root"
+    assert manager.active_db_config["user"] == "root"
+
+
+@pytest.mark.asyncio
 async def test_static_token_release_uses_captured_owner_pool(manager, monkeypatch):
     token = "static-token"
     old_pool = FakePool("token-v1")


### PR DESCRIPTION
Fixes #64

## Root cause

Token-bound database routing is already implemented in the current server, but there was no regression test covering the important case where a valid global Doris account is configured at the same time. That left room for a future regression to silently route an authenticated token through the global high-privilege account.

## Change

- Add a regression test with both a valid global account and a token-bound account.
- Assert the dedicated pool is created from the token database configuration.
- Assert the original and active global configurations remain unchanged.

## Verification

- `uv run pytest --no-cov -q test/utils/test_doris_user_pool_manager.py` — 15 passed
- `uv run ruff check test/utils/test_doris_user_pool_manager.py` — passed
- Full repository tests and coverage run in CI.