### PR TITLE
feat: add route-aware capability snapshots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,13 @@ DORIS_MAX_CONNECTION_AGE=3600
 MCP_TOOL_PROVIDERS=
 MCP_TOOL_EXPOSURE_MODE=hierarchical
 
+# Route-private capability snapshots drive each child availability decision.
+# A failed refresh may reuse the previous snapshot only during the bounded
+# stale grace window; unavailable or unknown capabilities remain fail-closed.
+CAPABILITY_SNAPSHOT_TTL_SECONDS=300
+CAPABILITY_PROBE_TIMEOUT_SECONDS=5
+CAPABILITY_STALE_GRACE_SECONDS=900
+
 # ===================================================================
 # Security Configuration
 # ===================================================================
@@ -311,21 +318,15 @@ DORIS_OAUTH_BASE_URL=http://localhost:3000
 # TRANSPORT=http
 # WORKERS=1
 
-# Doris OAuth operation gates. When enabled, these scopes are included in the
-# default OAuth grant; normal MCP clients do not need to pass long --scopes
-# lists. MySQL-channel operations run through the logged-in Doris user pool,
-# so Doris RBAC is the final data authorization backend.
-DORIS_OAUTH_DB_TOOLS_ENABLED=false
-DORIS_OAUTH_DB_TOOL_ALLOWLIST=get_db_list,get_db_table_list,get_table_schema,get_table_comment,get_table_column_comments,get_table_indexes,get_catalog_list
+# Doris OAuth child gate. The allowlist uses exact formal domain.child feature
+# IDs. Issued scopes use child:call:<domain>:<child> and
+# child:discover:<domain>:<child>; legacy tool:call scopes are not accepted.
+# Doris RBAC remains the final data authorization backend.
+DORIS_OAUTH_CHILD_TOOLS_ENABLED=false
+DORIS_OAUTH_CHILD_TOOL_ALLOWLIST=doris_catalog.list_databases,doris_query.execute_query,doris_query.explain_query
 
-# Query/explain are configurable Doris-user MySQL channels. If you want SQL,
-# DDL, or DML to be decided only by Doris RBAC, also set
-# ENABLE_SECURITY_CHECK=false; otherwise the legacy MCP SQL security layer can
-# reject some SQL before Doris sees it.
-DORIS_OAUTH_QUERY_TOOLS_ENABLED=false
-DORIS_OAUTH_QUERY_TOOL_ALLOWLIST=exec_query
-DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED=false
-DORIS_OAUTH_EXPLAIN_TOOL_ALLOWLIST=get_sql_explain
+# If SQL should be decided only by Doris RBAC, set ENABLE_SECURITY_CHECK=false;
+# otherwise the MCP SQL guard can reject some SQL before Doris sees it.
 
 # Token/code/client lifetime settings. Current OAuth store is memory-only and
 # process-local; tokens, auth codes, DCR clients, and client secrets do not

--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ export MCP_LIST_PAGE_SIZE=100
 export MCP_TOOL_EXPOSURE_MODE=hierarchical
 # Load only these installed custom tool providers. Empty disables extensions.
 export MCP_TOOL_PROVIDERS="orders_api"
+# Cache private route-specific Doris capability evidence for five minutes,
+# probe for at most five seconds, and allow a bounded stale fallback.
+export CAPABILITY_SNAPSHOT_TTL_SECONDS=300
+export CAPABILITY_PROBE_TIMEOUT_SECONDS=5
+export CAPABILITY_STALE_GRACE_SECONDS=900
 # A launch-local key is generated automatically. Configure one shared
 # high-entropy value when independently launched replicas share traffic.
 export MCP_STATE_HANDLE_SECRET="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
@@ -329,6 +334,12 @@ cp .env.example .env
         (default: hierarchical)
     *   `MCP_TOOL_PROVIDERS`: Comma-separated allowlist of installed
         `doris_mcp_server.tool_providers` entry points (default: empty)
+    *   `CAPABILITY_SNAPSHOT_TTL_SECONDS`: Lifetime of a private route-specific
+        Doris capability snapshot (default: 300; range: 1-86400)
+    *   `CAPABILITY_PROBE_TIMEOUT_SECONDS`: Total timeout for one capability
+        probe phase (default: 5; range: 1-60)
+    *   `CAPABILITY_STALE_GRACE_SECONDS`: Bounded interval in which a failed
+        refresh may reuse stale private evidence (default: 900; range: 0-86400)
     *   `MCP_STATE_HANDLE_SECRET`: Optional shared high-entropy key (at least
         32 bytes) used to authenticate explicit cross-call state handles
     *   `MCP_STATE_HANDLE_TTL_SECONDS`: Lifetime of an explicit state handle
@@ -402,11 +413,13 @@ tools, schemas, version support, availability, evidence, and risk annotations.
 See [docs/tool-registry.md](docs/tool-registry.md). The checked-in catalog is
 generated from the same validated domain definitions used at runtime.
 
-`tool:list` authorizes domain-manifest discovery for OAuth sessions; it does
-not authorize child execution. Children without discovery permission are
-omitted, while authorized but unavailable children remain visible with
-`callable=false`. Doris RBAC remains the final data authorization backend for
-all Doris object access.
+`tool:list` authorizes only the stable top-level domain list for OAuth
+sessions. Each child additionally requires its exact
+`child:discover:<domain>:<child>` or `child:call:<domain>:<child>` scope;
+`child:call` permits both discovery and execution. Children without an exact
+discovery grant are omitted, while authorized but unavailable children remain
+visible with `callable=false`. Doris RBAC remains the final data authorization
+backend for all Doris object access.
 
 ### 4. Run the Service
 
@@ -901,7 +914,7 @@ OAUTH_AUDIENCE=https://mcp.example.com/mcp
 OAUTH_INTROSPECTION_URL=https://issuer.example.com/introspect
 OAUTH_USERINFO_URL=https://issuer.example.com/userinfo
 
-OAUTH_SCOPE="tool:list tool:call:exec_query resource:list resource:read"
+OAUTH_SCOPE="tool:list child:call:doris_query:execute_query resource:list resource:read"
 OAUTH_REQUIRED_SCOPE="tool:list resource:read"
 ```
 
@@ -922,11 +935,14 @@ not copied into these responses. These HTTP OAuth challenges do not apply to
 stdio transport, where credentials are supplied through the local process
 environment.
 
-External OAuth operation scopes are exact: listing tools requires `tool:list`,
-calling a tool requires `tool:call:<tool-name>`, listing and reading resources
-require `resource:list` and `resource:read`, and Prompt operations require
-`prompt:list` and `prompt:get`. Add every callable tool scope to
-`OAUTH_SCOPE`; `*` and unrelated scopes never satisfy an operation check.
+External OAuth operation scopes are exact: listing the stable domains requires
+`tool:list`; each child requires
+`child:call:<domain>:<child>` for execution or
+`child:discover:<domain>:<child>` for discovery only. Listing and reading
+resources require `resource:list` and `resource:read`, and Prompt operations
+require `prompt:list` and `prompt:get`. Add every required child scope to
+`OAUTH_SCOPE`; `*`, legacy flat-tool scopes, and unrelated scopes never satisfy
+an operation check.
 Static token, JWT, anonymous loopback, and local stdio authorization keep
 their existing non-OAuth permission behavior.
 
@@ -963,10 +979,8 @@ ENABLE_DORIS_OAUTH_AUTH=true
 DORIS_OAUTH_BASE_URL=http://localhost:3000
 ENABLE_OAUTH_AUTH=false
 
-DORIS_OAUTH_DB_TOOLS_ENABLED=true
-DORIS_OAUTH_DB_TOOL_ALLOWLIST=get_db_list,get_db_table_list,get_table_schema,get_table_comment,get_table_column_comments,get_table_indexes,get_catalog_list
-DORIS_OAUTH_QUERY_TOOLS_ENABLED=true
-DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED=true
+DORIS_OAUTH_CHILD_TOOLS_ENABLED=true
+DORIS_OAUTH_CHILD_TOOL_ALLOWLIST=doris_catalog.list_databases,doris_query.execute_query,doris_query.explain_query
 
 # Optional: let Doris RBAC, not the legacy MCP SQL guard, decide DDL/DML.
 ENABLE_SECURITY_CHECK=false
@@ -974,23 +988,25 @@ ENABLE_SECURITY_CHECK=false
 
 The configured service Doris account is still required by startup validation and by non-Doris-OAuth compatibility paths. Doris-backed OAuth requests are fail-closed if the per-user pool is missing and must not fall back to the service/global account.
 
-#### Doris OAuth Tool Access
+#### Doris OAuth Child Access
 
-`DORIS_OAUTH_DB_TOOLS_ENABLED=true` opens the reviewed metadata bucket. The reviewed tools are:
+`DORIS_OAUTH_CHILD_TOOLS_ENABLED=true` opens only the formal child features in
+`DORIS_OAUTH_CHILD_TOOL_ALLOWLIST`. The allowlist uses exact
+`domain.child` IDs, such as `doris_catalog.list_databases` and
+`doris_query.execute_query`.
 
-*   `get_db_list`
-*   `get_db_table_list`
-*   `get_table_schema`
-*   `get_table_comment`
-*   `get_table_column_comments`
-*   `get_table_indexes`
-*   `get_catalog_list`
+The authorization server issues exact
+`child:call:<domain>:<child>` and
+`child:discover:<domain>:<child>` scopes. A call scope also permits discovery;
+a discovery scope never permits execution. Legacy flat names and
+`tool:call:<legacy-name>` scopes are rejected. If an OAuth request omits
+scope, the server grants the configured call envelope. For MySQL-channel
+operations, Doris RBAC still decides whether the logged-in Doris user can read
+metadata or run the requested SQL.
 
-For normal MCP OAuth flows, clients do not need to pass a long `--scopes` list. If the OAuth request omits scope, the server grants the configured Doris OAuth capability envelope. For MySQL-channel operations, Doris RBAC decides whether the logged-in Doris user can actually read metadata, run SQL, or explain SQL.
-
-`DORIS_OAUTH_QUERY_TOOLS_ENABLED=true` opens `exec_query`. `DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED=true` opens `get_sql_explain`. If `ENABLE_SECURITY_CHECK=true`, the legacy MCP SQL security layer can still reject some SQL before Doris sees it. Set `ENABLE_SECURITY_CHECK=false` when the intended policy is to let Doris RBAC decide SQL/DDL/DML.
-
-Doris-backed OAuth still does not open prompts, ADBC, FE HTTP profile/monitoring, audit/governance, or performance analytics in this phase unless those paths are separately routed through per-user credentials or given an explicit service-account/admin design.
+If `ENABLE_SECURITY_CHECK=true`, the MCP SQL security layer can still reject
+some SQL before Doris sees it. Set `ENABLE_SECURITY_CHECK=false` only when the
+intended policy is to let Doris RBAC decide SQL, DDL, and DML.
 
 #### OAuth Client Registration
 
@@ -2205,7 +2221,11 @@ cat logs/doris_mcp_server_critical.log
 
 These modes are mutually exclusive on one MCP URL. Do not enable `ENABLE_DORIS_OAUTH_AUTH=true` together with `ENABLE_OAUTH_AUTH=true`, `OAUTH_ENABLED=true`, or `AUTH_TYPE=oauth`; startup fails fast if both OAuth modes are configured.
 
-Doris-backed OAuth currently exposes MCP resources with disabled resources metadata cache. It exposes reviewed metadata tools when `DORIS_OAUTH_DB_TOOLS_ENABLED=true`, `exec_query` when `DORIS_OAUTH_QUERY_TOOLS_ENABLED=true`, and SQL explain when `DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED=true`. Normal clients do not need to pass a long scope list; omitted OAuth scope grants the configured Doris OAuth capability envelope. Doris RBAC remains the final data authorization backend for these MySQL-channel operations.
+Doris-backed OAuth exposes MCP resources with disabled resources metadata
+cache. Child access is controlled by `DORIS_OAUTH_CHILD_TOOLS_ENABLED`, the
+exact formal Feature-ID allowlist, and exact child discovery/call scopes.
+Omitted OAuth scope grants the configured call envelope. Doris RBAC remains
+the final data authorization backend for Doris operations.
 
 ### Q: Can Doris-backed OAuth run with multiple workers or multiple nodes?
 

--- a/docs/doris-fine-grained-access-control.md
+++ b/docs/doris-fine-grained-access-control.md
@@ -36,8 +36,9 @@ Doris MCP Server has two distinct authorization layers:
 2. Doris authorization decides which catalogs, databases, tables, columns, and
    rows the database identity may access.
 
-An OAuth scope such as `tool:call:exec_query` permits an MCP operation. It does
-not grant `SELECT_PRIV` in Doris and does not override a Doris row policy.
+An OAuth scope such as `child:call:doris_query:execute_query` permits one MCP
+child operation. It does not grant `SELECT_PRIV` in Doris and does not override
+a Doris row policy.
 Likewise, MCP security levels, SQL validation, and response masking are
 defense-in-depth controls rather than replacements for Doris RBAC.
 
@@ -235,20 +236,20 @@ has global/table-level privileges.
 
 With `ENABLE_DORIS_OAUTH_AUTH=true`, the user signs in with Doris credentials.
 The issued `doa_` token is associated with that user's dedicated Doris pool.
-Enable only reviewed MySQL-channel capabilities:
+Enable only reviewed formal child capabilities:
 
 ```bash
 ENABLE_DORIS_OAUTH_AUTH=true
 WORKERS=1
 
-DORIS_OAUTH_DB_TOOLS_ENABLED=true
-DORIS_OAUTH_QUERY_TOOLS_ENABLED=true
-DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED=true
+DORIS_OAUTH_CHILD_TOOLS_ENABLED=true
+DORIS_OAUTH_CHILD_TOOL_ALLOWLIST=doris_catalog.list_databases,doris_query.execute_query,doris_query.explain_query
 ```
 
-`exec_query`, reviewed metadata tools, and SQL explain then reach Doris as the
-signed-in user. Doris-backed OAuth must fail closed if its per-user pool is
-missing; it must never use the global service account as a fallback.
+Only exact allowlisted children with exact child scopes then reach Doris as the
+signed-in user. Legacy flat names and `tool:call:<legacy-name>` scopes are not
+accepted. Doris-backed OAuth must fail closed if its per-user pool is missing;
+it must never use the global service account as a fallback.
 When multiple FE candidates are configured, sign-in tries them in order.
 If an established per-user pool later fails, the user must sign in again:
 the server intentionally does not retain the raw Doris password needed to
@@ -314,11 +315,11 @@ Both queries must fail authorization.
 Then repeat the checks through the MCP route:
 
 1. Authenticate using the token binding or Doris OAuth user.
-2. Call `exec_query` with the allowed-column query.
-3. Call `exec_query` for `customer_phone` and confirm a bounded permission
-   error, without backend credentials or exception text.
+2. Call `doris_query.execute_query` with the allowed-column query.
+3. Call `doris_query.execute_query` for `customer_phone` and confirm a bounded
+   permission error, without backend credentials or exception text.
 4. Query for another region and confirm no rows are returned.
-5. Run metadata tools and confirm they do not reveal inaccessible objects or
+5. Run catalog children and confirm they do not reveal inaccessible objects or
    columns beyond what the Doris version exposes to that user.
 6. Repeat over every supported transport used by the deployment.
 

--- a/doris_mcp_server/auth/doris_oauth_provider.py
+++ b/doris_mcp_server/auth/doris_oauth_provider.py
@@ -574,6 +574,20 @@ class DorisOAuthProvider:
             oauth_audiences=[updated.resource],
             pool_key=f"doris_user:{updated.doris_user}",
         )
+        auth_context.doris_oauth_child_tools_enabled = bool(
+            getattr(
+                self.security_config,
+                "doris_oauth_child_tools_enabled",
+                False,
+            )
+        )
+        auth_context.doris_oauth_child_tool_allowlist = tuple(
+            getattr(
+                self.security_config,
+                "doris_oauth_child_tool_allowlist",
+                (),
+            )
+        )
         auth_context.doris_oauth_db_tools_enabled = bool(
             getattr(self.security_config, "doris_oauth_db_tools_enabled", False)
         )

--- a/doris_mcp_server/auth/doris_oauth_scope_policy.py
+++ b/doris_mcp_server/auth/doris_oauth_scope_policy.py
@@ -4,11 +4,7 @@
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-from ..tools.tool_registry import (
-    DORIS_OAUTH_EXPLAIN_TOOL_SET,
-    DORIS_OAUTH_METADATA_TOOL_NAMES,
-    DORIS_OAUTH_QUERY_TOOL_SET,
-)
+from ..tools.domain_catalog import FORMAL_CHILD_FEATURE_IDS
 from .doris_oauth_types import TokenEndpointError
 
 if TYPE_CHECKING:
@@ -17,29 +13,28 @@ if TYPE_CHECKING:
 BASE_DORIS_OAUTH_SCOPES = frozenset({"tool:list"})
 RESOURCE_SCOPES = frozenset({"resource:list", "resource:read"})
 
-DORIS_OAUTH_METADATA_TOOLS = DORIS_OAUTH_METADATA_TOOL_NAMES
 
-METADATA_DB_SCOPES = frozenset(
-    {
-        f"tool:call:{tool_name}" for tool_name in DORIS_OAUTH_METADATA_TOOLS
-    }
-)
+def child_call_scope(feature_id: str) -> str:
+    """Return the canonical execution scope for one formal child feature."""
+    domain, child = feature_id.split(".", 1)
+    return f"child:call:{domain}:{child}"
 
-QUERY_DB_SCOPES = frozenset(
-    f"tool:call:{tool_name}" for tool_name in DORIS_OAUTH_QUERY_TOOL_SET
+
+def child_discovery_scope(feature_id: str) -> str:
+    """Return the canonical discovery-only scope for one formal child feature."""
+    domain, child = feature_id.split(".", 1)
+    return f"child:discover:{domain}:{child}"
+
+
+CHILD_CALL_SCOPES = frozenset(
+    child_call_scope(feature_id)
+    for feature_id in FORMAL_CHILD_FEATURE_IDS
 )
-EXPLAIN_DB_SCOPES = frozenset(
-    f"tool:call:{tool_name}" for tool_name in DORIS_OAUTH_EXPLAIN_TOOL_SET
+CHILD_DISCOVERY_SCOPES = frozenset(
+    child_discovery_scope(feature_id)
+    for feature_id in FORMAL_CHILD_FEATURE_IDS
 )
-PENDING_DB_SCOPES = METADATA_DB_SCOPES | QUERY_DB_SCOPES | EXPLAIN_DB_SCOPES
-TOOL_SCOPE_ALIASES = {
-    tool_name: f"tool:call:{tool_name}"
-    for tool_name in (
-        *DORIS_OAUTH_METADATA_TOOLS,
-        *DORIS_OAUTH_QUERY_TOOL_SET,
-        *DORIS_OAUTH_EXPLAIN_TOOL_SET,
-    )
-}
+KNOWN_CHILD_SCOPES = CHILD_CALL_SCOPES | CHILD_DISCOVERY_SCOPES
 
 FORBIDDEN_DORIS_OAUTH_SCOPES = frozenset(
     {
@@ -76,12 +71,16 @@ class DorisOAuthScopePolicy:
             self.server_allowed_scopes = self._build_server_allowed_scopes(security_config)
         else:
             self.server_allowed_scopes = set(server_allowed_scopes)
-        self.server_default_scopes = set(self.server_allowed_scopes)
+        self.server_default_scopes = {
+            scope
+            for scope in self.server_allowed_scopes
+            if not scope.startswith("child:discover:")
+        }
         self.forbidden_scopes = set(FORBIDDEN_DORIS_OAUTH_SCOPES)
         self.known_scopes = (
             set(BASE_DORIS_OAUTH_SCOPES)
             | set(RESOURCE_SCOPES)
-            | set(PENDING_DB_SCOPES)
+            | set(KNOWN_CHILD_SCOPES)
             | set(FORBIDDEN_DORIS_OAUTH_SCOPES)
         )
 
@@ -91,56 +90,46 @@ class DorisOAuthScopePolicy:
         allowed = set(BASE_DORIS_OAUTH_SCOPES)
         allowed.update(RESOURCE_SCOPES)
 
-        if getattr(security_config, "doris_oauth_db_tools_enabled", False):
-            tool_names = self._configured_tool_names(
+        if getattr(
+            security_config,
+            "doris_oauth_child_tools_enabled",
+            False,
+        ):
+            feature_ids = self._configured_feature_ids(
                 getattr(
                     security_config,
-                    "doris_oauth_db_tool_allowlist",
-                    DORIS_OAUTH_METADATA_TOOLS,
+                    "doris_oauth_child_tool_allowlist",
+                    FORMAL_CHILD_FEATURE_IDS,
                 )
             )
-            metadata_tool_set = set(DORIS_OAUTH_METADATA_TOOLS)
-            allowed.update(f"tool:call:{tool_name}" for tool_name in tool_names if tool_name in metadata_tool_set)
-
-        if getattr(security_config, "doris_oauth_query_tools_enabled", False):
-            tool_names = self._configured_tool_names(
-                getattr(
-                    security_config,
-                    "doris_oauth_query_tool_allowlist",
-                    tuple(DORIS_OAUTH_QUERY_TOOL_SET),
-                )
-            )
-            if DORIS_OAUTH_QUERY_TOOL_SET.intersection(tool_names):
-                allowed.update(QUERY_DB_SCOPES)
-
-        if getattr(security_config, "doris_oauth_explain_tools_enabled", False):
-            tool_names = self._configured_tool_names(
-                getattr(
-                    security_config,
-                    "doris_oauth_explain_tool_allowlist",
-                    tuple(DORIS_OAUTH_EXPLAIN_TOOL_SET),
-                )
-            )
-            if DORIS_OAUTH_EXPLAIN_TOOL_SET.intersection(tool_names):
-                allowed.update(EXPLAIN_DB_SCOPES)
+            formal_features = set(FORMAL_CHILD_FEATURE_IDS)
+            for feature_id in feature_ids:
+                if feature_id not in formal_features:
+                    continue
+                allowed.add(child_call_scope(feature_id))
+                allowed.add(child_discovery_scope(feature_id))
 
         return allowed
 
-    def _configured_tool_names(
-        self, configured_tools: str | Iterable[object]
+    def _configured_feature_ids(
+        self, configured_features: str | Iterable[object]
     ) -> list[str]:
-        if isinstance(configured_tools, str):
-            return [part.strip() for part in configured_tools.split(",") if part.strip()]
-        return [str(tool).strip() for tool in configured_tools if str(tool).strip()]
+        if isinstance(configured_features, str):
+            return [
+                part.strip()
+                for part in configured_features.split(",")
+                if part.strip()
+            ]
+        return [
+            str(feature).strip()
+            for feature in configured_features
+            if str(feature).strip()
+        ]
 
     def parse_scope(self, scope: str | None) -> tuple[str, ...]:
         if scope is None:
             return ()
-        return tuple(
-            TOOL_SCOPE_ALIASES.get(part, part)
-            for part in str(scope).split()
-            if part
-        )
+        return tuple(part for part in str(scope).split() if part)
 
     def grant_client_scopes(self, requested_scope: str | None, *, explicit: bool) -> tuple[str, ...]:
         requested = self.parse_scope(requested_scope)

--- a/doris_mcp_server/main.py
+++ b/doris_mcp_server/main.py
@@ -92,6 +92,15 @@ def _multiworker_environment(
         "MCP_LIST_PAGE_SIZE": str(config.mcp_list_page_size),
         "MCP_TOOL_PROVIDERS": ",".join(config.mcp_tool_providers),
         "MCP_TOOL_EXPOSURE_MODE": config.tool_exposure.mode,
+        "CAPABILITY_SNAPSHOT_TTL_SECONDS": str(
+            config.capability.snapshot_ttl_seconds
+        ),
+        "CAPABILITY_PROBE_TIMEOUT_SECONDS": str(
+            config.capability.probe_timeout_seconds
+        ),
+        "CAPABILITY_STALE_GRACE_SECONDS": str(
+            config.capability.stale_grace_seconds
+        ),
         "MCP_STATE_HANDLE_SECRET": config.mcp_state_handle_secret,
         "MCP_STATE_HANDLE_TTL_SECONDS": str(config.mcp_state_handle_ttl_seconds),
         "SERVER_NAME": config.server_name,

--- a/doris_mcp_server/state_handles.py
+++ b/doris_mcp_server/state_handles.py
@@ -108,6 +108,12 @@ def authorization_fingerprint(auth_context: AuthContext | None) -> str:
             "oauthResource": auth_context.oauth_resource,
             "oauthAudiences": sorted(auth_context.oauth_audiences),
             "poolKey": auth_context.pool_key,
+            "dorisOAuthChildTools": {
+                "enabled": auth_context.doris_oauth_child_tools_enabled,
+                "allowlist": sorted(
+                    auth_context.doris_oauth_child_tool_allowlist
+                ),
+            },
             "dorisOAuthDatabaseTools": {
                 "enabled": auth_context.doris_oauth_db_tools_enabled,
                 "allowlist": sorted(auth_context.doris_oauth_db_tool_allowlist),

--- a/doris_mcp_server/tools/capability_detector.py
+++ b/doris_mcp_server/tools/capability_detector.py
@@ -1,0 +1,636 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Route-aware, read-only Doris capability probes."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from ..utils.db import DorisConnection, DorisConnectionManager, DorisRouteIdentity
+from .doris_feature_matrix import DorisClusterVersionVector
+from .doris_version import (
+    DorisVersion,
+    parse_doris_version_comment,
+    probe_doris_version,
+)
+
+
+class CapabilityProbeStatus(StrEnum):
+    """Normalized result of one private runtime capability probe."""
+
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+    UNKNOWN = "unknown"
+    DEGRADED = "degraded"
+    MISCONFIGURED = "misconfigured"
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityProbeEvidence:
+    """Bounded, secret-free evidence for one capability predicate."""
+
+    probe_id: str
+    status: CapabilityProbeStatus
+    reason_code: str
+    evidence_sources: tuple[str, ...] = ("runtime_probe",)
+
+
+@dataclass(frozen=True, slots=True)
+class DorisCapabilitySnapshot:
+    """Private capability facts for one route and optional domain."""
+
+    route: DorisRouteIdentity
+    capability_generation: int
+    provider_generation: str
+    cluster_fingerprint: str
+    version_vector: DorisClusterVersionVector
+    deployment_mode: str
+    mixed_versions: bool
+    probes: Mapping[str, CapabilityProbeEvidence]
+    probed_domains: frozenset[str]
+    created_at: datetime
+    expires_at: datetime
+    stale_until: datetime
+    stale: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "probes",
+            MappingProxyType(dict(self.probes)),
+        )
+
+    def probe(self, probe_id: str) -> CapabilityProbeEvidence | None:
+        return self.probes.get(probe_id)
+
+    @property
+    def generation_fingerprint(self) -> str:
+        """Return a stable private generation for Manifest invalidation."""
+        payload = {
+            "route": self.route.fingerprint,
+            "capability_generation": self.capability_generation,
+            "provider_generation": self.provider_generation,
+            "cluster": self.cluster_fingerprint,
+            "deployment_mode": self.deployment_mode,
+            "mixed_versions": self.mixed_versions,
+            "probed_domains": sorted(self.probed_domains),
+            "probes": {
+                probe_id: {
+                    "status": evidence.status.value,
+                    "reason_code": evidence.reason_code,
+                }
+                for probe_id, evidence in sorted(self.probes.items())
+            },
+            "stale": self.stale,
+        }
+        canonical = json.dumps(
+            payload,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return "cap." + hashlib.sha256(
+            canonical.encode("utf-8")
+        ).hexdigest()[:16]
+
+    def as_stale(
+        self,
+        *,
+        retry_at: datetime | None = None,
+    ) -> DorisCapabilitySnapshot:
+        expires_at = self.expires_at
+        if retry_at is not None:
+            expires_at = min(retry_at, self.stale_until)
+        return replace(
+            self,
+            expires_at=expires_at,
+            stale=True,
+        )
+
+
+class CapabilityDetectionError(RuntimeError):
+    """Raised when no safe base capability snapshot can be established."""
+
+
+class CapabilityRouteChangedError(CapabilityDetectionError):
+    """Raised when a route changes while a domain snapshot is extended."""
+
+
+_DOMAIN_PROBES: Mapping[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
+    "doris_catalog": (
+        ("SHOW CATALOGS", ("catalog_metadata_readable",)),
+        ("SHOW DATABASES", ("database_metadata_readable",)),
+        (
+            (
+                "SELECT 1 AS table_metadata_probe "
+                "FROM information_schema.tables LIMIT 1"
+            ),
+            ("table_metadata_readable",),
+        ),
+    ),
+    "doris_query": (
+        (
+            "EXPLAIN SELECT 1",
+            ("explain_output_readable", "explain_readable"),
+        ),
+    ),
+}
+
+
+class DorisCapabilityDetector:
+    """Build L1 snapshots and add low-cost domain probes lazily."""
+
+    def __init__(
+        self,
+        connection_manager: DorisConnectionManager,
+        *,
+        probe_timeout_seconds: float = 5.0,
+        snapshot_ttl_seconds: int = 300,
+        stale_grace_seconds: int = 900,
+        clock: Any | None = None,
+    ) -> None:
+        self._connection_manager = connection_manager
+        self._probe_timeout_seconds = probe_timeout_seconds
+        self._snapshot_ttl_seconds = snapshot_ttl_seconds
+        self._stale_grace_seconds = stale_grace_seconds
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    def route_identity(self, auth_context: Any | None) -> DorisRouteIdentity:
+        route = self._connection_manager.get_route_identity(auth_context)
+        if not isinstance(route, DorisRouteIdentity):
+            raise CapabilityDetectionError(
+                "Doris route identity is unavailable"
+            )
+        return route
+
+    async def detect_base(
+        self,
+        auth_context: Any | None,
+        *,
+        capability_generation: int,
+        provider_generation: str,
+    ) -> DorisCapabilitySnapshot:
+        try:
+            async with asyncio.timeout(self._probe_timeout_seconds):
+                for _ in range(2):
+                    requested_route = self.route_identity(auth_context)
+                    session_id = (
+                        "capability-base:"
+                        f"{requested_route.fingerprint[:16]}"
+                    )
+                    async with (
+                        self._connection_manager
+                        .get_connection_context_for_auth_context(
+                            session_id,
+                            auth_context,
+                        ) as connection
+                    ):
+                        snapshot = await self._detect_base_on_connection(
+                            connection,
+                            auth_context,
+                            capability_generation=capability_generation,
+                            provider_generation=provider_generation,
+                        )
+                    completed_route = self.route_identity(auth_context)
+                    if (
+                        snapshot.route.fingerprint
+                        == requested_route.fingerprint
+                        == completed_route.fingerprint
+                    ):
+                        return snapshot
+                raise CapabilityRouteChangedError(
+                    "Doris route changed during base capability probing"
+                )
+        except TimeoutError as exc:
+            raise CapabilityDetectionError(
+                "Doris capability base probe timed out"
+            ) from exc
+        except CapabilityDetectionError:
+            raise
+        except Exception as exc:
+            raise CapabilityDetectionError(
+                "Doris capability base probe failed"
+            ) from exc
+
+    async def detect_domain(
+        self,
+        base: DorisCapabilitySnapshot,
+        domain_name: str,
+        auth_context: Any | None,
+    ) -> DorisCapabilitySnapshot:
+        if domain_name in base.probed_domains:
+            return base
+
+        try:
+            requested_route = self.route_identity(auth_context)
+            if requested_route.fingerprint != base.route.fingerprint:
+                raise CapabilityRouteChangedError(
+                    "Doris route changed before domain capability probing"
+                )
+
+            session_id = (
+                f"capability-domain:{domain_name}:"
+                f"{requested_route.fingerprint[:12]}"
+            )
+            async with asyncio.timeout(self._probe_timeout_seconds):
+                async with (
+                    self._connection_manager
+                    .get_connection_context_for_auth_context(
+                        session_id,
+                        auth_context,
+                    ) as connection
+                ):
+                    current_route = self.route_identity(auth_context)
+                    if current_route.fingerprint != base.route.fingerprint:
+                        raise CapabilityRouteChangedError(
+                            "Doris route changed during domain capability probing"
+                        )
+                    probes = dict(base.probes)
+                    for sql, probe_ids in _DOMAIN_PROBES.get(
+                        domain_name,
+                        (),
+                    ):
+                        evidence = await self._probe_statement(
+                            connection,
+                            sql,
+                            probe_ids,
+                        )
+                        probes.update(evidence)
+                    completed_route = self.route_identity(auth_context)
+                    if completed_route.fingerprint != base.route.fingerprint:
+                        raise CapabilityRouteChangedError(
+                            "Doris route changed during domain capability probing"
+                        )
+                    return replace(
+                        base,
+                        probes=probes,
+                        probed_domains=(
+                            base.probed_domains | frozenset({domain_name})
+                        ),
+                    )
+        except TimeoutError as exc:
+            raise CapabilityDetectionError(
+                f"Doris capability probe timed out for {domain_name}"
+            ) from exc
+        except CapabilityDetectionError:
+            raise
+        except Exception as exc:
+            raise CapabilityDetectionError(
+                f"Doris capability probe failed for {domain_name}"
+            ) from exc
+
+    async def _detect_base_on_connection(
+        self,
+        connection: DorisConnection,
+        auth_context: Any | None,
+        *,
+        capability_generation: int,
+        provider_generation: str,
+    ) -> DorisCapabilitySnapshot:
+        version = await probe_doris_version(connection)
+        route = self.route_identity(auth_context)
+        now = self._clock()
+        probes: dict[str, CapabilityProbeEvidence] = {}
+        probes["version_probe_completed"] = CapabilityProbeEvidence(
+            probe_id="version_probe_completed",
+            status=(
+                CapabilityProbeStatus.SUPPORTED
+                if version.is_parsed
+                else CapabilityProbeStatus.UNKNOWN
+            ),
+            reason_code=(
+                "VERSION_PROBE_PARSED"
+                if version.is_parsed
+                else "DORIS_VERSION_UNKNOWN"
+            ),
+            evidence_sources=("version_probe",),
+        )
+        probes["read_only_sql_guard_ready"] = CapabilityProbeEvidence(
+            probe_id="read_only_sql_guard_ready",
+            status=CapabilityProbeStatus.SUPPORTED,
+            reason_code="READ_ONLY_GUARD_ENABLED",
+            evidence_sources=("server_policy",),
+        )
+        probes.update(
+            await self._probe_statement(
+                connection,
+                "SELECT 1 AS capability_probe",
+                ("query_execution_readable",),
+            )
+        )
+
+        frontend_rows, frontend_probe = await self._probe_rows(
+            connection,
+            "SHOW FRONTENDS",
+            "frontends_metadata_readable",
+        )
+        backend_rows, backend_probe = await self._probe_rows(
+            connection,
+            "SHOW BACKENDS",
+            "backends_metadata_readable",
+        )
+        probes[frontend_probe.probe_id] = frontend_probe
+        probes[backend_probe.probe_id] = backend_probe
+
+        master_fe, follower_fes = _frontend_versions(
+            frontend_rows,
+            fallback=version,
+        )
+        backends = _backend_versions(backend_rows)
+        versions = DorisClusterVersionVector(
+            master_fe=master_fe,
+            follower_fes=follower_fes,
+            backends=backends,
+        )
+        nodes_ready = bool(frontend_rows and backend_rows)
+        node_status = (
+            CapabilityProbeStatus.SUPPORTED
+            if nodes_ready
+            else CapabilityProbeStatus.UNKNOWN
+        )
+        node_reason = (
+            "FE_BE_VERSIONS_OBSERVED"
+            if nodes_ready
+            else "FE_BE_VERSIONS_INCOMPLETE"
+        )
+        for probe_id in (
+            "cluster_components_discoverable",
+            "fe_be_node_metadata_readable",
+        ):
+            probes[probe_id] = CapabilityProbeEvidence(
+                probe_id=probe_id,
+                status=node_status,
+                reason_code=node_reason,
+                evidence_sources=(
+                    "show_frontends",
+                    "show_backends",
+                ),
+            )
+
+        observed = (
+            versions.master_fe,
+            *versions.follower_fes,
+            *versions.backends,
+        )
+        normalized = {
+            candidate.normalized
+            for candidate in observed
+            if candidate.normalized is not None
+        }
+        mixed_versions = len(normalized) > 1
+        cluster_fingerprint = _cluster_fingerprint(
+            route,
+            frontend_rows,
+            backend_rows,
+        )
+        deployment_mode = version.deployment_hint or "unknown"
+        return DorisCapabilitySnapshot(
+            route=route,
+            capability_generation=capability_generation,
+            provider_generation=provider_generation,
+            cluster_fingerprint=cluster_fingerprint,
+            version_vector=versions,
+            deployment_mode=deployment_mode,
+            mixed_versions=mixed_versions,
+            probes=probes,
+            probed_domains=frozenset(),
+            created_at=now,
+            expires_at=now + timedelta(seconds=self._snapshot_ttl_seconds),
+            stale_until=now
+            + timedelta(
+                seconds=(
+                    self._snapshot_ttl_seconds
+                    + self._stale_grace_seconds
+                )
+            ),
+        )
+
+    async def _probe_statement(
+        self,
+        connection: DorisConnection,
+        sql: str,
+        probe_ids: tuple[str, ...],
+    ) -> dict[str, CapabilityProbeEvidence]:
+        try:
+            await connection.execute(
+                sql,
+                mask_result=False,
+                max_rows=64,
+                max_bytes=64 * 1024,
+            )
+        except Exception as exc:
+            status, reason = _classify_probe_error(exc)
+        else:
+            status = CapabilityProbeStatus.SUPPORTED
+            reason = "RUNTIME_PROBE_SUCCEEDED"
+        return {
+            probe_id: CapabilityProbeEvidence(
+                probe_id=probe_id,
+                status=status,
+                reason_code=reason,
+            )
+            for probe_id in probe_ids
+        }
+
+    async def _probe_rows(
+        self,
+        connection: DorisConnection,
+        sql: str,
+        probe_id: str,
+    ) -> tuple[tuple[Mapping[str, Any], ...], CapabilityProbeEvidence]:
+        try:
+            result = await connection.execute(
+                sql,
+                mask_result=False,
+                max_rows=512,
+                max_bytes=512 * 1024,
+            )
+            rows = tuple(
+                row
+                for row in (result.data or ())
+                if isinstance(row, Mapping)
+            )
+        except Exception as exc:
+            status, reason = _classify_probe_error(exc)
+            rows = ()
+        else:
+            status = CapabilityProbeStatus.SUPPORTED
+            reason = "RUNTIME_PROBE_SUCCEEDED"
+        return rows, CapabilityProbeEvidence(
+            probe_id=probe_id,
+            status=status,
+            reason_code=reason,
+        )
+
+
+def _classify_probe_error(
+    error: Exception,
+) -> tuple[CapabilityProbeStatus, str]:
+    error_code = next(
+        (
+            value
+            for value in getattr(error, "args", ())
+            if isinstance(value, int)
+        ),
+        None,
+    )
+    if error_code in {1044, 1045, 1142, 1227}:
+        return (
+            CapabilityProbeStatus.UNKNOWN,
+            "PROBE_PERMISSION_DENIED",
+        )
+    if error_code in {1064, 1109, 1146}:
+        return (
+            CapabilityProbeStatus.UNSUPPORTED,
+            "PROBE_OBJECT_OR_SYNTAX_UNSUPPORTED",
+        )
+    if isinstance(error, ConnectionError | TimeoutError):
+        return (
+            CapabilityProbeStatus.DEGRADED,
+            "PROBE_CONNECTION_FAILED",
+        )
+    return CapabilityProbeStatus.UNKNOWN, "RUNTIME_PROBE_FAILED"
+
+
+def _row_value(
+    row: Mapping[str, Any],
+    *names: str,
+) -> Any | None:
+    lowered = {str(key).lower(): value for key, value in row.items()}
+    for name in names:
+        if name.lower() in lowered:
+            return lowered[name.lower()]
+    return None
+
+
+def _component_version(value: Any) -> DorisVersion:
+    raw = "" if value is None else str(value).strip()
+    if not raw:
+        return parse_doris_version_comment("")
+    if "doris" not in raw.lower():
+        raw = f"Doris version doris-{raw}"
+    return parse_doris_version_comment(raw)
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes"}
+
+
+def _frontend_versions(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    fallback: DorisVersion,
+) -> tuple[DorisVersion, tuple[DorisVersion, ...]]:
+    observed: list[tuple[DorisVersion, bool]] = []
+    for row in rows:
+        version = _component_version(
+            _row_value(row, "Version", "FeVersion")
+        )
+        observed.append(
+            (
+                version,
+                _truthy(_row_value(row, "IsMaster", "Master")),
+            )
+        )
+    master_index = next(
+        (
+            index
+            for index, (_, is_master) in enumerate(observed)
+            if is_master
+        ),
+        None,
+    )
+    if master_index is None:
+        return fallback, tuple(version for version, _ in observed)
+
+    master = observed[master_index][0]
+    if not master.raw:
+        master = fallback
+    followers = tuple(
+        version
+        for index, (version, _) in enumerate(observed)
+        if index != master_index
+    )
+    return master, followers
+
+
+def _backend_versions(
+    rows: Sequence[Mapping[str, Any]],
+) -> tuple[DorisVersion, ...]:
+    return tuple(
+        _component_version(_row_value(row, "Version", "BeVersion"))
+        for row in rows
+    )
+
+
+def _cluster_fingerprint(
+    route: DorisRouteIdentity,
+    frontend_rows: Sequence[Mapping[str, Any]],
+    backend_rows: Sequence[Mapping[str, Any]],
+) -> str:
+    def node_values(
+        rows: Sequence[Mapping[str, Any]],
+        identifiers: tuple[str, ...],
+    ) -> list[str]:
+        values: list[str] = []
+        for row in rows:
+            values.append(
+                "\x1f".join(
+                    str(_row_value(row, identifier) or "")
+                    for identifier in identifiers
+                )
+            )
+        return sorted(values)
+
+    payload = {
+        "endpoint": route.endpoint_fingerprint,
+        "frontends": node_values(
+            frontend_rows,
+            ("Name", "Host", "Role", "IsMaster", "Version"),
+        ),
+        "backends": node_values(
+            backend_rows,
+            ("BackendId", "Host", "Version"),
+        ),
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "CapabilityDetectionError",
+    "CapabilityProbeEvidence",
+    "CapabilityProbeStatus",
+    "CapabilityRouteChangedError",
+    "DorisCapabilityDetector",
+    "DorisCapabilitySnapshot",
+]

--- a/doris_mcp_server/tools/capability_registry.py
+++ b/doris_mcp_server/tools/capability_registry.py
@@ -1,0 +1,911 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Capability snapshot cache and deterministic child availability evaluation."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from collections.abc import Callable, Coroutine, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from types import MappingProxyType
+from typing import Any
+
+from ..utils.db import DorisRouteIdentity
+from .capability_detector import (
+    CapabilityDetectionError,
+    CapabilityProbeEvidence,
+    CapabilityProbeStatus,
+    CapabilityRouteChangedError,
+    DorisCapabilityDetector,
+    DorisCapabilitySnapshot,
+)
+from .domain_dispatcher import BoundHandlerAvailabilityProvider
+from .domain_manifest import (
+    DomainAvailabilityResolution,
+    authorized_child_execution,
+)
+from .domain_models import (
+    Availability,
+    AvailabilityStatus,
+    CapabilityVariant,
+    ChildToolDefinition,
+    DomainDefinition,
+)
+from .doris_feature_matrix import (
+    CapabilityVersionScope,
+    DorisClusterVersionVector,
+    DorisFeatureMatrix,
+    VersionCertificationStatus,
+)
+from .doris_version import parse_doris_version_comment
+
+_STALE_RETRY_SECONDS = 30
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityProviderEvidence:
+    """Private readiness state for one runtime provider."""
+
+    provider_id: str
+    status: CapabilityProbeStatus
+    reason_code: str
+    evidence_sources: tuple[str, ...] = ("provider_registry",)
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityProviderSnapshot:
+    """Immutable provider state used in one availability calculation."""
+
+    providers: Mapping[str, CapabilityProviderEvidence]
+    generation: str
+
+
+class CapabilityProviderRegistry:
+    """Track provider readiness without publishing provider configuration."""
+
+    def __init__(
+        self,
+        providers: Mapping[str, CapabilityProviderEvidence],
+    ) -> None:
+        self._providers = dict(providers)
+
+    @classmethod
+    def from_runtime(
+        cls,
+        *,
+        matrix: DorisFeatureMatrix,
+        bound_handlers: BoundHandlerAvailabilityProvider,
+        config: Any | None,
+    ) -> CapabilityProviderRegistry:
+        provider_features: dict[str, set[str]] = {}
+        for feature in matrix.features:
+            for variant in feature.support_contract.variants:
+                for provider_id in variant.required_providers:
+                    provider_features.setdefault(provider_id, set()).add(
+                        feature.feature_id
+                    )
+
+        configured_adbc = bool(
+            getattr(getattr(config, "adbc", None), "enabled", False)
+        )
+        providers: dict[str, CapabilityProviderEvidence] = {}
+        for provider_id, feature_ids in provider_features.items():
+            has_bound_consumer = bool(
+                feature_ids & bound_handlers.bound_feature_ids
+            )
+            configured = has_bound_consumer
+            if provider_id == "adbc_provider":
+                configured = configured and configured_adbc
+            providers[provider_id] = CapabilityProviderEvidence(
+                provider_id=provider_id,
+                status=(
+                    CapabilityProbeStatus.DEGRADED
+                    if configured
+                    else CapabilityProbeStatus.MISCONFIGURED
+                ),
+                reason_code=(
+                    "PROVIDER_CONFIGURED_UNPROBED"
+                    if configured
+                    else "PROVIDER_NOT_CONFIGURED"
+                ),
+            )
+        return cls(providers)
+
+    def set_provider(
+        self,
+        provider_id: str,
+        *,
+        status: CapabilityProbeStatus,
+        reason_code: str,
+        evidence_sources: tuple[str, ...] = ("provider_registry",),
+    ) -> None:
+        """Replace one provider state and thereby advance its generation."""
+        self._providers[provider_id] = CapabilityProviderEvidence(
+            provider_id=provider_id,
+            status=status,
+            reason_code=reason_code,
+            evidence_sources=evidence_sources,
+        )
+
+    def snapshot(self) -> CapabilityProviderSnapshot:
+        providers = MappingProxyType(dict(self._providers))
+        payload = {
+            provider_id: {
+                "status": evidence.status.value,
+                "reason_code": evidence.reason_code,
+                "evidence_sources": evidence.evidence_sources,
+            }
+            for provider_id, evidence in sorted(providers.items())
+        }
+        canonical = json.dumps(
+            payload,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        generation = "provider." + hashlib.sha256(
+            canonical.encode("utf-8")
+        ).hexdigest()[:16]
+        return CapabilityProviderSnapshot(
+            providers=providers,
+            generation=generation,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _CandidateFailure:
+    status: AvailabilityStatus
+    reason_code: str
+    evidence_sources: tuple[str, ...]
+    limitations: tuple[str, ...]
+
+
+class CapabilityEvaluator:
+    """Merge version, provider, probe, handler, and auth facts."""
+
+    def __init__(
+        self,
+        *,
+        matrix: DorisFeatureMatrix,
+        bound_handlers: BoundHandlerAvailabilityProvider,
+    ) -> None:
+        self._matrix = matrix
+        self._bound_handlers = bound_handlers
+
+    def evaluate(
+        self,
+        *,
+        snapshot: DorisCapabilitySnapshot,
+        providers: CapabilityProviderSnapshot,
+        domain: DomainDefinition,
+        child: ChildToolDefinition,
+        auth_context: Any | None,
+    ) -> Availability:
+        detected_versions = _detected_versions(snapshot)
+        if not self._bound_handlers.is_bound(domain.name, child.name):
+            return Availability(
+                status=AvailabilityStatus.UNKNOWN,
+                callable=False,
+                reason_code="HANDLER_NOT_BOUND",
+                detected_versions=detected_versions,
+                evidence_sources=(
+                    "catalog_contract",
+                    "handler_registry",
+                ),
+            )
+
+        feature = self._matrix.get_feature(domain.name, child.name)
+        if (
+            snapshot.mixed_versions
+            and feature.version_scope
+            not in {
+                CapabilityVersionScope.MASTER_FE,
+                CapabilityVersionScope.PROVIDER_WITH_MASTER_FE_BASELINE,
+            }
+        ):
+            return Availability(
+                status=AvailabilityStatus.UNAVAILABLE,
+                callable=False,
+                reason_code="MIXED_DORIS_VERSIONS",
+                detected_versions=detected_versions,
+                evidence_sources=(
+                    "version_probe",
+                    "show_frontends",
+                    "show_backends",
+                ),
+                limitations=(
+                    "The required Doris component versions are mixed.",
+                ),
+            )
+
+        failures: list[_CandidateFailure] = []
+        for variant in child.support_contract.variants:
+            version_result = self._matrix.evaluate(
+                domain=domain.name,
+                child_name=child.name,
+                versions=snapshot.version_vector,
+                variant_name=variant.name,
+            )
+            if not version_result.compatible:
+                failures.append(
+                    _CandidateFailure(
+                        status=(
+                            AvailabilityStatus.UNKNOWN
+                            if version_result.reason_code
+                            == "DORIS_VERSION_UNKNOWN"
+                            else AvailabilityStatus.UNAVAILABLE
+                        ),
+                        reason_code=version_result.reason_code,
+                        evidence_sources=_normalized_source_ids(
+                            version_result.source_ids
+                        ),
+                        limitations=(),
+                    )
+                )
+                continue
+
+            candidate = self._evaluate_runtime_requirements(
+                snapshot=snapshot,
+                providers=providers,
+                variant=variant,
+                version_sources=_normalized_source_ids(
+                    version_result.source_ids
+                ),
+            )
+            if isinstance(candidate, _CandidateFailure):
+                failures.append(candidate)
+                continue
+
+            degraded, evidence_sources, limitations = candidate
+            if not authorized_child_execution(auth_context, domain, child):
+                return Availability(
+                    status=AvailabilityStatus.UNAVAILABLE,
+                    callable=False,
+                    reason_code="CHILD_CALL_PERMISSION_DENIED",
+                    detected_versions=detected_versions,
+                    evidence_sources=_ordered_unique(
+                        (*evidence_sources, "authorization_policy")
+                    ),
+                    limitations=limitations,
+                )
+
+            if (
+                version_result.certification_status
+                is not VersionCertificationStatus.CERTIFIED
+            ):
+                limitations = _ordered_unique(
+                    (
+                        *limitations,
+                        "The observed Doris patch is not certified by this project.",
+                    )
+                )
+            if snapshot.stale:
+                degraded = True
+                limitations = _ordered_unique(
+                    (
+                        *limitations,
+                        "The capability snapshot is stale.",
+                    )
+                )
+            return Availability(
+                status=(
+                    AvailabilityStatus.DEGRADED
+                    if degraded
+                    else AvailabilityStatus.AVAILABLE
+                ),
+                callable=True,
+                reason_code=(
+                    "CAPABILITY_VERIFIED_DEGRADED"
+                    if degraded
+                    else "CAPABILITY_VERIFIED"
+                ),
+                detected_versions=detected_versions,
+                active_variant=variant.name,
+                evidence_sources=evidence_sources,
+                limitations=limitations,
+            )
+
+        failure = _select_failure(failures)
+        return Availability(
+            status=failure.status,
+            callable=False,
+            reason_code=failure.reason_code,
+            detected_versions=detected_versions,
+            evidence_sources=failure.evidence_sources,
+            limitations=failure.limitations,
+        )
+
+    def _evaluate_runtime_requirements(
+        self,
+        *,
+        snapshot: DorisCapabilitySnapshot,
+        providers: CapabilityProviderSnapshot,
+        variant: CapabilityVariant,
+        version_sources: tuple[str, ...],
+    ) -> (
+        tuple[bool, tuple[str, ...], tuple[str, ...]]
+        | _CandidateFailure
+    ):
+        evidence_sources = list(version_sources)
+        limitations: list[str] = []
+        degraded = False
+
+        if variant.deployment_modes:
+            if snapshot.deployment_mode == "unknown":
+                return _CandidateFailure(
+                    status=AvailabilityStatus.UNKNOWN,
+                    reason_code="DEPLOYMENT_MODE_UNKNOWN",
+                    evidence_sources=tuple(version_sources),
+                    limitations=(),
+                )
+            if snapshot.deployment_mode not in variant.deployment_modes:
+                return _CandidateFailure(
+                    status=AvailabilityStatus.UNAVAILABLE,
+                    reason_code="DEPLOYMENT_MODE_NOT_SUPPORTED",
+                    evidence_sources=tuple(version_sources),
+                    limitations=(),
+                )
+
+        for provider_id in variant.required_providers:
+            provider = providers.providers.get(provider_id)
+            if provider is None or (
+                provider.status is CapabilityProbeStatus.MISCONFIGURED
+            ):
+                return _CandidateFailure(
+                    status=AvailabilityStatus.MISCONFIGURED,
+                    reason_code="PROVIDER_NOT_CONFIGURED",
+                    evidence_sources=_ordered_unique(
+                        (*version_sources, "provider_registry")
+                    ),
+                    limitations=(),
+                )
+            evidence_sources.extend(provider.evidence_sources)
+            evidence_sources.append(provider_id)
+            if provider.status is CapabilityProbeStatus.UNSUPPORTED:
+                return _CandidateFailure(
+                    status=AvailabilityStatus.UNAVAILABLE,
+                    reason_code=provider.reason_code,
+                    evidence_sources=_ordered_unique(evidence_sources),
+                    limitations=(),
+                )
+            if provider.status is CapabilityProbeStatus.UNKNOWN:
+                return _CandidateFailure(
+                    status=AvailabilityStatus.UNKNOWN,
+                    reason_code=provider.reason_code,
+                    evidence_sources=_ordered_unique(evidence_sources),
+                    limitations=(),
+                )
+            if provider.status is CapabilityProbeStatus.DEGRADED:
+                degraded = True
+                limitations.append(
+                    f"Provider {provider_id} is degraded."
+                )
+
+        requirement_ids = _ordered_unique(
+            (
+                *variant.required_features,
+                *variant.required_system_objects,
+                *variant.required_endpoints,
+                *variant.required_probes,
+            )
+        )
+        for requirement_id in requirement_ids:
+            probe = snapshot.probe(requirement_id)
+            if probe is None:
+                return _CandidateFailure(
+                    status=AvailabilityStatus.UNKNOWN,
+                    reason_code="CAPABILITY_PROBE_PENDING",
+                    evidence_sources=_ordered_unique(
+                        (*evidence_sources, "runtime_probe")
+                    ),
+                    limitations=(),
+                )
+            evidence_sources.extend(probe.evidence_sources)
+            evidence_sources.append(probe.probe_id)
+            if probe.status is CapabilityProbeStatus.MISCONFIGURED:
+                return _CandidateFailure(
+                    status=AvailabilityStatus.MISCONFIGURED,
+                    reason_code=probe.reason_code,
+                    evidence_sources=_ordered_unique(evidence_sources),
+                    limitations=(),
+                )
+            if probe.status is CapabilityProbeStatus.UNSUPPORTED:
+                return _CandidateFailure(
+                    status=AvailabilityStatus.UNAVAILABLE,
+                    reason_code=probe.reason_code,
+                    evidence_sources=_ordered_unique(evidence_sources),
+                    limitations=(),
+                )
+            if probe.status is CapabilityProbeStatus.UNKNOWN:
+                return _CandidateFailure(
+                    status=AvailabilityStatus.UNKNOWN,
+                    reason_code=probe.reason_code,
+                    evidence_sources=_ordered_unique(evidence_sources),
+                    limitations=(),
+                )
+            if probe.status is CapabilityProbeStatus.DEGRADED:
+                degraded = True
+                limitations.append(
+                    f"Probe {requirement_id} is degraded."
+                )
+
+        if degraded and not variant.callable_when_degraded:
+            return _CandidateFailure(
+                status=AvailabilityStatus.DEGRADED,
+                reason_code="CAPABILITY_DEGRADED",
+                evidence_sources=_ordered_unique(evidence_sources),
+                limitations=_ordered_unique(limitations),
+            )
+        return (
+            degraded,
+            _ordered_unique(evidence_sources),
+            _ordered_unique(limitations),
+        )
+
+
+class CapabilityRegistry:
+    """Route-private snapshot cache implementing Manifest availability."""
+
+    def __init__(
+        self,
+        *,
+        detector: DorisCapabilityDetector,
+        provider_registry: CapabilityProviderRegistry,
+        evaluator: CapabilityEvaluator,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._detector = detector
+        self._provider_registry = provider_registry
+        self._evaluator = evaluator
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self._capability_generation = 1
+        self._base_cache: dict[str, DorisCapabilitySnapshot] = {}
+        self._domain_cache: dict[str, DorisCapabilitySnapshot] = {}
+        self._latest_domain: dict[
+            tuple[str, str],
+            DorisCapabilitySnapshot,
+        ] = {}
+        self._inflight: dict[
+            str,
+            asyncio.Task[DorisCapabilitySnapshot],
+        ] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def capability_generation(self) -> int:
+        return self._capability_generation
+
+    async def availability_for(
+        self,
+        domain: DomainDefinition,
+        child: ChildToolDefinition,
+        auth_context: Any | None,
+    ) -> Availability:
+        providers = self._provider_registry.snapshot()
+        snapshot = await self._ensure_fresh(
+            domain.name,
+            auth_context,
+            providers,
+        )
+        return self._evaluator.evaluate(
+            snapshot=snapshot,
+            providers=providers,
+            domain=domain,
+            child=child,
+            auth_context=auth_context,
+        )
+
+    async def resolve_domain(
+        self,
+        domain: DomainDefinition,
+        children: Sequence[ChildToolDefinition],
+        auth_context: Any | None,
+    ) -> DomainAvailabilityResolution:
+        """Resolve every authorized child against one immutable generation."""
+        providers = self._provider_registry.snapshot()
+        snapshot = await self._ensure_fresh(
+            domain.name,
+            auth_context,
+            providers,
+        )
+        availabilities = MappingProxyType(
+            {
+                child.name: self._evaluator.evaluate(
+                    snapshot=snapshot,
+                    providers=providers,
+                    domain=domain,
+                    child=child,
+                    auth_context=auth_context,
+                )
+                for child in children
+            }
+        )
+        return DomainAvailabilityResolution(
+            availabilities=availabilities,
+            generation_fingerprint=snapshot.generation_fingerprint,
+        )
+
+    async def manifest_generation(
+        self,
+        domain: DomainDefinition,
+        auth_context: Any | None,
+    ) -> str:
+        snapshot = await self.ensure_fresh(domain.name, auth_context)
+        return snapshot.generation_fingerprint
+
+    async def ensure_fresh(
+        self,
+        domain_name: str,
+        auth_context: Any | None,
+    ) -> DorisCapabilitySnapshot:
+        providers = self._provider_registry.snapshot()
+        return await self._ensure_fresh(
+            domain_name,
+            auth_context,
+            providers,
+        )
+
+    async def _ensure_fresh(
+        self,
+        domain_name: str,
+        auth_context: Any | None,
+        providers: CapabilityProviderSnapshot,
+    ) -> DorisCapabilitySnapshot:
+        route = self._safe_route_identity(auth_context)
+        capability_generation = self._capability_generation
+        base_key = self._base_key(
+            route.fingerprint,
+            providers.generation,
+            capability_generation,
+        )
+        base = self._base_cache.get(base_key)
+        now = self._clock()
+        if base is None or now >= base.expires_at:
+            base = await self._singleflight(
+                f"base:{base_key}",
+                lambda: self._refresh_base(
+                    base_key,
+                    base,
+                    auth_context,
+                    providers.generation,
+                    capability_generation,
+                ),
+            )
+
+        domain_key = (
+            f"{base.generation_fingerprint}:{domain_name}"
+        )
+        domain_snapshot = self._domain_cache.get(domain_key)
+        if (
+            domain_snapshot is not None
+            and now < domain_snapshot.expires_at
+        ):
+            return domain_snapshot
+        return await self._singleflight(
+            f"domain:{domain_key}",
+            lambda: self._refresh_domain(
+                domain_key,
+                base,
+                domain_name,
+                auth_context,
+            ),
+        )
+
+    async def invalidate_route(self, route_fingerprint: str) -> None:
+        """Drop one route's private snapshots without affecting other tenants."""
+        async with self._lock:
+            self._base_cache = {
+                key: snapshot
+                for key, snapshot in self._base_cache.items()
+                if snapshot.route.fingerprint != route_fingerprint
+            }
+            self._domain_cache = {
+                key: snapshot
+                for key, snapshot in self._domain_cache.items()
+                if snapshot.route.fingerprint != route_fingerprint
+            }
+            self._latest_domain = {
+                key: snapshot
+                for key, snapshot in self._latest_domain.items()
+                if key[0] != route_fingerprint
+            }
+
+    async def bump_generation(self) -> int:
+        """Invalidate all snapshots after a capability policy change."""
+        async with self._lock:
+            self._capability_generation += 1
+            self._base_cache.clear()
+            self._domain_cache.clear()
+            self._latest_domain.clear()
+            return self._capability_generation
+
+    async def close(self) -> None:
+        async with self._lock:
+            tasks = tuple(self._inflight.values())
+            self._inflight.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _refresh_base(
+        self,
+        requested_key: str,
+        previous: DorisCapabilitySnapshot | None,
+        auth_context: Any | None,
+        provider_generation: str,
+        capability_generation: int,
+    ) -> DorisCapabilitySnapshot:
+        try:
+            snapshot = await self._detector.detect_base(
+                auth_context,
+                capability_generation=capability_generation,
+                provider_generation=provider_generation,
+            )
+        except CapabilityRouteChangedError:
+            now = self._clock()
+            snapshot = _unknown_snapshot(
+                route=self._safe_route_identity(auth_context),
+                capability_generation=capability_generation,
+                provider_generation=provider_generation,
+                now=now,
+            )
+        except CapabilityDetectionError:
+            now = self._clock()
+            if previous is not None and now < previous.stale_until:
+                snapshot = previous.as_stale(
+                    retry_at=now
+                    + timedelta(seconds=_STALE_RETRY_SECONDS)
+                )
+            else:
+                route = self._safe_route_identity(auth_context)
+                snapshot = _unknown_snapshot(
+                    route=route,
+                    capability_generation=capability_generation,
+                    provider_generation=provider_generation,
+                    now=now,
+                )
+
+        actual_key = self._base_key(
+            snapshot.route.fingerprint,
+            provider_generation,
+            snapshot.capability_generation,
+        )
+        if snapshot.capability_generation == self._capability_generation:
+            self._base_cache[actual_key] = snapshot
+        return snapshot
+
+    async def _refresh_domain(
+        self,
+        domain_key: str,
+        base: DorisCapabilitySnapshot,
+        domain_name: str,
+        auth_context: Any | None,
+    ) -> DorisCapabilitySnapshot:
+        previous = self._latest_domain.get(
+            (base.route.fingerprint, domain_name)
+        )
+        try:
+            snapshot = await self._detector.detect_domain(
+                base,
+                domain_name,
+                auth_context,
+            )
+        except CapabilityRouteChangedError:
+            await self.invalidate_route(base.route.fingerprint)
+            return await self.ensure_fresh(domain_name, auth_context)
+        except CapabilityDetectionError:
+            now = self._clock()
+            if (
+                previous is not None
+                and previous.capability_generation
+                == base.capability_generation
+                and previous.provider_generation
+                == base.provider_generation
+                and now < previous.stale_until
+            ):
+                snapshot = previous.as_stale(
+                    retry_at=now
+                    + timedelta(seconds=_STALE_RETRY_SECONDS)
+                )
+            else:
+                retry_at = min(
+                    now + timedelta(seconds=_STALE_RETRY_SECONDS),
+                    base.stale_until,
+                )
+                snapshot = DorisCapabilitySnapshot(
+                    route=base.route,
+                    capability_generation=base.capability_generation,
+                    provider_generation=base.provider_generation,
+                    cluster_fingerprint=base.cluster_fingerprint,
+                    version_vector=base.version_vector,
+                    deployment_mode=base.deployment_mode,
+                    mixed_versions=base.mixed_versions,
+                    probes=base.probes,
+                    probed_domains=frozenset({domain_name}),
+                    created_at=base.created_at,
+                    expires_at=retry_at,
+                    stale_until=base.stale_until,
+                    stale=True,
+                )
+        if snapshot.capability_generation == self._capability_generation:
+            self._domain_cache[domain_key] = snapshot
+            self._latest_domain[
+                (snapshot.route.fingerprint, domain_name)
+            ] = snapshot
+        return snapshot
+
+    async def _singleflight(
+        self,
+        key: str,
+        factory: Callable[
+            [],
+            Coroutine[Any, Any, DorisCapabilitySnapshot],
+        ],
+    ) -> DorisCapabilitySnapshot:
+        async with self._lock:
+            task = self._inflight.get(key)
+            if task is None:
+                task = asyncio.create_task(factory())
+                self._inflight[key] = task
+        try:
+            return await asyncio.shield(task)
+        finally:
+            if task.done():
+                async with self._lock:
+                    if self._inflight.get(key) is task:
+                        self._inflight.pop(key, None)
+
+    def _base_key(
+        self,
+        route_fingerprint: str,
+        provider_generation: str,
+        capability_generation: int,
+    ) -> str:
+        return (
+            f"{route_fingerprint}:"
+            f"{capability_generation}:"
+            f"{provider_generation}"
+        )
+
+    def _safe_route_identity(
+        self,
+        auth_context: Any | None,
+    ) -> DorisRouteIdentity:
+        try:
+            route = self._detector.route_identity(auth_context)
+        except Exception:
+            route = None
+        if isinstance(route, DorisRouteIdentity):
+            return route
+
+        principal_material = "\x1f".join(
+            str(getattr(auth_context, name, "") or "")
+            for name in (
+                "auth_method",
+                "token_id",
+                "user_id",
+                "oauth_token_id",
+                "pool_key",
+            )
+        )
+        fingerprint = hashlib.sha256(
+            principal_material.encode("utf-8")
+        ).hexdigest()
+        return DorisRouteIdentity(
+            route_key="unresolved",
+            generation=0,
+            endpoint_fingerprint=fingerprint,
+            fingerprint=f"unresolved-{fingerprint}",
+        )
+
+
+def _unknown_snapshot(
+    *,
+    route: Any,
+    capability_generation: int,
+    provider_generation: str,
+    now: datetime,
+) -> DorisCapabilitySnapshot:
+    unknown_version = parse_doris_version_comment("")
+    return DorisCapabilitySnapshot(
+        route=route,
+        capability_generation=capability_generation,
+        provider_generation=provider_generation,
+        cluster_fingerprint=route.endpoint_fingerprint,
+        version_vector=DorisClusterVersionVector(
+            master_fe=unknown_version,
+        ),
+        deployment_mode="unknown",
+        mixed_versions=False,
+        probes={
+            "version_probe_completed": CapabilityProbeEvidence(
+                probe_id="version_probe_completed",
+                status=CapabilityProbeStatus.UNKNOWN,
+                reason_code="CAPABILITY_SNAPSHOT_UNAVAILABLE",
+            )
+        },
+        probed_domains=frozenset(),
+        created_at=now,
+        expires_at=now + timedelta(seconds=30),
+        stale_until=now + timedelta(seconds=30),
+    )
+
+
+def _detected_versions(
+    snapshot: DorisCapabilitySnapshot,
+) -> dict[str, tuple[str, ...]]:
+    def values(versions: tuple[Any, ...]) -> tuple[str, ...]:
+        return tuple(
+            dict.fromkeys(
+                value
+                for version in versions
+                if (value := version.normalized or version.raw)
+            )
+        )
+
+    detected: dict[str, tuple[str, ...]] = {}
+    master = values((snapshot.version_vector.master_fe,))
+    followers = values(snapshot.version_vector.follower_fes)
+    backends = values(snapshot.version_vector.backends)
+    if master:
+        detected["master_fe"] = master
+    if followers:
+        detected["follower_fe"] = followers
+    if backends:
+        detected["be"] = backends
+    return detected
+
+
+def _ordered_unique(values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+def _normalized_source_ids(values: tuple[str, ...]) -> tuple[str, ...]:
+    return _ordered_unique([value.lower() for value in values])
+
+
+def _select_failure(
+    failures: list[_CandidateFailure],
+) -> _CandidateFailure:
+    if not failures:
+        return _CandidateFailure(
+            status=AvailabilityStatus.UNKNOWN,
+            reason_code="CAPABILITY_SNAPSHOT_UNAVAILABLE",
+            evidence_sources=("catalog_contract",),
+            limitations=(),
+        )
+    priority = {
+        AvailabilityStatus.MISCONFIGURED: 4,
+        AvailabilityStatus.DEGRADED: 3,
+        AvailabilityStatus.UNKNOWN: 2,
+        AvailabilityStatus.UNAVAILABLE: 1,
+        AvailabilityStatus.AVAILABLE: 0,
+    }
+    return max(failures, key=lambda failure: priority[failure.status])
+
+
+__all__ = [
+    "CapabilityEvaluator",
+    "CapabilityProviderEvidence",
+    "CapabilityProviderRegistry",
+    "CapabilityProviderSnapshot",
+    "CapabilityRegistry",
+]

--- a/doris_mcp_server/tools/domain_catalog.py
+++ b/doris_mcp_server/tools/domain_catalog.py
@@ -1956,12 +1956,18 @@ DORIS_DOMAIN_CATALOG = DorisDomainCatalog(
     domains=DOMAIN_DEFINITIONS,
     legacy_migrations=LEGACY_TOOL_MIGRATIONS,
 )
+FORMAL_CHILD_FEATURE_IDS = tuple(
+    f"{domain.name}.{child.name}"
+    for domain in DORIS_DOMAIN_CATALOG.domains
+    for child in domain.children
+)
 
 
 __all__ = [
     "CURRENT_FLAT_TOOL_NAMES",
     "DOMAIN_DEFINITIONS",
     "DORIS_DOMAIN_CATALOG",
+    "FORMAL_CHILD_FEATURE_IDS",
     "LEGACY_TOOL_MIGRATIONS",
     "DomainCatalogDomainSummary",
     "DomainCatalogError",

--- a/doris_mcp_server/tools/domain_dispatcher.py
+++ b/doris_mcp_server/tools/domain_dispatcher.py
@@ -160,6 +160,15 @@ class BoundHandlerAvailabilityProvider:
         self._catalog = catalog or domain_catalog_module.DORIS_DOMAIN_CATALOG
         self._bindings = _build_bindings(owner, self._catalog)
 
+    @property
+    def bound_feature_ids(self) -> frozenset[str]:
+        """Return the exact formal features backed by production handlers."""
+        return frozenset(self._bindings)
+
+    def is_bound(self, domain_name: str, child_name: str) -> bool:
+        """Return whether one formal child has a production handler."""
+        return f"{domain_name}.{child_name}" in self._bindings
+
     async def availability_for(
         self,
         domain: DomainDefinition,

--- a/doris_mcp_server/tools/domain_manifest.py
+++ b/doris_mcp_server/tools/domain_manifest.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Protocol
 
@@ -211,6 +212,14 @@ class DomainAvailabilityProvider(Protocol):
         """Return authoritative availability for a single child."""
 
 
+@dataclass(frozen=True, slots=True)
+class DomainAvailabilityResolution:
+    """One coherent capability generation for a domain manifest."""
+
+    availabilities: Mapping[str, Availability]
+    generation_fingerprint: str = ""
+
+
 class PendingCapabilityProvider:
     """Fail-closed provider used until runtime capability snapshots are enabled."""
 
@@ -245,14 +254,20 @@ def authorized_child_discovery(
     domain: DomainDefinition,
     child: ChildToolDefinition,
 ) -> bool:
-    """Apply explicit child grants without changing legacy local-session access."""
-    del domain
+    """Require exact OAuth discovery grants and preserve local compatibility."""
     if auth_context is None:
         return True
 
+    auth_method = str(getattr(auth_context, "auth_method", ""))
+    is_oauth = auth_method in {"external_oauth", "doris_oauth"}
+    collection_names = (
+        ("oauth_scopes",)
+        if is_oauth
+        else ("permissions", "oauth_scopes")
+    )
     controls = {
         str(value)
-        for collection_name in ("permissions", "oauth_scopes")
+        for collection_name in collection_names
         for value in (getattr(auth_context, collection_name, None) or ())
     }
     child_controls = {
@@ -260,8 +275,32 @@ def authorized_child_discovery(
         for value in controls
         if value.startswith(("child:call:", "child:discover:"))
     }
-    if not child_controls:
+    if not is_oauth and not child_controls:
         return True
+
+    if auth_method == "doris_oauth":
+        feature_id = f"{domain.name}.{child.name}"
+        if not bool(
+            getattr(
+                auth_context,
+                "doris_oauth_child_tools_enabled",
+                False,
+            )
+        ):
+            return False
+        allowlist = {
+            str(value)
+            for value in (
+                getattr(
+                    auth_context,
+                    "doris_oauth_child_tool_allowlist",
+                    (),
+                )
+                or ()
+            )
+        }
+        if feature_id not in allowlist:
+            return False
 
     discover_policy = child.authorization_policy.replace(
         "child:call:",
@@ -280,20 +319,50 @@ def authorized_child_execution(
     child: ChildToolDefinition,
 ) -> bool:
     """Require an exact child call grant on OAuth execution paths."""
-    del domain
     if auth_context is None:
         return True
 
+    auth_method = str(getattr(auth_context, "auth_method", ""))
+    is_oauth = auth_method in {"external_oauth", "doris_oauth"}
+    collection_names = (
+        ("oauth_scopes",)
+        if is_oauth
+        else ("permissions", "oauth_scopes")
+    )
     controls = {
         str(value)
-        for collection_name in ("permissions", "oauth_scopes")
+        for collection_name in collection_names
         for value in (getattr(auth_context, collection_name, None) or ())
     }
+
+    if auth_method == "doris_oauth":
+        feature_id = f"{domain.name}.{child.name}"
+        if not bool(
+            getattr(
+                auth_context,
+                "doris_oauth_child_tools_enabled",
+                False,
+            )
+        ):
+            return False
+        allowlist = {
+            str(value)
+            for value in (
+                getattr(
+                    auth_context,
+                    "doris_oauth_child_tool_allowlist",
+                    (),
+                )
+                or ()
+            )
+        }
+        if feature_id not in allowlist:
+            return False
+
     if child.authorization_policy in controls:
         return True
 
-    auth_method = str(getattr(auth_context, "auth_method", ""))
-    if auth_method in {"external_oauth", "doris_oauth"}:
+    if is_oauth:
         return False
 
     child_controls = {
@@ -424,10 +493,47 @@ class DomainManifestService:
         auth_context: Any | None,
     ) -> DiscoveryEnvelope:
         """Build the current authorized manifest in stable catalog order."""
+        authorized_children = tuple(
+            child
+            for child in domain.children
+            if self._discovery_policy(auth_context, domain, child)
+        )
+        batch_resolver = getattr(
+            self._availability_provider,
+            "resolve_domain",
+            None,
+        )
+        if callable(batch_resolver):
+            resolution = await batch_resolver(
+                domain,
+                authorized_children,
+                auth_context,
+            )
+            if not isinstance(
+                resolution,
+                DomainAvailabilityResolution,
+            ):
+                raise TypeError(
+                    "domain availability resolver returned an invalid result"
+                )
+            batch_entries = [
+                _render_child(
+                    child,
+                    resolution.availabilities[child.name],
+                )
+                for child in authorized_children
+            ]
+            return _build_manifest(
+                domain,
+                tuple(batch_entries),
+                generated_at=self._clock(),
+                generation_fingerprint=(
+                    resolution.generation_fingerprint
+                ),
+            )
+
         entries: list[ChildManifestEntry] = []
-        for child in domain.children:
-            if not self._discovery_policy(auth_context, domain, child):
-                continue
+        for child in authorized_children:
             availability = await self._availability_provider.availability_for(
                 domain,
                 child,
@@ -435,10 +541,22 @@ class DomainManifestService:
             )
             entries.append(_render_child(child, availability))
 
+        generation_fingerprint = ""
+        resolve_generation = getattr(
+            self._availability_provider,
+            "manifest_generation",
+            None,
+        )
+        if callable(resolve_generation):
+            resolved = await resolve_generation(domain, auth_context)
+            if isinstance(resolved, str):
+                generation_fingerprint = resolved
+
         return _build_manifest(
             domain,
             tuple(entries),
             generated_at=self._clock(),
+            generation_fingerprint=generation_fingerprint,
         )
 
     def validate_default_manifest_budgets(self) -> None:
@@ -581,8 +699,13 @@ def _build_manifest(
     entries: tuple[ChildManifestEntry, ...],
     *,
     generated_at: datetime,
+    generation_fingerprint: str = "",
 ) -> DiscoveryEnvelope:
-    version = _manifest_version(domain, entries)
+    version = _manifest_version(
+        domain,
+        entries,
+        generation_fingerprint=generation_fingerprint,
+    )
     envelope = DiscoveryEnvelope(
         mode="manifest",
         domain=domain.name,
@@ -602,11 +725,14 @@ def _build_manifest(
 def _manifest_version(
     domain: DomainDefinition,
     entries: Sequence[ChildManifestEntry],
+    *,
+    generation_fingerprint: str = "",
 ) -> str:
     payload = {
         "format_version": MANIFEST_FORMAT_VERSION,
         "domain_contract": domain.to_wire(),
         "children": [entry.to_wire() for entry in entries],
+        "capability_generation": generation_fingerprint,
     }
     canonical = json.dumps(
         payload,
@@ -680,6 +806,7 @@ __all__ = [
     "MAX_SCHEMA_ENUM_VALUES",
     "ChildDiscoveryPolicy",
     "DomainAvailabilityProvider",
+    "DomainAvailabilityResolution",
     "DomainManifestBudgetError",
     "DomainManifestError",
     "DomainManifestManagerMixin",

--- a/doris_mcp_server/tools/doris_feature_matrix.py
+++ b/doris_mcp_server/tools/doris_feature_matrix.py
@@ -958,7 +958,7 @@ FEATURE_DEFINITIONS = (
     _feature(
         "doris_query",
         "execute_query",
-        A,
+        M,
         _variant(
             "mysql_read_only",
             probes=("read_only_sql_guard_ready", "query_execution_readable"),
@@ -967,7 +967,7 @@ FEATURE_DEFINITIONS = (
     _feature(
         "doris_query",
         "explain_query",
-        A,
+        M,
         _variant("base_explain", probes=("explain_output_readable",)),
         _variant(
             "search_plan_facets",
@@ -980,7 +980,7 @@ FEATURE_DEFINITIONS = (
     _feature(
         "doris_query",
         "get_query_profile",
-        A,
+        M,
         _variant(
             "query_profile",
             endpoints=("fe_profile_api",),

--- a/doris_mcp_server/tools/tools_manager.py
+++ b/doris_mcp_server/tools/tools_manager.py
@@ -41,6 +41,12 @@ from ..utils.query_executor import DorisQueryExecutor
 from ..utils.schema_extractor import MetadataExtractor
 from ..utils.security import get_current_auth_context
 from ..utils.security_analytics_tools import SecurityAnalyticsTools
+from .capability_detector import DorisCapabilityDetector
+from .capability_registry import (
+    CapabilityEvaluator,
+    CapabilityProviderRegistry,
+    CapabilityRegistry,
+)
 from .domain_catalog import CURRENT_FLAT_TOOL_NAMES
 from .domain_dispatcher import (
     BoundHandlerAvailabilityProvider,
@@ -54,6 +60,7 @@ from .domain_manifest import (
     DomainManifestManagerMixin,
     DomainManifestService,
 )
+from .doris_feature_matrix import DORIS_FEATURE_MATRIX
 from .tool_provider import CustomToolProvider, ToolProviderRuntime
 from .tool_registry import ToolRegistryError
 
@@ -95,8 +102,42 @@ class DorisToolsManager(DomainManifestManagerMixin):
 
         # Initialize ADBC query tools
         self.adbc_query_tools = DorisADBCQueryTools(connection_manager)
+        self._capability_registry: CapabilityRegistry | None = None
         if domain_availability_provider is None:
-            domain_availability_provider = BoundHandlerAvailabilityProvider(self)
+            bound_handlers = BoundHandlerAvailabilityProvider(self)
+            capability_config = getattr(config, "capability", None)
+            detector = DorisCapabilityDetector(
+                connection_manager,
+                probe_timeout_seconds=getattr(
+                    capability_config,
+                    "probe_timeout_seconds",
+                    5,
+                ),
+                snapshot_ttl_seconds=getattr(
+                    capability_config,
+                    "snapshot_ttl_seconds",
+                    300,
+                ),
+                stale_grace_seconds=getattr(
+                    capability_config,
+                    "stale_grace_seconds",
+                    900,
+                ),
+            )
+            provider_registry = CapabilityProviderRegistry.from_runtime(
+                matrix=DORIS_FEATURE_MATRIX,
+                bound_handlers=bound_handlers,
+                config=config,
+            )
+            self._capability_registry = CapabilityRegistry(
+                detector=detector,
+                provider_registry=provider_registry,
+                evaluator=CapabilityEvaluator(
+                    matrix=DORIS_FEATURE_MATRIX,
+                    bound_handlers=bound_handlers,
+                ),
+            )
+            domain_availability_provider = self._capability_registry
         self._domain_manifest_service = DomainManifestService(
             availability_provider=domain_availability_provider,
         )
@@ -135,6 +176,8 @@ class DorisToolsManager(DomainManifestManagerMixin):
 
     async def close(self) -> None:
         """Stop runtime resources owned by the tools manager."""
+        if self._capability_registry is not None:
+            await self._capability_registry.close()
         await self._tool_provider_runtime.close()
         await self.query_executor.close()
 

--- a/doris_mcp_server/utils/config.py
+++ b/doris_mcp_server/utils/config.py
@@ -70,6 +70,14 @@ DORIS_OAUTH_METADATA_TOOL_ALLOWLIST_DEFAULT = list(
     DORIS_OAUTH_METADATA_TOOL_NAMES
 )
 
+
+def _default_doris_oauth_child_tool_allowlist() -> list[str]:
+    """Load formal child feature IDs without creating a config import cycle."""
+    from ..tools.domain_catalog import FORMAL_CHILD_FEATURE_IDS
+
+    return list(FORMAL_CHILD_FEATURE_IDS)
+
+
 EXTERNAL_OAUTH_SECURITY_LEVELS = frozenset(
     {"public", "internal", "confidential", "secret"}
 )
@@ -417,6 +425,10 @@ class SecurityConfig:
     enable_doris_oauth_auth: bool = False  # Enable Doris-backed OAuth (default: disabled)
     allow_unauthenticated_non_loopback: bool = False
     doris_oauth_base_url: str = ""  # Public base URL for future Doris OAuth metadata
+    doris_oauth_child_tools_enabled: bool = False
+    doris_oauth_child_tool_allowlist: list[str] = field(
+        default_factory=_default_doris_oauth_child_tool_allowlist
+    )
     doris_oauth_db_tools_enabled: bool = False
     doris_oauth_db_tool_allowlist: list[str] = field(
         default_factory=lambda: list(DORIS_OAUTH_METADATA_TOOL_ALLOWLIST_DEFAULT)
@@ -845,6 +857,15 @@ class ToolExposureConfig:
 
 
 @dataclass
+class CapabilityConfig:
+    """Private Doris capability snapshot controls."""
+
+    snapshot_ttl_seconds: int = 300
+    probe_timeout_seconds: int = 5
+    stale_grace_seconds: int = 900
+
+
+@dataclass
 class DorisConfig:
     """Doris MCP Server complete configuration"""
 
@@ -879,6 +900,9 @@ class DorisConfig:
     adbc: ADBCConfig = field(default_factory=ADBCConfig)
     tool_exposure: ToolExposureConfig = field(
         default_factory=ToolExposureConfig
+    )
+    capability: CapabilityConfig = field(
+        default_factory=CapabilityConfig
     )
 
     # Custom configuration
@@ -1164,6 +1188,17 @@ class DorisConfig:
         if "DORIS_OAUTH_BASE_URL" in os.environ:
             config.security.doris_oauth_base_url = os.getenv("DORIS_OAUTH_BASE_URL", "").strip()
             _mark_source(config, "doris_oauth_base_url", "env")
+        if "DORIS_OAUTH_CHILD_TOOLS_ENABLED" in os.environ:
+            config.security.doris_oauth_child_tools_enabled = _str_to_bool(
+                os.getenv("DORIS_OAUTH_CHILD_TOOLS_ENABLED")
+            )
+            _mark_source(config, "doris_oauth_child_tools_enabled", "env")
+        if "DORIS_OAUTH_CHILD_TOOL_ALLOWLIST" in os.environ:
+            config.security.doris_oauth_child_tool_allowlist = _env_csv(
+                "DORIS_OAUTH_CHILD_TOOL_ALLOWLIST",
+                config.security.doris_oauth_child_tool_allowlist,
+            )
+            _mark_source(config, "doris_oauth_child_tool_allowlist", "env")
         if "DORIS_OAUTH_DB_TOOLS_ENABLED" in os.environ:
             config.security.doris_oauth_db_tools_enabled = _str_to_bool(os.getenv("DORIS_OAUTH_DB_TOOLS_ENABLED"))
             _mark_source(config, "doris_oauth_db_tools_enabled", "env")
@@ -1522,6 +1557,24 @@ class DorisConfig:
                 config.tool_exposure.mode,
             ).strip()
             _mark_source(config, "mcp_tool_exposure_mode", "env")
+        if "CAPABILITY_SNAPSHOT_TTL_SECONDS" in os.environ:
+            config.capability.snapshot_ttl_seconds = _env_int(
+                "CAPABILITY_SNAPSHOT_TTL_SECONDS",
+                config.capability.snapshot_ttl_seconds,
+            )
+            _mark_source(config, "capability_snapshot_ttl_seconds", "env")
+        if "CAPABILITY_PROBE_TIMEOUT_SECONDS" in os.environ:
+            config.capability.probe_timeout_seconds = _env_int(
+                "CAPABILITY_PROBE_TIMEOUT_SECONDS",
+                config.capability.probe_timeout_seconds,
+            )
+            _mark_source(config, "capability_probe_timeout_seconds", "env")
+        if "CAPABILITY_STALE_GRACE_SECONDS" in os.environ:
+            config.capability.stale_grace_seconds = _env_int(
+                "CAPABILITY_STALE_GRACE_SECONDS",
+                config.capability.stale_grace_seconds,
+            )
+            _mark_source(config, "capability_stale_grace_seconds", "env")
         if "MCP_STATE_HANDLE_SECRET" in os.environ:
             config.mcp_state_handle_secret = os.getenv(
                 "MCP_STATE_HANDLE_SECRET",
@@ -1628,6 +1681,12 @@ class DorisConfig:
                 "config_file",
             )
 
+        if "capability" in config_data:
+            capability_config = config_data["capability"]
+            for key, value in capability_config.items():
+                if hasattr(config.capability, key):
+                    setattr(config.capability, key, value)
+
         # Custom configuration
         config.custom_config = config_data.get("custom", {})
 
@@ -1649,6 +1708,17 @@ class DorisConfig:
             "temp_files_dir": self.temp_files_dir,
             "tool_exposure": {
                 "mode": self.tool_exposure.mode,
+            },
+            "capability": {
+                "snapshot_ttl_seconds": (
+                    self.capability.snapshot_ttl_seconds
+                ),
+                "probe_timeout_seconds": (
+                    self.capability.probe_timeout_seconds
+                ),
+                "stale_grace_seconds": (
+                    self.capability.stale_grace_seconds
+                ),
             },
             "database": {
                 "host": self.database.host,
@@ -1698,12 +1768,8 @@ class DorisConfig:
                 "enable_doris_oauth_auth": self.security.enable_doris_oauth_auth,
                 "allow_unauthenticated_non_loopback": self.security.allow_unauthenticated_non_loopback,
                 "doris_oauth_base_url": self.security.doris_oauth_base_url,
-                "doris_oauth_db_tools_enabled": self.security.doris_oauth_db_tools_enabled,
-                "doris_oauth_db_tool_allowlist": self.security.doris_oauth_db_tool_allowlist,
-                "doris_oauth_query_tools_enabled": self.security.doris_oauth_query_tools_enabled,
-                "doris_oauth_query_tool_allowlist": self.security.doris_oauth_query_tool_allowlist,
-                "doris_oauth_explain_tools_enabled": self.security.doris_oauth_explain_tools_enabled,
-                "doris_oauth_explain_tool_allowlist": self.security.doris_oauth_explain_tool_allowlist,
+                "doris_oauth_child_tools_enabled": self.security.doris_oauth_child_tools_enabled,
+                "doris_oauth_child_tool_allowlist": self.security.doris_oauth_child_tool_allowlist,
                 "doris_oauth_access_token_expire_seconds": self.security.doris_oauth_access_token_expire_seconds,
                 "doris_oauth_refresh_token_expire_seconds": self.security.doris_oauth_refresh_token_expire_seconds,
                 "doris_oauth_auth_code_expire_seconds": self.security.doris_oauth_auth_code_expire_seconds,
@@ -1883,6 +1949,18 @@ class DorisConfig:
             errors.append(
                 "MCP tool exposure mode must be hierarchical or flat"
             )
+        if not 1 <= self.capability.snapshot_ttl_seconds <= 86400:
+            errors.append(
+                "Capability snapshot TTL must be in the range 1-86400 seconds"
+            )
+        if not 1 <= self.capability.probe_timeout_seconds <= 60:
+            errors.append(
+                "Capability probe timeout must be in the range 1-60 seconds"
+            )
+        if not 0 <= self.capability.stale_grace_seconds <= 86400:
+            errors.append(
+                "Capability stale grace must be in the range 0-86400 seconds"
+            )
 
         raw_tool_providers: Any = self.mcp_tool_providers
         if not isinstance(raw_tool_providers, list):
@@ -2058,6 +2136,17 @@ class DorisConfig:
             "tool_exposure": {
                 "mode": self.tool_exposure.mode,
             },
+            "capability": {
+                "snapshot_ttl_seconds": (
+                    self.capability.snapshot_ttl_seconds
+                ),
+                "probe_timeout_seconds": (
+                    self.capability.probe_timeout_seconds
+                ),
+                "stale_grace_seconds": (
+                    self.capability.stale_grace_seconds
+                ),
+            },
         }
 
 
@@ -2206,8 +2295,47 @@ def normalize_effective_auth_config(
     enable_external_oauth_auth = _str_to_bool(inputs.enable_external_oauth_auth.value)
     enable_doris_oauth_auth = _str_to_bool(inputs.enable_doris_oauth_auth.value)
 
+    explicit_sources = getattr(config, "_explicit_sources", {})
+    legacy_doris_oauth_fields = (
+        "doris_oauth_db_tools_enabled",
+        "doris_oauth_db_tool_allowlist",
+        "doris_oauth_query_tools_enabled",
+        "doris_oauth_query_tool_allowlist",
+        "doris_oauth_explain_tools_enabled",
+        "doris_oauth_explain_tool_allowlist",
+    )
+    configured_legacy_fields = [
+        field_name
+        for field_name in legacy_doris_oauth_fields
+        if explicit_sources.get(field_name, "default") != "default"
+    ]
+    if configured_legacy_fields:
+        raise AuthConfigError(
+            "Legacy Doris OAuth tool-bucket settings are not supported. "
+            "Use DORIS_OAUTH_CHILD_TOOLS_ENABLED and "
+            "DORIS_OAUTH_CHILD_TOOL_ALLOWLIST with formal domain.child "
+            "feature IDs."
+        )
+
     config.security.doris_oauth_db_tool_allowlist = _validate_doris_oauth_metadata_tool_allowlist(
         config.security.doris_oauth_db_tool_allowlist
+    )
+    child_allowlist = _coerce_csv_config(
+        config.security.doris_oauth_child_tool_allowlist
+    )
+    from ..tools.domain_catalog import FORMAL_CHILD_FEATURE_IDS
+
+    invalid_child_features = set(child_allowlist) - set(
+        FORMAL_CHILD_FEATURE_IDS
+    )
+    if invalid_child_features:
+        invalid_list = ", ".join(sorted(invalid_child_features))
+        raise AuthConfigError(
+            "DORIS_OAUTH_CHILD_TOOL_ALLOWLIST can only contain formal "
+            f"domain.child feature IDs; invalid entries: {invalid_list}"
+        )
+    config.security.doris_oauth_child_tool_allowlist = list(
+        dict.fromkeys(child_allowlist)
     )
     query_allowlist = _coerce_csv_config(config.security.doris_oauth_query_tool_allowlist)
     invalid_query_tools = set(query_allowlist) - DORIS_OAUTH_QUERY_TOOL_SET

--- a/doris_mcp_server/utils/db.py
+++ b/doris_mcp_server/utils/db.py
@@ -120,6 +120,16 @@ class DorisUserPoolMeta:
     generation: int = 0
 
 
+@dataclass(frozen=True, slots=True)
+class DorisRouteIdentity:
+    """Secret-free identity for one routed Doris connection pool."""
+
+    route_key: str
+    generation: int
+    endpoint_fingerprint: str
+    fingerprint: str
+
+
 class DorisUserPoolMissingError(RuntimeError):
     """Raised when a Doris OAuth request has no local Doris user pool."""
 
@@ -2344,6 +2354,66 @@ class DorisConnectionManager:
                 return token_config
         return self.config.database
 
+    def get_route_identity(
+        self,
+        auth_context: AuthContext | None = None,
+    ) -> DorisRouteIdentity:
+        """Return the current routed pool identity without exposing credentials."""
+        effective_context = self._get_effective_auth_context(auth_context)
+        route_key = "global"
+        generation = self._global_pool_generation
+
+        if (
+            effective_context is not None
+            and effective_context.auth_method == "doris_oauth"
+        ):
+            doris_user = self._validate_doris_user(
+                effective_context.doris_user
+            )
+            route_key = self._doris_user_route_key(doris_user)
+            meta = self.doris_user_pool_meta.get(doris_user)
+            generation = meta.generation if meta is not None else 0
+        elif effective_context is not None and effective_context.token:
+            token_hash = self._get_token_hash(effective_context.token)
+            route_key = f"static_token:{token_hash}"
+            generation = self._token_pool_generations.get(token_hash, 0)
+
+        database_config = self.get_database_config_for_auth_context(
+            effective_context
+        )
+
+        def config_value(name: str, default: Any = "") -> Any:
+            if isinstance(database_config, Mapping):
+                return database_config.get(name, default)
+            return getattr(database_config, name, default)
+
+        hosts = self._ordered_hosts(
+            str(config_value("host", "")),
+            config_value("hosts", ()),
+        )
+        endpoint_material = "\x1f".join(
+            (
+                *hosts,
+                str(config_value("port", "")),
+                str(config_value("user", "")),
+                str(config_value("database", "")),
+            )
+        )
+        endpoint_fingerprint = hashlib.sha256(
+            endpoint_material.encode("utf-8")
+        ).hexdigest()
+        route_material = (
+            f"{route_key}\x1f{generation}\x1f{endpoint_fingerprint}"
+        )
+        return DorisRouteIdentity(
+            route_key=route_key,
+            generation=generation,
+            endpoint_fingerprint=endpoint_fingerprint,
+            fingerprint=hashlib.sha256(
+                route_material.encode("utf-8")
+            ).hexdigest(),
+        )
+
     async def _get_connection_for_auth_context(
         self,
         session_id: str,
@@ -2697,9 +2767,25 @@ class DorisConnectionManager:
         session_id: str,
     ) -> AsyncIterator[DorisConnection]:
         """Get connection context manager - Simplified Strategy"""
+        async with self.get_connection_context_for_auth_context(
+            session_id,
+            self._get_effective_auth_context(),
+        ) as connection:
+            yield connection
+
+    @asynccontextmanager
+    async def get_connection_context_for_auth_context(
+        self,
+        session_id: str,
+        auth_context: AuthContext | None,
+    ) -> AsyncIterator[DorisConnection]:
+        """Acquire and release a connection for an explicit request route."""
         connection = None
         try:
-            connection = await self.get_connection(session_id)
+            connection = await self._get_connection_for_auth_context(
+                session_id,
+                auth_context,
+            )
             yield connection
         finally:
             if connection:

--- a/doris_mcp_server/utils/security.py
+++ b/doris_mcp_server/utils/security.py
@@ -113,6 +113,10 @@ class AuthContext:
     oauth_resource: str = ""
     oauth_audiences: list[str] = field(default_factory=list)
     pool_key: str = ""
+    doris_oauth_child_tools_enabled: bool = False
+    doris_oauth_child_tool_allowlist: tuple[str, ...] = field(
+        default_factory=tuple
+    )
     doris_oauth_db_tools_enabled: bool = False
     doris_oauth_db_tool_allowlist: tuple[str, ...] = field(default_factory=tuple)
     doris_oauth_query_tools_enabled: bool = False

--- a/test/auth/test_doris_oauth_routes.py
+++ b/test/auth/test_doris_oauth_routes.py
@@ -11,10 +11,15 @@ from starlette.applications import Starlette
 
 from doris_mcp_server.auth.doris_oauth_handlers import DorisOAuthHandlers
 from doris_mcp_server.auth.doris_oauth_provider import DorisOAuthProvider
+from doris_mcp_server.auth.doris_oauth_scope_policy import (
+    child_call_scope,
+    child_discovery_scope,
+)
 from doris_mcp_server.auth.doris_oauth_types import (
     ProtectedResourceAuthError,
     TokenEndpointError,
 )
+from doris_mcp_server.tools.domain_catalog import FORMAL_CHILD_FEATURE_IDS
 from doris_mcp_server.utils.auth_credentials import BearerCredentials
 from doris_mcp_server.utils.config import (
     DorisConfig,
@@ -28,18 +33,17 @@ FULL_DORIS_OAUTH_SCOPE_SET = tuple(
             "tool:list",
             "resource:list",
             "resource:read",
-            "tool:call:get_db_list",
-            "tool:call:get_db_table_list",
-            "tool:call:get_table_schema",
-            "tool:call:get_table_comment",
-            "tool:call:get_table_column_comments",
-            "tool:call:get_table_indexes",
-            "tool:call:get_catalog_list",
-            "tool:call:exec_query",
-            "tool:call:get_sql_explain",
+            *(
+                child_call_scope(feature_id)
+                for feature_id in FORMAL_CHILD_FEATURE_IDS
+            ),
         }
     )
 )
+
+CATALOG_DATABASES_FEATURE = "doris_catalog.list_databases"
+QUERY_EXECUTE_FEATURE = "doris_query.execute_query"
+QUERY_EXPLAIN_FEATURE = "doris_query.explain_query"
 
 
 class FakeConnectionManager:
@@ -71,10 +75,8 @@ def _pkce(verifier="verifier-123"):
 
 def _config(
     *,
-    db_tools_enabled=False,
+    child_tools_enabled=False,
     allowlist=None,
-    query_tools_enabled=False,
-    explain_tools_enabled=False,
 ):
     config = DorisConfig()
     config.transport = "http"
@@ -82,11 +84,9 @@ def _config(
     config.security.enable_doris_oauth_auth = True
     _mark_source(config, "enable_doris_oauth_auth", "test")
     config.security.doris_oauth_base_url = "http://localhost:3000"
-    config.security.doris_oauth_db_tools_enabled = db_tools_enabled
+    config.security.doris_oauth_child_tools_enabled = child_tools_enabled
     if allowlist is not None:
-        config.security.doris_oauth_db_tool_allowlist = list(allowlist)
-    config.security.doris_oauth_query_tools_enabled = query_tools_enabled
-    config.security.doris_oauth_explain_tools_enabled = explain_tools_enabled
+        config.security.doris_oauth_child_tool_allowlist = list(allowlist)
     config.security.doris_oauth_access_token_expire_seconds = 900
     config.security.doris_oauth_refresh_token_expire_seconds = 86400
     normalize_effective_auth_config(config, requested_workers=1)
@@ -333,8 +333,11 @@ async def test_register_omitted_and_blank_scope_allow_safe_client_scope_set():
 
 
 @pytest.mark.asyncio
-async def test_register_omitted_scope_client_allowlist_includes_safe_metadata_when_db_gate_true():
-    config = _config(db_tools_enabled=True, allowlist=["get_db_list"])
+async def test_register_omitted_scope_includes_enabled_child_envelope():
+    config = _config(
+        child_tools_enabled=True,
+        allowlist=[CATALOG_DATABASES_FEATURE],
+    )
     _provider, _cm, app = _provider_app(config)
     async with await _client(app) as client:
         response = await client.post(
@@ -343,7 +346,17 @@ async def test_register_omitted_scope_client_allowlist_includes_safe_metadata_wh
         )
 
     assert response.status_code == 201
-    assert response.json()["scope"] == "resource:list resource:read tool:call:get_db_list tool:list"
+    assert response.json()["scope"] == " ".join(
+        sorted(
+            {
+                "resource:list",
+                "resource:read",
+                "tool:list",
+                child_call_scope(CATALOG_DATABASES_FEATURE),
+                child_discovery_scope(CATALOG_DATABASES_FEATURE),
+            }
+        )
+    )
 
 
 @pytest.mark.asyncio
@@ -364,7 +377,7 @@ async def test_register_explicit_unknown_or_forbidden_scope_is_invalid_scope():
 
 
 @pytest.mark.asyncio
-async def test_register_metadata_scope_requires_db_gate():
+async def test_register_child_scope_requires_child_gate():
     _provider, _cm, app = _provider_app()
     async with await _client(app) as client:
         response = await client.post(
@@ -372,7 +385,10 @@ async def test_register_metadata_scope_requires_db_gate():
             json={
                 "application_type": "native",
                 "redirect_uris": ["http://localhost:7777/callback"],
-                "scope": "tool:list tool:call:get_db_list",
+                "scope": (
+                    "tool:list "
+                    "child:call:doris_catalog:list_databases"
+                ),
             },
         )
 
@@ -381,8 +397,11 @@ async def test_register_metadata_scope_requires_db_gate():
 
 
 @pytest.mark.asyncio
-async def test_register_metadata_scope_allowed_when_db_gate_true_and_explicit():
-    config = _config(db_tools_enabled=True, allowlist=["get_db_list"])
+async def test_register_exact_child_scope_allowed_when_gate_is_enabled():
+    config = _config(
+        child_tools_enabled=True,
+        allowlist=[CATALOG_DATABASES_FEATURE],
+    )
     _provider, _cm, app = _provider_app(config)
     async with await _client(app) as client:
         response = await client.post(
@@ -390,12 +409,17 @@ async def test_register_metadata_scope_allowed_when_db_gate_true_and_explicit():
             json={
                 "application_type": "native",
                 "redirect_uris": ["http://localhost:7777/callback"],
-                "scope": "tool:list tool:call:get_db_list",
+                "scope": (
+                    "tool:list "
+                    "child:call:doris_catalog:list_databases"
+                ),
             },
         )
 
     assert response.status_code == 201
-    assert response.json()["scope"] == "tool:call:get_db_list tool:list"
+    assert response.json()["scope"] == (
+        "child:call:doris_catalog:list_databases tool:list"
+    )
 
 
 @pytest.mark.asyncio
@@ -452,10 +476,19 @@ async def test_authorize_can_request_resource_scopes_after_dcr_omits_scope():
     )
 
 
-@pytest.mark.parametrize("scope", ["tool:call:exec_query", "tool:call:get_sql_explain"])
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "child:call:doris_query:execute_query",
+        "child:call:doris_query:explain_query",
+    ],
+)
 @pytest.mark.asyncio
-async def test_register_query_and_explain_scopes_require_their_own_gates(scope):
-    config = _config(db_tools_enabled=True, allowlist=["get_db_list"])
+async def test_register_children_outside_allowlist_is_rejected(scope):
+    config = _config(
+        child_tools_enabled=True,
+        allowlist=[CATALOG_DATABASES_FEATURE],
+    )
     _provider, _cm, app = _provider_app(config)
     async with await _client(app) as client:
         response = await client.post(
@@ -472,12 +505,15 @@ async def test_register_query_and_explain_scopes_require_their_own_gates(scope):
 
 
 @pytest.mark.asyncio
-async def test_register_omitted_scope_client_allowlist_includes_query_and_explain_when_enabled():
+async def test_register_omitted_scope_includes_multiple_enabled_children():
+    feature_ids = (
+        CATALOG_DATABASES_FEATURE,
+        QUERY_EXECUTE_FEATURE,
+        QUERY_EXPLAIN_FEATURE,
+    )
     config = _config(
-        db_tools_enabled=True,
-        allowlist=["get_db_list"],
-        query_tools_enabled=True,
-        explain_tools_enabled=True,
+        child_tools_enabled=True,
+        allowlist=list(feature_ids),
     )
     _provider, _cm, app = _provider_app(config)
     async with await _client(app) as client:
@@ -487,19 +523,31 @@ async def test_register_omitted_scope_client_allowlist_includes_query_and_explai
         )
 
     assert response.status_code == 201
-    assert response.json()["scope"] == (
-        "resource:list resource:read tool:call:exec_query "
-        "tool:call:get_db_list tool:call:get_sql_explain tool:list"
+    assert response.json()["scope"] == " ".join(
+        sorted(
+            {
+                "resource:list",
+                "resource:read",
+                "tool:list",
+                *(child_call_scope(feature_id) for feature_id in feature_ids),
+                *(
+                    child_discovery_scope(feature_id)
+                    for feature_id in feature_ids
+                ),
+            }
+        )
     )
 
 
 @pytest.mark.asyncio
-async def test_register_short_tool_scope_aliases_are_canonicalized_when_enabled():
+async def test_register_legacy_tool_scope_aliases_are_rejected():
     config = _config(
-        db_tools_enabled=True,
-        allowlist=["get_db_list"],
-        query_tools_enabled=True,
-        explain_tools_enabled=True,
+        child_tools_enabled=True,
+        allowlist=[
+            CATALOG_DATABASES_FEATURE,
+            QUERY_EXECUTE_FEATURE,
+            QUERY_EXPLAIN_FEATURE,
+        ],
     )
     _provider, _cm, app = _provider_app(config)
     async with await _client(app) as client:
@@ -512,21 +560,21 @@ async def test_register_short_tool_scope_aliases_are_canonicalized_when_enabled(
             },
         )
 
-    assert response.status_code == 201
-    assert response.json()["scope"] == (
-        "tool:call:exec_query tool:call:get_db_list "
-        "tool:call:get_sql_explain tool:list"
-    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_scope"
 
 
 @pytest.mark.asyncio
 async def test_authorize_omitted_scope_grants_configured_server_allowlist():
+    feature_ids = (
+        CATALOG_DATABASES_FEATURE,
+        QUERY_EXECUTE_FEATURE,
+        QUERY_EXPLAIN_FEATURE,
+    )
     provider, _cm, app = _provider_app(
         _config(
-            db_tools_enabled=True,
-            allowlist=["get_db_list"],
-            query_tools_enabled=True,
-            explain_tools_enabled=True,
+            child_tools_enabled=True,
+            allowlist=list(feature_ids),
         )
     )
     async with await _client(app) as client:
@@ -551,24 +599,28 @@ async def test_authorize_omitted_scope_grants_configured_server_allowlist():
     assert authorize.status_code == 302
     txn_id = parse_qs(urlparse(authorize.headers["location"]).query)["txn_id"][0]
     transaction = provider.get_login_transaction(txn_id)
-    assert transaction.candidate_granted_scopes == (
-        "resource:list",
-        "resource:read",
-        "tool:call:exec_query",
-        "tool:call:get_db_list",
-        "tool:call:get_sql_explain",
-        "tool:list",
+    assert transaction.candidate_granted_scopes == tuple(
+        sorted(
+            {
+                "resource:list",
+                "resource:read",
+                "tool:list",
+                *(child_call_scope(feature_id) for feature_id in feature_ids),
+            }
+        )
     )
 
 
 @pytest.mark.asyncio
-async def test_authorize_short_tool_scope_aliases_are_canonicalized_when_enabled():
+async def test_authorize_legacy_tool_scope_aliases_are_rejected():
     provider, _cm, app = _provider_app(
         _config(
-            db_tools_enabled=True,
-            allowlist=["get_db_list"],
-            query_tools_enabled=True,
-            explain_tools_enabled=True,
+            child_tools_enabled=True,
+            allowlist=[
+                CATALOG_DATABASES_FEATURE,
+                QUERY_EXECUTE_FEATURE,
+                QUERY_EXPLAIN_FEATURE,
+            ],
         )
     )
     async with await _client(app) as client:
@@ -592,20 +644,8 @@ async def test_authorize_short_tool_scope_aliases_are_canonicalized_when_enabled
         )
 
     assert authorize.status_code == 302
-    txn_id = parse_qs(urlparse(authorize.headers["location"]).query)["txn_id"][0]
-    transaction = provider.get_login_transaction(txn_id)
-    assert transaction.requested_scopes == (
-        "tool:list",
-        "tool:call:get_db_list",
-        "tool:call:exec_query",
-        "tool:call:get_sql_explain",
-    )
-    assert transaction.candidate_granted_scopes == (
-        "tool:call:exec_query",
-        "tool:call:get_db_list",
-        "tool:call:get_sql_explain",
-        "tool:list",
-    )
+    query = parse_qs(urlparse(authorize.headers["location"]).query)
+    assert query["error"] == ["invalid_scope"]
 
 
 @pytest.mark.asyncio
@@ -930,9 +970,7 @@ async def test_authorization_code_exchange_rejects_unbound_resource(
 async def test_full_login_without_scope_grants_configured_rbac_capability_envelope():
     provider, cm, app = _provider_app(
         _config(
-            db_tools_enabled=True,
-            query_tools_enabled=True,
-            explain_tools_enabled=True,
+            child_tools_enabled=True,
         )
     )
     async with await _client(app) as client:
@@ -1002,9 +1040,10 @@ async def test_full_login_without_scope_grants_configured_rbac_capability_envelo
     assert auth_context.auth_method == "doris_oauth"
     assert auth_context.doris_user == "alice"
     assert tuple(auth_context.oauth_scopes) == FULL_DORIS_OAUTH_SCOPE_SET
-    assert auth_context.doris_oauth_db_tools_enabled is True
-    assert auth_context.doris_oauth_query_tools_enabled is True
-    assert auth_context.doris_oauth_explain_tools_enabled is True
+    assert auth_context.doris_oauth_child_tools_enabled is True
+    assert auth_context.doris_oauth_child_tool_allowlist == (
+        FORMAL_CHILD_FEATURE_IDS
+    )
     assert auth_context.pool_key == "doris_user:alice"
     assert auth_context.token == ""
 

--- a/test/protocol/test_multiworker_config.py
+++ b/test/protocol/test_multiworker_config.py
@@ -105,6 +105,53 @@ def test_tool_exposure_mode_loads_from_json_config(tmp_path) -> None:
     assert configured.tool_exposure.mode == "flat"
 
 
+def test_capability_cache_controls_are_explicit_and_validated(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("CAPABILITY_SNAPSHOT_TTL_SECONDS", "120")
+    monkeypatch.setenv("CAPABILITY_PROBE_TIMEOUT_SECONDS", "7")
+    monkeypatch.setenv("CAPABILITY_STALE_GRACE_SECONDS", "480")
+
+    configured = DorisConfig.from_env()
+
+    assert configured.capability.snapshot_ttl_seconds == 120
+    assert configured.capability.probe_timeout_seconds == 7
+    assert configured.capability.stale_grace_seconds == 480
+    assert configured.to_dict()["capability"] == {
+        "snapshot_ttl_seconds": 120,
+        "probe_timeout_seconds": 7,
+        "stale_grace_seconds": 480,
+    }
+    assert configured.validate() == []
+
+    config_path = tmp_path / "doris-mcp.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "capability": {
+                    "snapshot_ttl_seconds": 30,
+                    "probe_timeout_seconds": 3,
+                    "stale_grace_seconds": 60,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    from_file = DorisConfig.from_file(str(config_path))
+    assert from_file.capability.snapshot_ttl_seconds == 30
+    assert from_file.capability.probe_timeout_seconds == 3
+    assert from_file.capability.stale_grace_seconds == 60
+
+    from_file.capability.snapshot_ttl_seconds = 0
+    from_file.capability.probe_timeout_seconds = 61
+    from_file.capability.stale_grace_seconds = -1
+    errors = from_file.validate()
+    assert "Capability snapshot TTL must be in the range 1-86400 seconds" in errors
+    assert "Capability probe timeout must be in the range 1-60 seconds" in errors
+    assert "Capability stale grace must be in the range 0-86400 seconds" in errors
+
+
 def test_state_handle_secret_and_ttl_are_configurable_without_serializing_secret(
     monkeypatch,
 ):
@@ -150,6 +197,9 @@ def test_multiworker_environment_preserves_resolved_parent_config(monkeypatch):
     config.mcp_list_page_size = 17
     config.mcp_tool_providers = ["orders_api", "customer-tools"]
     config.tool_exposure.mode = "flat"
+    config.capability.snapshot_ttl_seconds = 120
+    config.capability.probe_timeout_seconds = 7
+    config.capability.stale_grace_seconds = 480
     config.mcp_state_handle_secret = "parent-shared-state-handle-secret-value"
     config.mcp_state_handle_ttl_seconds = 45
 
@@ -188,6 +238,9 @@ def test_multiworker_environment_preserves_resolved_parent_config(monkeypatch):
     assert child_config.mcp_list_page_size == 17
     assert child_config.mcp_tool_providers == ["orders_api", "customer-tools"]
     assert child_config.tool_exposure.mode == "flat"
+    assert child_config.capability.snapshot_ttl_seconds == 120
+    assert child_config.capability.probe_timeout_seconds == 7
+    assert child_config.capability.stale_grace_seconds == 480
     assert (
         child_config.mcp_state_handle_secret
         == "parent-shared-state-handle-secret-value"

--- a/test/security/test_effective_auth_config.py
+++ b/test/security/test_effective_auth_config.py
@@ -128,6 +128,70 @@ def test_doris_oauth_query_and_explain_flags_are_supported(field_name):
     normalize_effective_auth_config(config)
 
 
+@pytest.mark.parametrize(
+    "feature_id",
+    [
+        "get_db_list",
+        "doris_catalog.not_real",
+        "not_a_feature",
+    ],
+)
+def test_doris_oauth_child_allowlist_rejects_non_formal_features(
+    feature_id,
+):
+    config = _doris_oauth_http_config("http://localhost:3000")
+    config.security.doris_oauth_child_tool_allowlist = [
+        "doris_catalog.list_databases",
+        feature_id,
+    ]
+
+    with pytest.raises(
+        AuthConfigError,
+        match="DORIS_OAUTH_CHILD_TOOL_ALLOWLIST",
+    ):
+        normalize_effective_auth_config(config)
+
+
+@pytest.mark.parametrize(
+    "setting",
+    [
+        "DORIS_OAUTH_DB_TOOLS_ENABLED",
+        "DORIS_OAUTH_DB_TOOL_ALLOWLIST",
+        "DORIS_OAUTH_QUERY_TOOLS_ENABLED",
+        "DORIS_OAUTH_QUERY_TOOL_ALLOWLIST",
+        "DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED",
+        "DORIS_OAUTH_EXPLAIN_TOOL_ALLOWLIST",
+    ],
+)
+def test_legacy_doris_oauth_tool_bucket_environment_is_rejected(
+    monkeypatch,
+    setting,
+):
+    monkeypatch.setenv(setting, "true")
+    config = DorisConfig.from_env()
+
+    with pytest.raises(
+        AuthConfigError,
+        match="Legacy Doris OAuth tool-bucket settings",
+    ):
+        normalize_effective_auth_config(config)
+
+
+def test_serialized_config_exposes_only_formal_child_oauth_controls():
+    security = DorisConfig().to_dict()["security"]
+
+    assert security["doris_oauth_child_tools_enabled"] is False
+    assert security["doris_oauth_child_tool_allowlist"]
+    assert {
+        "doris_oauth_db_tools_enabled",
+        "doris_oauth_db_tool_allowlist",
+        "doris_oauth_query_tools_enabled",
+        "doris_oauth_query_tool_allowlist",
+        "doris_oauth_explain_tools_enabled",
+        "doris_oauth_explain_tool_allowlist",
+    }.isdisjoint(security)
+
+
 def _doris_oauth_smoke_env_values():
     return {
         "TRANSPORT": "http",
@@ -145,13 +209,12 @@ def _doris_oauth_smoke_env_values():
         "ENABLE_JWT_AUTH": "false",
         "ENABLE_OAUTH_AUTH": "false",
         "OAUTH_ENABLED": "false",
-        "DORIS_OAUTH_DB_TOOLS_ENABLED": "true",
-        "DORIS_OAUTH_DB_TOOL_ALLOWLIST": (
-            "get_db_list,get_db_table_list,get_table_schema,get_table_comment,"
-            "get_table_column_comments,get_table_indexes,get_catalog_list"
+        "DORIS_OAUTH_CHILD_TOOLS_ENABLED": "true",
+        "DORIS_OAUTH_CHILD_TOOL_ALLOWLIST": (
+            "doris_catalog.list_databases,"
+            "doris_query.execute_query,"
+            "doris_query.explain_query"
         ),
-        "DORIS_OAUTH_QUERY_TOOLS_ENABLED": "true",
-        "DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED": "true",
         "ENABLE_SECURITY_CHECK": "false",
         "DORIS_OAUTH_DYNAMIC_CLIENT_REGISTRATION_MODE": "auto",
         "DORIS_OAUTH_CIMD_FETCH_TIMEOUT_SECONDS": "7",
@@ -180,10 +243,8 @@ def test_runtime_doris_oauth_smoke_env_matches_rbac_default_scope_model(monkeypa
         "ENABLE_JWT_AUTH",
         "ENABLE_OAUTH_AUTH",
         "OAUTH_ENABLED",
-        "DORIS_OAUTH_DB_TOOLS_ENABLED",
-        "DORIS_OAUTH_DB_TOOL_ALLOWLIST",
-        "DORIS_OAUTH_QUERY_TOOLS_ENABLED",
-        "DORIS_OAUTH_EXPLAIN_TOOLS_ENABLED",
+        "DORIS_OAUTH_CHILD_TOOLS_ENABLED",
+        "DORIS_OAUTH_CHILD_TOOL_ALLOWLIST",
         "ENABLE_SECURITY_CHECK",
         "DORIS_OAUTH_DYNAMIC_CLIENT_REGISTRATION_MODE",
         "DORIS_OAUTH_CIMD_FETCH_TIMEOUT_SECONDS",
@@ -218,16 +279,18 @@ def test_runtime_doris_oauth_smoke_env_matches_rbac_default_scope_model(monkeypa
         "tool:list",
         "resource:list",
         "resource:read",
+        "child:call:doris_catalog:list_databases",
+        "child:discover:doris_catalog:list_databases",
+        "child:call:doris_query:execute_query",
+        "child:discover:doris_query:execute_query",
+        "child:call:doris_query:explain_query",
+        "child:discover:doris_query:explain_query",
+    } <= policy.server_allowed_scopes
+    assert {
         "tool:call:get_db_list",
-        "tool:call:get_db_table_list",
-        "tool:call:get_table_schema",
-        "tool:call:get_table_comment",
-        "tool:call:get_table_column_comments",
-        "tool:call:get_table_indexes",
-        "tool:call:get_catalog_list",
         "tool:call:exec_query",
         "tool:call:get_sql_explain",
-    } <= policy.server_allowed_scopes
+    }.isdisjoint(policy.server_allowed_scopes)
     assert {
         "*",
         "scope:admin",

--- a/test/security/test_token_digest_storage.py
+++ b/test/security/test_token_digest_storage.py
@@ -156,6 +156,10 @@ async def test_legacy_plaintext_file_is_atomically_migrated_without_expiry_exten
     monkeypatch,
 ):
     _clear_static_token_environment(monkeypatch)
+    monkeypatch.setattr(
+        "doris_mcp_server.auth.token_manager.utc_now",
+        lambda: datetime(2026, 7, 15, tzinfo=UTC),
+    )
     token_path = tmp_path / "tokens.json"
     token_path.write_text(
         json.dumps(

--- a/test/tools/test_capability_detector.py
+++ b/test/tools/test_capability_detector.py
@@ -1,0 +1,395 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for route-aware, read-only Doris capability probes."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from doris_mcp_server.tools.capability_detector import (
+    CapabilityDetectionError,
+    CapabilityProbeStatus,
+    CapabilityRouteChangedError,
+    DorisCapabilityDetector,
+)
+from doris_mcp_server.tools.doris_feature_matrix import DORIS_FEATURE_MATRIX
+from doris_mcp_server.utils.db import DorisRouteIdentity
+
+
+class _ProbeConnection:
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+        self.failures: dict[str, Exception] = {}
+        self.row_overrides: dict[str, list[dict[str, Any]]] = {}
+        self.on_execute: Any | None = None
+
+    async def execute(
+        self,
+        sql: str,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        self.statements.append(sql)
+        if self.on_execute is not None:
+            self.on_execute(sql)
+        if sql in self.failures:
+            raise self.failures[sql]
+        rows: dict[str, list[dict[str, Any]]] = {
+            "SELECT @@version_comment;": [
+                {
+                    "@@version_comment": (
+                        "Doris version "
+                        "doris-4.0.5-rc01-59de8c4c524"
+                    )
+                }
+            ],
+            "SELECT 1 AS capability_probe": [
+                {"capability_probe": 1}
+            ],
+            "SHOW FRONTENDS": [
+                {
+                    "Name": "fe-1",
+                    "Role": "FOLLOWER",
+                    "IsMaster": "true",
+                    "Version": "doris-4.0.5-rc01-59de8c4c524",
+                },
+                {
+                    "Name": "fe-2",
+                    "Role": "FOLLOWER",
+                    "IsMaster": "false",
+                    "Version": "doris-4.0.5-rc01-59de8c4c524",
+                },
+            ],
+            "SHOW BACKENDS": [
+                {
+                    "BackendId": "1",
+                    "Version": "doris-4.0.5-rc01-59de8c4c524",
+                },
+                {
+                    "BackendId": "2",
+                    "Version": "doris-4.0.5-rc01-59de8c4c524",
+                },
+            ],
+            "EXPLAIN SELECT 1": [{"Explain String": "PLAN"}],
+            "SHOW CATALOGS": [{"CatalogId": 0, "CatalogName": "internal"}],
+            "SHOW DATABASES": [{"Database": "information_schema"}],
+            (
+                "SELECT 1 AS table_metadata_probe "
+                "FROM information_schema.tables LIMIT 1"
+            ): [
+                {"table_metadata_probe": 1}
+            ],
+        }
+        return SimpleNamespace(
+            data=self.row_overrides.get(sql, rows.get(sql, []))
+        )
+
+
+class _ProbeConnectionManager:
+    def __init__(self, connection: _ProbeConnection) -> None:
+        self.connection = connection
+        self.route = DorisRouteIdentity(
+            route_key="global",
+            generation=1,
+            endpoint_fingerprint="endpoint-a",
+            fingerprint="route-a",
+        )
+        self.context_error: Exception | None = None
+
+    def get_route_identity(self, _auth_context: Any) -> DorisRouteIdentity:
+        return self.route
+
+    @asynccontextmanager
+    async def get_connection_context_for_auth_context(
+        self,
+        _session_id: str,
+        _auth_context: Any,
+    ):
+        if self.context_error is not None:
+            raise self.context_error
+        yield self.connection
+
+
+@pytest.mark.asyncio
+async def test_detector_builds_version_vector_and_extends_domains_lazily() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+
+    base = await detector.detect_base(
+        None,
+        capability_generation=3,
+        provider_generation="provider.a",
+    )
+    query = await detector.detect_domain(base, "doris_query", None)
+    catalog = await detector.detect_domain(base, "doris_catalog", None)
+
+    assert base.route.fingerprint == "route-a"
+    assert base.capability_generation == 3
+    assert base.version_vector.master_fe.normalized == "4.0.5rc1"
+    assert len(base.version_vector.follower_fes) == 1
+    assert len(base.version_vector.backends) == 2
+    assert base.mixed_versions is False
+    assert (
+        base.probe("version_probe_completed").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert (
+        base.probe("query_execution_readable").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert query.probed_domains == frozenset({"doris_query"})
+    assert (
+        query.probe("explain_output_readable").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert catalog.probed_domains == frozenset({"doris_catalog"})
+    assert (
+        catalog.probe("database_metadata_readable").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert connection.statements.count("SELECT @@version_comment;") == 1
+
+
+@pytest.mark.asyncio
+async def test_detector_marks_permission_failure_unknown_not_unsupported() -> None:
+    connection = _ProbeConnection()
+    connection.failures["SHOW BACKENDS"] = RuntimeError(
+        1142,
+        "permission denied",
+    )
+    detector = DorisCapabilityDetector(  # type: ignore[arg-type]
+        _ProbeConnectionManager(connection)
+    )
+
+    snapshot = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    evidence = snapshot.probe("backends_metadata_readable")
+    assert evidence is not None
+    assert evidence.status is CapabilityProbeStatus.UNKNOWN
+    assert evidence.reason_code == "PROBE_PERMISSION_DENIED"
+    assert snapshot.version_vector.backends == ()
+
+
+@pytest.mark.asyncio
+async def test_detector_retains_visible_backend_with_unknown_version() -> None:
+    connection = _ProbeConnection()
+    connection.row_overrides["SHOW BACKENDS"] = [
+        {
+            "BackendId": "1",
+            "Version": "doris-4.0.5-rc01-59de8c4c524",
+        },
+        {
+            "BackendId": "2",
+            "Version": "",
+        },
+    ]
+    detector = DorisCapabilityDetector(  # type: ignore[arg-type]
+        _ProbeConnectionManager(connection)
+    )
+
+    snapshot = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+    evaluation = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_cluster",
+        child_name="get_cache_status",
+        versions=snapshot.version_vector,
+    )
+
+    assert len(snapshot.version_vector.backends) == 2
+    assert snapshot.version_vector.backends[0].is_parsed is True
+    assert snapshot.version_vector.backends[1].is_parsed is False
+    assert evaluation.compatible is False
+    assert evaluation.reason_code == "DORIS_VERSION_UNKNOWN"
+
+
+@pytest.mark.asyncio
+async def test_detector_uses_fallback_for_unknown_master_and_retains_follower() -> None:
+    connection = _ProbeConnection()
+    connection.row_overrides["SHOW FRONTENDS"] = [
+        {
+            "Name": "fe-1",
+            "IsMaster": "true",
+            "Version": "",
+        },
+        {
+            "Name": "fe-2",
+            "IsMaster": "false",
+            "Version": "",
+        },
+    ]
+    detector = DorisCapabilityDetector(  # type: ignore[arg-type]
+        _ProbeConnectionManager(connection)
+    )
+
+    snapshot = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+    evaluation = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_governance",
+        child_name="get_lineage_capability_status",
+        versions=snapshot.version_vector,
+        variant_name="native_lineage_status",
+    )
+
+    assert snapshot.version_vector.master_fe.normalized == "4.0.5rc1"
+    assert len(snapshot.version_vector.follower_fes) == 1
+    assert snapshot.version_vector.follower_fes[0].is_parsed is False
+    assert evaluation.compatible is False
+    assert evaluation.reason_code == "DORIS_VERSION_UNKNOWN"
+
+
+@pytest.mark.asyncio
+async def test_detector_rejects_route_change_before_domain_probe() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+    manager.route = DorisRouteIdentity(
+        route_key="global",
+        generation=2,
+        endpoint_fingerprint="endpoint-a",
+        fingerprint="route-b",
+    )
+
+    with pytest.raises(CapabilityRouteChangedError):
+        await detector.detect_domain(base, "doris_query", None)
+
+
+@pytest.mark.asyncio
+async def test_detector_reprobes_after_route_changes_during_base_probe() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    switched = False
+
+    def switch_route(sql: str) -> None:
+        nonlocal switched
+        if sql != "SELECT @@version_comment;" or switched:
+            return
+        switched = True
+        manager.route = DorisRouteIdentity(
+            route_key="global",
+            generation=2,
+            endpoint_fingerprint="endpoint-b",
+            fingerprint="route-b",
+        )
+
+    connection.on_execute = switch_route
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+
+    snapshot = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    assert snapshot.route.fingerprint == "route-b"
+    assert connection.statements.count("SELECT @@version_comment;") == 2
+
+
+@pytest.mark.asyncio
+async def test_detector_reprobes_after_route_changes_at_end_of_base_probe() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    switched = False
+
+    def switch_route(sql: str) -> None:
+        nonlocal switched
+        if sql != "SHOW BACKENDS" or switched:
+            return
+        switched = True
+        manager.route = DorisRouteIdentity(
+            route_key="global",
+            generation=2,
+            endpoint_fingerprint="endpoint-b",
+            fingerprint="route-b",
+        )
+
+    connection.on_execute = switch_route
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+
+    snapshot = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    assert snapshot.route.fingerprint == "route-b"
+    assert connection.statements.count("SELECT @@version_comment;") == 2
+
+
+@pytest.mark.asyncio
+async def test_detector_rejects_route_change_at_end_of_domain_probe() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    def switch_route(sql: str) -> None:
+        if sql != "EXPLAIN SELECT 1":
+            return
+        manager.route = DorisRouteIdentity(
+            route_key="global",
+            generation=2,
+            endpoint_fingerprint="endpoint-b",
+            fingerprint="route-b",
+        )
+
+    connection.on_execute = switch_route
+
+    with pytest.raises(CapabilityRouteChangedError):
+        await detector.detect_domain(base, "doris_query", None)
+
+
+@pytest.mark.asyncio
+async def test_detector_wraps_domain_connection_failures() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+    manager.context_error = ConnectionError("connection unavailable")
+
+    with pytest.raises(
+        CapabilityDetectionError,
+        match="probe failed for doris_query",
+    ):
+        await detector.detect_domain(base, "doris_query", None)

--- a/test/tools/test_capability_registry.py
+++ b/test/tools/test_capability_registry.py
@@ -1,0 +1,617 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for snapshot caching and deterministic availability evaluation."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from doris_mcp_server.tools.capability_detector import (
+    CapabilityDetectionError,
+    CapabilityProbeEvidence,
+    CapabilityProbeStatus,
+    CapabilityRouteChangedError,
+    DorisCapabilitySnapshot,
+)
+from doris_mcp_server.tools.capability_registry import (
+    CapabilityEvaluator,
+    CapabilityProviderEvidence,
+    CapabilityProviderRegistry,
+    CapabilityRegistry,
+)
+from doris_mcp_server.tools.domain_catalog import DORIS_DOMAIN_CATALOG
+from doris_mcp_server.tools.domain_manifest import DomainManifestService
+from doris_mcp_server.tools.domain_models import AvailabilityStatus
+from doris_mcp_server.tools.doris_feature_matrix import (
+    DORIS_FEATURE_MATRIX,
+    DorisClusterVersionVector,
+)
+from doris_mcp_server.utils.db import DorisRouteIdentity
+from doris_mcp_server.utils.security import AuthContext
+
+
+class _BoundHandlers:
+    def __init__(self, *feature_ids: str) -> None:
+        self.bound_feature_ids = frozenset(feature_ids)
+
+    def is_bound(self, domain_name: str, child_name: str) -> bool:
+        return f"{domain_name}.{child_name}" in self.bound_feature_ids
+
+
+def _snapshot(
+    *,
+    route: DorisRouteIdentity | None = None,
+    generation: int = 1,
+    provider_generation: str = "provider.empty",
+    probes: dict[str, CapabilityProbeEvidence] | None = None,
+    mixed_versions: bool = False,
+    now: datetime | None = None,
+) -> DorisCapabilitySnapshot:
+    created = now or datetime(2026, 7, 31, tzinfo=UTC)
+    versions = DorisClusterVersionVector.from_comments(
+        master_fe="Doris version doris-4.0.5",
+        follower_fes=("Doris version doris-4.0.5",),
+        backends=(
+            "Doris version doris-4.0.5",
+            (
+                "Doris version doris-4.0.6"
+                if mixed_versions
+                else "Doris version doris-4.0.5"
+            ),
+        ),
+    )
+    return DorisCapabilitySnapshot(
+        route=route
+        or DorisRouteIdentity(
+            route_key="global",
+            generation=1,
+            endpoint_fingerprint="endpoint-a",
+            fingerprint="route-a",
+        ),
+        capability_generation=generation,
+        provider_generation=provider_generation,
+        cluster_fingerprint="cluster-a",
+        version_vector=versions,
+        deployment_mode="unknown",
+        mixed_versions=mixed_versions,
+        probes=probes or {},
+        probed_domains=frozenset({"doris_query"}),
+        created_at=created,
+        expires_at=created + timedelta(seconds=10),
+        stale_until=created + timedelta(seconds=30),
+    )
+
+
+def _query_probes() -> dict[str, CapabilityProbeEvidence]:
+    return {
+        probe_id: CapabilityProbeEvidence(
+            probe_id=probe_id,
+            status=CapabilityProbeStatus.SUPPORTED,
+            reason_code="TEST_PROBE_SUPPORTED",
+            evidence_sources=("test_probe",),
+        )
+        for probe_id in (
+            "read_only_sql_guard_ready",
+            "query_execution_readable",
+        )
+    }
+
+
+def _query_contract():
+    domain = DORIS_DOMAIN_CATALOG.resolve_domain("doris_query")
+    child = DORIS_DOMAIN_CATALOG.resolve_child(
+        "doris_query",
+        "execute_query",
+    )
+    return domain, child
+
+
+def test_evaluator_requires_version_probes_handler_and_call_permission() -> None:
+    bound = _BoundHandlers("doris_query.execute_query")
+    evaluator = CapabilityEvaluator(
+        matrix=DORIS_FEATURE_MATRIX,
+        bound_handlers=bound,  # type: ignore[arg-type]
+    )
+    providers = CapabilityProviderRegistry({}).snapshot()
+    domain, child = _query_contract()
+
+    available = evaluator.evaluate(
+        snapshot=_snapshot(probes=_query_probes()),
+        providers=providers,
+        domain=domain,
+        child=child,
+        auth_context=None,
+    )
+    missing_probe = evaluator.evaluate(
+        snapshot=_snapshot(probes={}),
+        providers=providers,
+        domain=domain,
+        child=child,
+        auth_context=None,
+    )
+    mixed_backends = evaluator.evaluate(
+        snapshot=_snapshot(
+            probes=_query_probes(),
+            mixed_versions=True,
+        ),
+        providers=providers,
+        domain=domain,
+        child=child,
+        auth_context=None,
+    )
+    denied = evaluator.evaluate(
+        snapshot=_snapshot(probes=_query_probes()),
+        providers=providers,
+        domain=domain,
+        child=child,
+        auth_context=AuthContext(
+            auth_method="external_oauth",
+            oauth_scopes=["tool:list"],
+        ),
+    )
+    allowed = evaluator.evaluate(
+        snapshot=_snapshot(probes=_query_probes()),
+        providers=providers,
+        domain=domain,
+        child=child,
+        auth_context=AuthContext(
+            auth_method="external_oauth",
+            oauth_scopes=["child:call:doris_query:execute_query"],
+        ),
+    )
+
+    assert available.status is AvailabilityStatus.AVAILABLE
+    assert available.callable is True
+    assert available.active_variant == "mysql_read_only"
+    assert missing_probe.status is AvailabilityStatus.UNKNOWN
+    assert missing_probe.reason_code == "CAPABILITY_PROBE_PENDING"
+    assert mixed_backends.status is AvailabilityStatus.AVAILABLE
+    assert mixed_backends.callable is True
+    assert denied.status is AvailabilityStatus.UNAVAILABLE
+    assert denied.reason_code == "CHILD_CALL_PERMISSION_DENIED"
+    assert allowed.callable is True
+
+
+def test_evaluator_distinguishes_provider_misconfiguration() -> None:
+    bound = _BoundHandlers("doris_query.diagnose_query_performance")
+    evaluator = CapabilityEvaluator(
+        matrix=DORIS_FEATURE_MATRIX,
+        bound_handlers=bound,  # type: ignore[arg-type]
+    )
+    domain = DORIS_DOMAIN_CATALOG.resolve_domain("doris_query")
+    child = DORIS_DOMAIN_CATALOG.resolve_child(
+        "doris_query",
+        "diagnose_query_performance",
+    )
+
+    availability = evaluator.evaluate(
+        snapshot=_snapshot(),
+        providers=CapabilityProviderRegistry({}).snapshot(),
+        domain=domain,
+        child=child,
+        auth_context=None,
+    )
+
+    assert availability.status is AvailabilityStatus.MISCONFIGURED
+    assert availability.callable is False
+    assert availability.reason_code == "PROVIDER_NOT_CONFIGURED"
+
+
+@pytest.mark.parametrize(
+    ("enabled", "bound", "expected_status"),
+    [
+        (False, True, CapabilityProbeStatus.MISCONFIGURED),
+        (True, False, CapabilityProbeStatus.MISCONFIGURED),
+        (True, True, CapabilityProbeStatus.DEGRADED),
+    ],
+)
+def test_adbc_provider_requires_configuration_and_bound_consumer(
+    enabled: bool,
+    bound: bool,
+    expected_status: CapabilityProbeStatus,
+) -> None:
+    handlers = (
+        _BoundHandlers(
+            "doris_query.get_adbc_connection_info",
+            "doris_query.execute_adbc_query",
+        )
+        if bound
+        else _BoundHandlers()
+    )
+    registry = CapabilityProviderRegistry.from_runtime(
+        matrix=DORIS_FEATURE_MATRIX,
+        bound_handlers=handlers,  # type: ignore[arg-type]
+        config=SimpleNamespace(adbc=SimpleNamespace(enabled=enabled)),
+    )
+
+    provider = registry.snapshot().providers["adbc_provider"]
+
+    assert provider.status is expected_status
+    assert provider.reason_code == (
+        "PROVIDER_CONFIGURED_UNPROBED"
+        if expected_status is CapabilityProbeStatus.DEGRADED
+        else "PROVIDER_NOT_CONFIGURED"
+    )
+
+
+class _MutableClock:
+    def __init__(self) -> None:
+        self.now = datetime(2026, 7, 31, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+
+class _FakeDetector:
+    def __init__(
+        self,
+        clock: _MutableClock,
+        *,
+        probes: dict[str, CapabilityProbeEvidence] | None = None,
+    ) -> None:
+        self.clock = clock
+        self.probes = probes or _query_probes()
+        self.route = DorisRouteIdentity(
+            route_key="global",
+            generation=1,
+            endpoint_fingerprint="endpoint-a",
+            fingerprint="route-a",
+        )
+        self.base_calls = 0
+        self.domain_calls = 0
+        self.fail_base = False
+        self.fail_base_with_route_change = False
+        self.domain_hook: Callable[[], None] | None = None
+
+    def route_identity(self, _auth_context: Any) -> DorisRouteIdentity:
+        return self.route
+
+    async def detect_base(
+        self,
+        _auth_context: Any,
+        *,
+        capability_generation: int,
+        provider_generation: str,
+    ) -> DorisCapabilitySnapshot:
+        self.base_calls += 1
+        await asyncio.sleep(0.01)
+        if self.fail_base_with_route_change:
+            self.route = DorisRouteIdentity(
+                route_key="global",
+                generation=2,
+                endpoint_fingerprint="endpoint-b",
+                fingerprint="route-b",
+            )
+            raise CapabilityRouteChangedError("test route change")
+        if self.fail_base:
+            raise CapabilityDetectionError("test failure")
+        return _snapshot(
+            route=self.route,
+            generation=capability_generation,
+            provider_generation=provider_generation,
+            probes=self.probes,
+            now=self.clock(),
+        )
+
+    async def detect_domain(
+        self,
+        base: DorisCapabilitySnapshot,
+        domain_name: str,
+        _auth_context: Any,
+    ) -> DorisCapabilitySnapshot:
+        self.domain_calls += 1
+        await asyncio.sleep(0.01)
+        if self.domain_hook is not None:
+            hook, self.domain_hook = self.domain_hook, None
+            hook()
+        return replace(
+            base,
+            probed_domains=base.probed_domains | {domain_name},
+        )
+
+
+def _registry(
+    detector: _FakeDetector,
+    clock: _MutableClock,
+) -> CapabilityRegistry:
+    bound = _BoundHandlers("doris_query.execute_query")
+    return CapabilityRegistry(
+        detector=detector,  # type: ignore[arg-type]
+        provider_registry=CapabilityProviderRegistry({}),
+        evaluator=CapabilityEvaluator(
+            matrix=DORIS_FEATURE_MATRIX,
+            bound_handlers=bound,  # type: ignore[arg-type]
+        ),
+        clock=clock,
+    )
+
+
+@pytest.mark.asyncio
+async def test_registry_singleflight_route_switch_and_generation() -> None:
+    clock = _MutableClock()
+    detector = _FakeDetector(clock)
+    registry = _registry(detector, clock)
+
+    snapshots = await asyncio.gather(
+        *(registry.ensure_fresh("doris_query", None) for _ in range(12))
+    )
+    first_generation = snapshots[0].generation_fingerprint
+
+    assert detector.base_calls == 1
+    assert detector.domain_calls == 1
+    assert len({item.generation_fingerprint for item in snapshots}) == 1
+
+    await registry.ensure_fresh("doris_catalog", None)
+    assert detector.base_calls == 1
+    assert detector.domain_calls == 2
+
+    detector.route = DorisRouteIdentity(
+        route_key="global",
+        generation=2,
+        endpoint_fingerprint="endpoint-b",
+        fingerprint="route-b",
+    )
+    switched = await registry.ensure_fresh("doris_query", None)
+    assert detector.base_calls == 2
+    assert switched.route.fingerprint == "route-b"
+
+    await registry.bump_generation()
+    regenerated = await registry.ensure_fresh("doris_query", None)
+    assert detector.base_calls == 3
+    assert regenerated.capability_generation == 2
+    assert regenerated.generation_fingerprint != first_generation
+
+
+@pytest.mark.asyncio
+async def test_registry_uses_stale_snapshot_within_grace() -> None:
+    clock = _MutableClock()
+    detector = _FakeDetector(clock)
+    registry = _registry(detector, clock)
+    first = await registry.ensure_fresh("doris_query", None)
+    clock.now += timedelta(seconds=11)
+    detector.fail_base = True
+
+    stale = await registry.ensure_fresh("doris_query", None)
+
+    assert first.stale is False
+    assert stale.stale is True
+    assert detector.base_calls == 2
+
+    repeated = await registry.ensure_fresh("doris_query", None)
+
+    assert repeated.stale is True
+    assert detector.base_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_route_change_does_not_reuse_previous_route_stale_snapshot() -> None:
+    clock = _MutableClock()
+    detector = _FakeDetector(clock)
+    registry = _registry(detector, clock)
+    previous = await registry.ensure_fresh("doris_query", None)
+    clock.now += timedelta(seconds=11)
+    detector.fail_base_with_route_change = True
+
+    current = await registry.ensure_fresh("doris_query", None)
+
+    assert previous.route.fingerprint == "route-a"
+    assert current.route.fingerprint == "route-b"
+    assert current.stale is False
+    assert current.version_vector.master_fe.is_parsed is False
+
+
+@pytest.mark.asyncio
+async def test_singleflight_waiter_cancellation_does_not_cancel_probe() -> None:
+    clock = _MutableClock()
+    detector = _FakeDetector(clock)
+    registry = _registry(detector, clock)
+    cancelled_waiter = asyncio.create_task(registry.ensure_fresh("doris_query", None))
+    surviving_waiter = asyncio.create_task(registry.ensure_fresh("doris_query", None))
+    while detector.base_calls == 0:
+        await asyncio.sleep(0)
+
+    cancelled_waiter.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await cancelled_waiter
+    snapshot = await surviving_waiter
+
+    assert snapshot.route.fingerprint == "route-a"
+    assert detector.base_calls == 1
+    assert detector.domain_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_generation_bump_does_not_accept_inflight_old_snapshot() -> None:
+    clock = _MutableClock()
+    detector = _FakeDetector(clock)
+    registry = _registry(detector, clock)
+    old_request = asyncio.create_task(registry.ensure_fresh("doris_query", None))
+    while detector.base_calls == 0:
+        await asyncio.sleep(0)
+
+    await registry.bump_generation()
+    old_snapshot = await old_request
+    current_snapshot = await registry.ensure_fresh(
+        "doris_query",
+        None,
+    )
+
+    assert old_snapshot.capability_generation == 1
+    assert current_snapshot.capability_generation == 2
+    assert detector.base_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_manifest_version_tracks_private_capability_generation() -> None:
+    clock = _MutableClock()
+    detector = _FakeDetector(clock)
+    registry = _registry(detector, clock)
+    service = DomainManifestService(
+        availability_provider=registry,
+        clock=clock,
+    )
+    domain = DORIS_DOMAIN_CATALOG.resolve_domain("doris_query")
+
+    first = await service.discover(domain, None)
+    await registry.bump_generation()
+    second = await service.discover(domain, None)
+
+    assert first.manifest_version != second.manifest_version
+
+
+@pytest.mark.asyncio
+async def test_provider_down_advances_generation_and_fails_closed() -> None:
+    clock = _MutableClock()
+    detector = _FakeDetector(
+        clock,
+        probes={
+            probe_id: CapabilityProbeEvidence(
+                probe_id=probe_id,
+                status=CapabilityProbeStatus.SUPPORTED,
+                reason_code="TEST_PROBE_SUPPORTED",
+                evidence_sources=("test_probe",),
+            )
+            for probe_id in (
+                "adbc_driver_ready",
+                "flight_sql",
+                "read_only_sql_guard_ready",
+            )
+        },
+    )
+    providers = CapabilityProviderRegistry(
+        {
+            "adbc_provider": CapabilityProviderEvidence(
+                provider_id="adbc_provider",
+                status=CapabilityProbeStatus.SUPPORTED,
+                reason_code="PROVIDER_HEALTHY",
+            )
+        }
+    )
+    registry = CapabilityRegistry(
+        detector=detector,  # type: ignore[arg-type]
+        provider_registry=providers,
+        evaluator=CapabilityEvaluator(
+            matrix=DORIS_FEATURE_MATRIX,
+            bound_handlers=_BoundHandlers("doris_query.execute_adbc_query"),  # type: ignore[arg-type]
+        ),
+        clock=clock,
+    )
+    service = DomainManifestService(
+        availability_provider=registry,
+        clock=clock,
+    )
+    domain = DORIS_DOMAIN_CATALOG.resolve_domain("doris_query")
+
+    available = await service.discover(domain, None)
+    available_child = next(
+        child for child in available.children if child.name == "execute_adbc_query"
+    )
+    providers.set_provider(
+        "adbc_provider",
+        status=CapabilityProbeStatus.UNKNOWN,
+        reason_code="PROVIDER_HEALTHCHECK_FAILED",
+    )
+    unavailable = await service.discover(domain, None)
+    unavailable_child = next(
+        child for child in unavailable.children if child.name == "execute_adbc_query"
+    )
+
+    assert available_child.availability.callable is True
+    assert unavailable_child.availability.callable is False
+    assert unavailable_child.availability.status is AvailabilityStatus.UNKNOWN
+    assert unavailable_child.availability.reason_code == "PROVIDER_HEALTHCHECK_FAILED"
+    assert available.manifest_version != unavailable.manifest_version
+    assert detector.base_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_manifest_uses_one_provider_generation_during_refresh() -> None:
+    clock = _MutableClock()
+    detector = _FakeDetector(
+        clock,
+        probes={
+            probe_id: CapabilityProbeEvidence(
+                probe_id=probe_id,
+                status=CapabilityProbeStatus.SUPPORTED,
+                reason_code="TEST_PROBE_SUPPORTED",
+                evidence_sources=("test_probe",),
+            )
+            for probe_id in (
+                "adbc_driver_ready",
+                "flight_sql",
+                "read_only_sql_guard_ready",
+            )
+        },
+    )
+    providers = CapabilityProviderRegistry(
+        {
+            "adbc_provider": CapabilityProviderEvidence(
+                provider_id="adbc_provider",
+                status=CapabilityProbeStatus.SUPPORTED,
+                reason_code="PROVIDER_HEALTHY",
+            )
+        }
+    )
+    registry = CapabilityRegistry(
+        detector=detector,  # type: ignore[arg-type]
+        provider_registry=providers,
+        evaluator=CapabilityEvaluator(
+            matrix=DORIS_FEATURE_MATRIX,
+            bound_handlers=_BoundHandlers(
+                "doris_query.execute_adbc_query"
+            ),  # type: ignore[arg-type]
+        ),
+        clock=clock,
+    )
+    service = DomainManifestService(
+        availability_provider=registry,
+        clock=clock,
+    )
+    domain = DORIS_DOMAIN_CATALOG.resolve_domain("doris_query")
+    detector.domain_hook = lambda: providers.set_provider(
+        "adbc_provider",
+        status=CapabilityProbeStatus.UNKNOWN,
+        reason_code="PROVIDER_HEALTHCHECK_FAILED",
+    )
+
+    coherent_old = await service.discover(domain, None)
+    current = await service.discover(domain, None)
+    old_child = next(
+        child
+        for child in coherent_old.children
+        if child.name == "execute_adbc_query"
+    )
+    current_child = next(
+        child
+        for child in current.children
+        if child.name == "execute_adbc_query"
+    )
+
+    assert old_child.availability.callable is True
+    assert current_child.availability.callable is False
+    assert current_child.availability.reason_code == (
+        "PROVIDER_HEALTHCHECK_FAILED"
+    )
+    assert coherent_old.manifest_version != current.manifest_version

--- a/test/tools/test_capability_runtime_integration.py
+++ b/test/tools/test_capability_runtime_integration.py
@@ -1,0 +1,154 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for the default detector-to-dispatch capability path."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from doris_mcp_server.tools.domain_models import AvailabilityStatus
+from doris_mcp_server.tools.tools_manager import DorisToolsManager
+from doris_mcp_server.utils.config import DorisConfig
+from doris_mcp_server.utils.db import DorisRouteIdentity
+
+
+class _CapabilityConnection:
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+
+    async def execute(
+        self,
+        sql: str,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        self.statements.append(sql)
+        rows = {
+            "SELECT @@version_comment;": [
+                {
+                    "@@version_comment": (
+                        "Doris version doris-4.0.5-59de8c4c524 "
+                        "(Cloud Mode)"
+                    )
+                }
+            ],
+            "SELECT 1 AS capability_probe": [
+                {"capability_probe": 1}
+            ],
+            "SHOW FRONTENDS": [
+                {
+                    "Name": "fe-1",
+                    "IsMaster": "true",
+                    "Version": "doris-4.0.5-59de8c4c524",
+                }
+            ],
+            "SHOW BACKENDS": [
+                {
+                    "BackendId": "1",
+                    "Version": "doris-4.0.5-59de8c4c524",
+                }
+            ],
+            "EXPLAIN SELECT 1": [{"Explain String": "PLAN"}],
+        }
+        return SimpleNamespace(data=rows.get(sql, []))
+
+
+class _CapabilityConnectionManager:
+    def __init__(self) -> None:
+        self.config = DorisConfig()
+        self.connection = _CapabilityConnection()
+        self.route = DorisRouteIdentity(
+            route_key="global",
+            generation=1,
+            endpoint_fingerprint="endpoint-a",
+            fingerprint="route-a",
+        )
+
+    def get_route_identity(
+        self,
+        _auth_context: Any = None,
+    ) -> DorisRouteIdentity:
+        return self.route
+
+    @asynccontextmanager
+    async def get_connection_context_for_auth_context(
+        self,
+        _session_id: str,
+        _auth_context: Any,
+    ):
+        yield self.connection
+
+
+@pytest.mark.asyncio
+async def test_default_manager_detects_caches_and_dispatches() -> None:
+    connection_manager = _CapabilityConnectionManager()
+    manager = DorisToolsManager(connection_manager)  # type: ignore[arg-type]
+    manager._exec_query_tool = AsyncMock(
+        return_value={
+            "success": True,
+            "data": [{"answer": 42}],
+            "row_count": 1,
+            "metadata": {"columns": ["answer"]},
+        }
+    )
+
+    first = await manager.domain_dispatcher.call_domain(
+        "doris_query",
+        {},
+        None,
+    )
+    second = await manager.domain_dispatcher.call_domain(
+        "doris_query",
+        {},
+        None,
+    )
+    execute_child = next(
+        child
+        for child in first.children
+        if child.name == "execute_query"
+    )
+    result = await manager.domain_dispatcher.call_domain(
+        "doris_query",
+        {
+            "child_tool": "execute_query",
+            "arguments": {"sql": "SELECT 42 AS answer"},
+            "manifest_version": first.manifest_version,
+        },
+        None,
+    )
+
+    assert execute_child.availability.status is AvailabilityStatus.AVAILABLE
+    assert execute_child.availability.callable is True
+    assert execute_child.availability.detected_versions == {
+        "master_fe": ("4.0.5",),
+        "be": ("4.0.5",),
+    }
+    assert first.manifest_version == second.manifest_version
+    assert result.mode == "result"
+    assert connection_manager.connection.statements.count(
+        "SELECT @@version_comment;"
+    ) == 1
+    assert connection_manager.connection.statements.count(
+        "EXPLAIN SELECT 1"
+    ) == 1
+    manager._exec_query_tool.assert_awaited_once()
+

--- a/test/tools/test_domain_dispatcher.py
+++ b/test/tools/test_domain_dispatcher.py
@@ -92,11 +92,13 @@ def _connection_manager() -> Mock:
 def _manager(
     *callable_features: str,
     mode: str | ToolExposureMode = ToolExposureMode.HIERARCHICAL,
+    availability_provider: SelectiveAvailabilityProvider | None = None,
 ) -> DorisToolsManager:
     return DorisToolsManager(
         _connection_manager(),
-        domain_availability_provider=SelectiveAvailabilityProvider(
-            set(callable_features)
+        domain_availability_provider=(
+            availability_provider
+            or SelectiveAvailabilityProvider(set(callable_features))
         ),
         tool_exposure_mode=mode,
     )
@@ -130,14 +132,12 @@ def test_dispatcher_registers_exactly_47_formal_flat_names() -> None:
     assert len(set(names)) == 47
     assert "doris_query_execute_query" in names
     assert not set(CURRENT_FLAT_TOOL_NAMES).intersection(names)
-    assert manager.domain_dispatcher.handles_flat(
-        "doris_query_execute_query"
-    )
+    assert manager.domain_dispatcher.handles_flat("doris_query_execute_query")
     assert not manager.domain_dispatcher.handles_flat("exec_query")
 
 
 @pytest.mark.asyncio
-async def test_default_manager_exposes_bound_handlers_as_callable() -> None:
+async def test_default_manager_fails_closed_without_capability_snapshot() -> None:
     manager = DorisToolsManager(_connection_manager())
     manager._exec_query_tool = AsyncMock(return_value=_successful_query())
 
@@ -148,28 +148,15 @@ async def test_default_manager_exposes_bound_handlers_as_callable() -> None:
     )
     children = {child.name: child for child in manifest.children}
 
-    assert children["execute_query"].availability.callable is True
-    assert (
-        children["execute_query"].availability.reason_code
-        == "BOUND_HANDLER_FALLBACK"
-    )
+    assert children["execute_query"].availability.callable is False
+    assert children["execute_query"].availability.reason_code == "DORIS_VERSION_UNKNOWN"
     assert children["diagnose_query_performance"].availability.callable is False
     assert (
         children["diagnose_query_performance"].availability.reason_code
         == "HANDLER_NOT_BOUND"
     )
 
-    result = await manager.domain_dispatcher.call_domain(
-        "doris_query",
-        {
-            "child_tool": "execute_query",
-            "arguments": {"sql": "SELECT 1"},
-        },
-        None,
-    )
-
-    assert result.mode == "result"
-    manager._exec_query_tool.assert_awaited_once()
+    manager._exec_query_tool.assert_not_awaited()
 
 
 def test_dispatcher_rejects_colliding_formal_flat_names() -> None:
@@ -253,18 +240,14 @@ async def test_flat_mode_lists_47_formal_tools_and_uses_same_handler() -> None:
     assert tools[5].input_schema["required"] == ["sql"]
     assert result["domain"] == "doris_query"
     assert result["child_tool"] == "execute_query"
-    manager._exec_query_tool.assert_awaited_once_with(
-        {"sql": "SELECT 1 AS answer"}
-    )
+    manager._exec_query_tool.assert_awaited_once_with({"sql": "SELECT 1 AS answer"})
 
 
 @pytest.mark.asyncio
 async def test_error_envelopes_match_both_public_output_schemas() -> None:
     hierarchical = _manager("doris_query.execute_query")
     hierarchical_tool = next(
-        tool
-        for tool in await hierarchical.list_tools()
-        if tool.name == "doris_query"
+        tool for tool in await hierarchical.list_tools() if tool.name == "doris_query"
     )
     hierarchical_schema = ToolSchemaGuard().compile_tool(hierarchical_tool)
     hierarchical_error = json.loads(
@@ -439,12 +422,8 @@ async def test_domain_and_child_argument_schemas_fail_closed() -> None:
         )
     )
 
-    assert invalid_outer["error"]["code"] == (
-        DomainErrorCode.CHILD_ARGUMENTS_INVALID
-    )
-    assert invalid_child["error"]["code"] == (
-        DomainErrorCode.CHILD_ARGUMENTS_INVALID
-    )
+    assert invalid_outer["error"]["code"] == (DomainErrorCode.CHILD_ARGUMENTS_INVALID)
+    assert invalid_child["error"]["code"] == (DomainErrorCode.CHILD_ARGUMENTS_INVALID)
     assert invalid_child["error"]["details"]["violations"] == [
         {"instancePath": "", "keyword": "required"}
     ]
@@ -456,9 +435,7 @@ async def test_child_argument_violation_list_is_bounded_and_marked() -> None:
     dispatcher = DomainDispatcher(
         manager,
         manager.domain_manifest_service,
-        schema_guard=ToolSchemaGuard(
-            SchemaLimits(max_validation_errors=1)
-        ),
+        schema_guard=ToolSchemaGuard(SchemaLimits(max_validation_errors=1)),
     )
 
     result = await dispatcher.call_domain(
@@ -514,10 +491,46 @@ async def test_manifest_version_unavailable_and_unbound_fail_closed() -> None:
     assert unavailable["error"]["code"] == (
         DomainErrorCode.CHILD_CAPABILITY_UNAVAILABLE
     )
-    assert unavailable["error"]["details"]["reason_code"] == (
-        "TEST_HANDLER_PENDING"
-    )
+    assert unavailable["error"]["details"]["reason_code"] == ("TEST_HANDLER_PENDING")
     assert unbound["error"]["details"]["reason_code"] == "HANDLER_NOT_BOUND"
+
+
+@pytest.mark.asyncio
+async def test_runtime_provider_down_is_rechecked_before_execution() -> None:
+    provider = SelectiveAvailabilityProvider({"doris_query.execute_query"})
+    manager = _manager(availability_provider=provider)
+    manager._exec_query_tool = AsyncMock(return_value=_successful_query())
+    manifest = await manager.domain_dispatcher.call_domain(
+        "doris_query",
+        {},
+        None,
+    )
+
+    provider.callable_features.clear()
+    stale = await manager.domain_dispatcher.call_domain(
+        "doris_query",
+        {
+            "child_tool": "execute_query",
+            "arguments": {"sql": "SELECT 1"},
+            "manifest_version": manifest.manifest_version,
+        },
+        None,
+    )
+    unavailable = await manager.domain_dispatcher.call_domain(
+        "doris_query",
+        {
+            "child_tool": "execute_query",
+            "arguments": {"sql": "SELECT 1"},
+        },
+        None,
+    )
+
+    assert stale.mode == "error"
+    assert stale.error.code is DomainErrorCode.CHILD_MANIFEST_STALE
+    assert unavailable.mode == "error"
+    assert unavailable.error.code is DomainErrorCode.CHILD_CAPABILITY_UNAVAILABLE
+    assert unavailable.error.details["reason_code"] == "TEST_HANDLER_PENDING"
+    manager._exec_query_tool.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -564,6 +577,10 @@ async def test_oauth_execution_requires_exact_child_call_grant(
     context = AuthContext(
         auth_method=auth_method,
         oauth_scopes=oauth_scopes,
+        doris_oauth_child_tools_enabled=auth_method == "doris_oauth",
+        doris_oauth_child_tool_allowlist=(
+            ("doris_query.execute_query",) if auth_method == "doris_oauth" else ()
+        ),
     )
 
     result = await manager.domain_dispatcher.call_domain(
@@ -601,6 +618,10 @@ async def test_exact_child_call_grant_executes_and_static_token_fallback_remains
                 "tool:list",
                 "child:call:doris_query:execute_query",
             ],
+            doris_oauth_child_tools_enabled=auth_method == "doris_oauth",
+            doris_oauth_child_tool_allowlist=(
+                ("doris_query.execute_query",) if auth_method == "doris_oauth" else ()
+            ),
         ),
     )
     token_result = await manager.domain_dispatcher.call_domain(
@@ -848,9 +869,7 @@ async def test_table_context_skips_unrequested_optional_sections() -> None:
     )
 
     assert result.mode == "result"
-    assert result.to_wire()["data"]["data"] == {
-        "schema": {"columns": ["id"]}
-    }
+    assert result.to_wire()["data"]["data"] == {"schema": {"columns": ["id"]}}
 
 
 @pytest.mark.asyncio

--- a/test/tools/test_domain_manifest.py
+++ b/test/tools/test_domain_manifest.py
@@ -354,6 +354,52 @@ async def test_explicit_child_grants_hide_every_unauthorized_child() -> None:
 
 
 @pytest.mark.asyncio
+async def test_oauth_without_exact_child_scope_discovers_no_children() -> None:
+    context = AuthContext(
+        auth_method="external_oauth",
+        oauth_scopes=["tool:list"],
+    )
+
+    manifest = await _service().call("doris_catalog", {}, context)
+
+    assert manifest.children == ()
+
+
+@pytest.mark.asyncio
+async def test_doris_oauth_requires_gate_allowlist_and_exact_scope() -> None:
+    provider = StaticAvailabilityProvider(_availability())
+    scope = "child:call:doris_catalog:list_tables"
+    disabled = AuthContext(
+        auth_method="doris_oauth",
+        oauth_scopes=["tool:list", scope],
+    )
+    enabled = AuthContext(
+        auth_method="doris_oauth",
+        oauth_scopes=["tool:list", scope],
+        doris_oauth_child_tools_enabled=True,
+        doris_oauth_child_tool_allowlist=(
+            "doris_catalog.list_tables",
+        ),
+    )
+
+    disabled_manifest = await _service(provider).call(
+        "doris_catalog",
+        {},
+        disabled,
+    )
+    enabled_manifest = await _service(provider).call(
+        "doris_catalog",
+        {},
+        enabled,
+    )
+
+    assert disabled_manifest.children == ()
+    assert [child.name for child in enabled_manifest.children] == [
+        "list_tables"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_explicit_discovery_permission_is_accepted() -> None:
     context = AuthContext(
         permissions=["child:discover:doris_semantic:get_semantic_context"],

--- a/test/tools/test_doris_feature_matrix.py
+++ b/test/tools/test_doris_feature_matrix.py
@@ -411,6 +411,34 @@ def test_master_fe_scope_does_not_inherit_an_unrelated_old_be_version() -> None:
     assert result.compatible is True
 
 
+@pytest.mark.parametrize(
+    "child_name",
+    [
+        "execute_query",
+        "explain_query",
+        "get_query_profile",
+    ],
+)
+def test_fe_query_entrypoints_ignore_unknown_backend_version(
+    child_name: str,
+) -> None:
+    result = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_query",
+        child_name=child_name,
+        versions=DorisClusterVersionVector.from_comments(
+            master_fe="Doris version doris-4.0.5",
+            backends=(
+                "Doris version doris-4.0.5",
+                "",
+            ),
+        ),
+    )
+
+    assert result.version_scope is CapabilityVersionScope.MASTER_FE
+    assert result.effective_version == "4.0.5"
+    assert result.compatible is True
+
+
 def test_missing_required_component_version_fails_closed() -> None:
     versions = DorisClusterVersionVector.from_comments(
         master_fe="Doris version doris-4.1.2",

--- a/test/utils/test_doris_route_identity.py
+++ b/test/utils/test_doris_route_identity.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for secret-free Doris route cache identities."""
+
+from doris_mcp_server.utils.config import DorisConfig
+from doris_mcp_server.utils.db import DorisConnectionManager
+from doris_mcp_server.utils.security import AuthContext
+
+
+def test_route_identity_is_stable_isolated_and_secret_free() -> None:
+    config = DorisConfig()
+    config.database.host = "doris.internal"
+    config.database.hosts = ["doris.internal", "doris-backup.internal"]
+    config.database.port = 9030
+    config.database.user = "service_user"
+    config.database.password = "database-password"
+    config.database.database = "analytics"
+    manager = DorisConnectionManager(config)
+
+    global_route = manager.get_route_identity()
+    token_route = manager.get_route_identity(
+        AuthContext(
+            auth_method="token",
+            token="raw-static-token",
+        )
+    )
+    doris_user_route = manager.get_route_identity(
+        AuthContext(
+            auth_method="doris_oauth",
+            doris_user="analyst",
+        )
+    )
+
+    assert global_route.route_key == "global"
+    assert token_route.route_key.startswith("static_token:")
+    assert doris_user_route.route_key == "doris_user:analyst"
+    assert len(
+        {
+            global_route.fingerprint,
+            token_route.fingerprint,
+            doris_user_route.fingerprint,
+        }
+    ) == 3
+    rendered = repr(
+        (global_route, token_route, doris_user_route)
+    )
+    assert "database-password" not in rendered
+    assert "raw-static-token" not in rendered


### PR DESCRIPTION
## Summary

- add route-private Doris capability snapshots with parsed FE/BE version vectors, bounded lazy probes, singleflight refresh, stale-grace handling, and generation-based manifest invalidation
- evaluate every domain manifest against one coherent route, capability, and provider generation, and fail closed on mixed or unknown runtime evidence
- replace legacy Doris OAuth tool buckets with exact `domain.child` discovery and execution grants backed by a server-side allowlist
- expose capability cache controls, keep route fingerprints secret-free, and preserve the `hierarchical | flat` tool exposure switch
- add production-path tests for route changes, provider transitions, cache isolation, OAuth authorization parity, and real dispatcher preflight checks

## Validation

- `uv run pytest -q -W error` — 1494 passed, 69 skipped; 63.98% total coverage
- coverage domain gates — protocol 90.31%, authentication 81.53%, core managers 82.09%
- `uv lock --check`
- `uv run ruff check .`
- `uv run mypy doris_mcp_server`
- `uv run bandit -q -c pyproject.toml -r doris_mcp_server doris_mcp_client generate_requirements.py`
- `uv build`
- clean Python 3.12 wheel install and runtime dependency smoke
- official MCP 2026-07-28 `server-stateless` conformance — 25/25 passed, 0 failed, 0 warnings
- official MCP Inspector over stdio against a real Doris 4.0.5 RC environment:
  - eight stable domain tools exposed
  - progressive Query discovery and exact child execution succeeded
  - real read-only SQL returned the expected row
  - an unavailable Cluster child was rejected before handler execution