### PR TITLE
feat: add Query domain and ADBC provider

### DIFF
--- a/doris_mcp_server/tools/capability_detector.py
+++ b/doris_mcp_server/tools/capability_detector.py
@@ -28,7 +28,15 @@ from enum import StrEnum
 from types import MappingProxyType
 from typing import Any
 
+from ..utils.adbc_query_tools import DorisADBCQueryTools
 from ..utils.db import DorisConnection, DorisConnectionManager, DorisRouteIdentity
+from ..utils.doris_http_client import (
+    DorisHTTPClient,
+    DorisHTTPPolicyError,
+    DorisHTTPRequestError,
+    configured_fe_http_hosts,
+    database_config_for_request,
+)
 from .doris_feature_matrix import DorisClusterVersionVector
 from .doris_version import (
     DorisVersion,
@@ -111,9 +119,7 @@ class DorisCapabilitySnapshot:
             separators=(",", ":"),
             sort_keys=True,
         )
-        return "cap." + hashlib.sha256(
-            canonical.encode("utf-8")
-        ).hexdigest()[:16]
+        return "cap." + hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
 
     def as_stale(
         self,
@@ -143,17 +149,11 @@ _DOMAIN_PROBES: Mapping[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
         ("SHOW CATALOGS", ("catalog_metadata_readable",)),
         ("SHOW DATABASES", ("database_metadata_readable",)),
         (
-            (
-                "SELECT 1 AS table_metadata_probe "
-                "FROM information_schema.tables LIMIT 1"
-            ),
+            ("SELECT 1 AS table_metadata_probe FROM information_schema.tables LIMIT 1"),
             ("table_metadata_readable",),
         ),
         (
-            (
-                "SELECT COLUMN_NAME, DATA_TYPE "
-                "FROM information_schema.columns LIMIT 1"
-            ),
+            ("SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.columns LIMIT 1"),
             (
                 "information_schema.columns",
                 "table_context_sections_readable",
@@ -172,6 +172,10 @@ _DOMAIN_PROBES: Mapping[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
             "EXPLAIN SELECT 1",
             ("explain_output_readable", "explain_readable"),
         ),
+        (
+            ("SELECT `query_id` FROM internal.__internal_schema.audit_log LIMIT 1"),
+            ("audit_log_readable",),
+        ),
     ),
 }
 
@@ -186,20 +190,20 @@ class DorisCapabilityDetector:
         probe_timeout_seconds: float = 5.0,
         snapshot_ttl_seconds: int = 300,
         stale_grace_seconds: int = 900,
+        adbc_query_tools: DorisADBCQueryTools | None = None,
         clock: Any | None = None,
     ) -> None:
         self._connection_manager = connection_manager
         self._probe_timeout_seconds = probe_timeout_seconds
         self._snapshot_ttl_seconds = snapshot_ttl_seconds
         self._stale_grace_seconds = stale_grace_seconds
+        self._adbc_query_tools = adbc_query_tools
         self._clock = clock or (lambda: datetime.now(UTC))
 
     def route_identity(self, auth_context: Any | None) -> DorisRouteIdentity:
         route = self._connection_manager.get_route_identity(auth_context)
         if not isinstance(route, DorisRouteIdentity):
-            raise CapabilityDetectionError(
-                "Doris route identity is unavailable"
-            )
+            raise CapabilityDetectionError("Doris route identity is unavailable")
         return route
 
     async def detect_base(
@@ -213,13 +217,9 @@ class DorisCapabilityDetector:
             async with asyncio.timeout(self._probe_timeout_seconds):
                 for _ in range(2):
                     requested_route = self.route_identity(auth_context)
-                    session_id = (
-                        "capability-base:"
-                        f"{requested_route.fingerprint[:16]}"
-                    )
+                    session_id = f"capability-base:{requested_route.fingerprint[:16]}"
                     async with (
-                        self._connection_manager
-                        .get_connection_context_for_auth_context(
+                        self._connection_manager.get_connection_context_for_auth_context(
                             session_id,
                             auth_context,
                         ) as connection
@@ -268,13 +268,11 @@ class DorisCapabilityDetector:
                 )
 
             session_id = (
-                f"capability-domain:{domain_name}:"
-                f"{requested_route.fingerprint[:12]}"
+                f"capability-domain:{domain_name}:{requested_route.fingerprint[:12]}"
             )
             async with asyncio.timeout(self._probe_timeout_seconds):
                 async with (
-                    self._connection_manager
-                    .get_connection_context_for_auth_context(
+                    self._connection_manager.get_connection_context_for_auth_context(
                         session_id,
                         auth_context,
                     ) as connection
@@ -295,18 +293,21 @@ class DorisCapabilityDetector:
                             probe_ids,
                         )
                         probes.update(evidence)
-                    completed_route = self.route_identity(auth_context)
-                    if completed_route.fingerprint != base.route.fingerprint:
-                        raise CapabilityRouteChangedError(
-                            "Doris route changed during domain capability probing"
-                        )
-                    return replace(
-                        base,
-                        probes=probes,
-                        probed_domains=(
-                            base.probed_domains | frozenset({domain_name})
-                        ),
+                if domain_name == "doris_query":
+                    probes.update(await self._probe_query_services(auth_context))
+                    probes["profile_or_audit_readable"] = _combine_query_evidence_probe(
+                        probes
                     )
+                completed_route = self.route_identity(auth_context)
+                if completed_route.fingerprint != base.route.fingerprint:
+                    raise CapabilityRouteChangedError(
+                        "Doris route changed during domain capability probing"
+                    )
+                return replace(
+                    base,
+                    probes=probes,
+                    probed_domains=(base.probed_domains | frozenset({domain_name})),
+                )
         except TimeoutError as exc:
             raise CapabilityDetectionError(
                 f"Doris capability probe timed out for {domain_name}"
@@ -338,9 +339,7 @@ class DorisCapabilityDetector:
                 else CapabilityProbeStatus.UNKNOWN
             ),
             reason_code=(
-                "VERSION_PROBE_PARSED"
-                if version.is_parsed
-                else "DORIS_VERSION_UNKNOWN"
+                "VERSION_PROBE_PARSED" if version.is_parsed else "DORIS_VERSION_UNKNOWN"
             ),
             evidence_sources=("version_probe",),
         )
@@ -388,9 +387,7 @@ class DorisCapabilityDetector:
             else CapabilityProbeStatus.UNKNOWN
         )
         node_reason = (
-            "FE_BE_VERSIONS_OBSERVED"
-            if nodes_ready
-            else "FE_BE_VERSIONS_INCOMPLETE"
+            "FE_BE_VERSIONS_OBSERVED" if nodes_ready else "FE_BE_VERSIONS_INCOMPLETE"
         )
         for probe_id in (
             "cluster_components_discoverable",
@@ -437,10 +434,7 @@ class DorisCapabilityDetector:
             expires_at=now + timedelta(seconds=self._snapshot_ttl_seconds),
             stale_until=now
             + timedelta(
-                seconds=(
-                    self._snapshot_ttl_seconds
-                    + self._stale_grace_seconds
-                )
+                seconds=(self._snapshot_ttl_seconds + self._stale_grace_seconds)
             ),
         )
 
@@ -484,11 +478,7 @@ class DorisCapabilityDetector:
                 max_rows=512,
                 max_bytes=512 * 1024,
             )
-            rows = tuple(
-                row
-                for row in (result.data or ())
-                if isinstance(row, Mapping)
-            )
+            rows = tuple(row for row in (result.data or ()) if isinstance(row, Mapping))
         except Exception as exc:
             status, reason = _classify_probe_error(exc)
             rows = ()
@@ -501,16 +491,243 @@ class DorisCapabilityDetector:
             reason_code=reason,
         )
 
+    async def _probe_query_services(
+        self,
+        auth_context: Any | None,
+    ) -> dict[str, CapabilityProbeEvidence]:
+        profile, probes = await asyncio.gather(
+            self._safe_probe_profile_api(auth_context),
+            self._safe_probe_adbc_services(auth_context),
+        )
+        probes["query_profile_api_readable"] = profile
+        probes["fe_profile_api"] = CapabilityProbeEvidence(
+            probe_id="fe_profile_api",
+            status=profile.status,
+            reason_code=profile.reason_code,
+            evidence_sources=profile.evidence_sources,
+        )
+        return probes
+
+    async def _safe_probe_profile_api(
+        self,
+        auth_context: Any | None,
+    ) -> CapabilityProbeEvidence:
+        try:
+            async with asyncio.timeout(self._optional_probe_timeout()):
+                return await self._probe_profile_api(auth_context)
+        except TimeoutError:
+            return CapabilityProbeEvidence(
+                probe_id="query_profile_api_readable",
+                status=CapabilityProbeStatus.DEGRADED,
+                reason_code="PROFILE_API_PROBE_TIMED_OUT",
+                evidence_sources=("doris_fe_http", "runtime_probe"),
+            )
+        except Exception:
+            return CapabilityProbeEvidence(
+                probe_id="query_profile_api_readable",
+                status=CapabilityProbeStatus.UNKNOWN,
+                reason_code="PROFILE_API_PROBE_FAILED",
+                evidence_sources=("doris_fe_http", "runtime_probe"),
+            )
+
+    async def _probe_profile_api(
+        self,
+        auth_context: Any | None,
+    ) -> CapabilityProbeEvidence:
+        if getattr(auth_context, "auth_method", "") == "doris_oauth":
+            return CapabilityProbeEvidence(
+                probe_id="query_profile_api_readable",
+                status=CapabilityProbeStatus.MISCONFIGURED,
+                reason_code="PROFILE_API_CREDENTIAL_ROUTE_UNAVAILABLE",
+                evidence_sources=("credential_route_policy",),
+            )
+        try:
+            config_resolver = getattr(
+                self._connection_manager,
+                "get_database_config_for_auth_context",
+                None,
+            )
+            db_config = (
+                config_resolver(auth_context)
+                if callable(config_resolver)
+                else database_config_for_request(self._connection_manager)
+            )
+            client = DorisHTTPClient.from_database_config(db_config)
+            response = await client.get_first_available(
+                role="fe",
+                hosts=configured_fe_http_hosts(db_config),
+                port=db_config.fe_http_port,
+                path="/rest/v2/manager/query/query_info",
+                params={
+                    "query_id": ("0000000000000000-0000000000000000"),
+                    "is_all_node": "false",
+                },
+                headers={"Accept": "application/json, text/plain"},
+            )
+        except DorisHTTPPolicyError:
+            status = CapabilityProbeStatus.MISCONFIGURED
+            reason = "PROFILE_API_ENDPOINT_MISCONFIGURED"
+        except DorisHTTPRequestError:
+            status = CapabilityProbeStatus.DEGRADED
+            reason = "PROFILE_API_UNREACHABLE"
+        except Exception:
+            status = CapabilityProbeStatus.UNKNOWN
+            reason = "PROFILE_API_PROBE_FAILED"
+        else:
+            payload: Mapping[str, Any] | None = None
+            if response.status == 200:
+                try:
+                    parsed = json.loads(response.text())
+                except json.JSONDecodeError:
+                    parsed = None
+                if isinstance(parsed, Mapping):
+                    payload = parsed
+            status, reason = _classify_profile_api_response(
+                response.status,
+                payload,
+            )
+        return CapabilityProbeEvidence(
+            probe_id="query_profile_api_readable",
+            status=status,
+            reason_code=reason,
+            evidence_sources=("doris_fe_http", "runtime_probe"),
+        )
+
+    async def _probe_adbc_services(
+        self,
+        auth_context: Any | None,
+    ) -> dict[str, CapabilityProbeEvidence]:
+        if getattr(auth_context, "auth_method", "") == "doris_oauth":
+            return _adbc_probe_evidence(
+                driver_status=CapabilityProbeStatus.MISCONFIGURED,
+                driver_reason="ADBC_CREDENTIAL_ROUTE_UNAVAILABLE",
+                endpoint_status=CapabilityProbeStatus.MISCONFIGURED,
+                endpoint_reason="ADBC_CREDENTIAL_ROUTE_UNAVAILABLE",
+            )
+        global_database_config = getattr(
+            getattr(self._connection_manager, "config", None),
+            "database",
+            None,
+        )
+        config_resolver = getattr(
+            self._connection_manager,
+            "get_database_config_for_auth_context",
+            None,
+        )
+        if global_database_config is not None and callable(config_resolver):
+            selected_database_config = config_resolver(auth_context)
+            if selected_database_config is not global_database_config:
+                return _adbc_probe_evidence(
+                    driver_status=CapabilityProbeStatus.MISCONFIGURED,
+                    driver_reason="ADBC_CREDENTIAL_ROUTE_UNAVAILABLE",
+                    endpoint_status=CapabilityProbeStatus.MISCONFIGURED,
+                    endpoint_reason="ADBC_CREDENTIAL_ROUTE_UNAVAILABLE",
+                )
+        enabled = bool(
+            getattr(
+                getattr(
+                    getattr(self._connection_manager, "config", None),
+                    "adbc",
+                    None,
+                ),
+                "enabled",
+                False,
+            )
+        )
+        if not enabled:
+            return _adbc_probe_evidence(
+                driver_status=CapabilityProbeStatus.MISCONFIGURED,
+                driver_reason="ADBC_PROVIDER_NOT_CONFIGURED",
+                endpoint_status=CapabilityProbeStatus.MISCONFIGURED,
+                endpoint_reason="ADBC_PROVIDER_NOT_CONFIGURED",
+            )
+        if self._adbc_query_tools is None:
+            return _adbc_probe_evidence(
+                driver_status=CapabilityProbeStatus.UNKNOWN,
+                driver_reason="ADBC_RUNTIME_PROBE_PENDING",
+                endpoint_status=CapabilityProbeStatus.UNKNOWN,
+                endpoint_reason="ADBC_RUNTIME_PROBE_PENDING",
+            )
+
+        module_result = await self._adbc_query_tools._import_adbc_modules()
+        port_result = await self._adbc_query_tools._check_arrow_flight_ports(
+            connectivity_timeout=max(
+                0.25,
+                min(1.0, self._probe_timeout_seconds / 4),
+            )
+        )
+        driver_ready = bool(module_result.get("success"))
+        endpoint_ready = bool(port_result.get("success"))
+        endpoint_error_type = str(port_result.get("error_type", ""))
+        endpoint_status = (
+            CapabilityProbeStatus.SUPPORTED
+            if endpoint_ready
+            else (
+                CapabilityProbeStatus.MISCONFIGURED
+                if endpoint_error_type
+                in {
+                    "missing_fe_port_config",
+                    "missing_be_port_config",
+                    "invalid_port_format",
+                }
+                else CapabilityProbeStatus.DEGRADED
+            )
+        )
+        return _adbc_probe_evidence(
+            driver_status=(
+                CapabilityProbeStatus.SUPPORTED
+                if driver_ready
+                else CapabilityProbeStatus.MISCONFIGURED
+            ),
+            driver_reason=(
+                "ADBC_DRIVER_READY" if driver_ready else "ADBC_DRIVER_NOT_READY"
+            ),
+            endpoint_status=endpoint_status,
+            endpoint_reason=(
+                "FLIGHT_SQL_REACHABLE"
+                if endpoint_ready
+                else (
+                    "FLIGHT_SQL_ENDPOINT_MISCONFIGURED"
+                    if endpoint_status is CapabilityProbeStatus.MISCONFIGURED
+                    else "FLIGHT_SQL_UNREACHABLE"
+                )
+            ),
+        )
+
+    async def _safe_probe_adbc_services(
+        self,
+        auth_context: Any | None,
+    ) -> dict[str, CapabilityProbeEvidence]:
+        try:
+            async with asyncio.timeout(self._optional_probe_timeout()):
+                return await self._probe_adbc_services(auth_context)
+        except TimeoutError:
+            return _adbc_probe_evidence(
+                driver_status=CapabilityProbeStatus.DEGRADED,
+                driver_reason="ADBC_RUNTIME_PROBE_TIMED_OUT",
+                endpoint_status=CapabilityProbeStatus.DEGRADED,
+                endpoint_reason="ADBC_RUNTIME_PROBE_TIMED_OUT",
+            )
+        except Exception:
+            return _adbc_probe_evidence(
+                driver_status=CapabilityProbeStatus.UNKNOWN,
+                driver_reason="ADBC_RUNTIME_PROBE_FAILED",
+                endpoint_status=CapabilityProbeStatus.UNKNOWN,
+                endpoint_reason="ADBC_RUNTIME_PROBE_FAILED",
+            )
+
+    def _optional_probe_timeout(self) -> float:
+        return max(
+            0.25,
+            min(2.0, self._probe_timeout_seconds / 2),
+        )
+
 
 def _classify_probe_error(
     error: Exception,
 ) -> tuple[CapabilityProbeStatus, str]:
     error_code = next(
-        (
-            value
-            for value in getattr(error, "args", ())
-            if isinstance(value, int)
-        ),
+        (value for value in getattr(error, "args", ()) if isinstance(value, int)),
         None,
     )
     if error_code in {1044, 1045, 1142, 1227}:
@@ -529,6 +746,105 @@ def _classify_probe_error(
             "PROBE_CONNECTION_FAILED",
         )
     return CapabilityProbeStatus.UNKNOWN, "RUNTIME_PROBE_FAILED"
+
+
+def _profile_api_code(payload: Mapping[str, Any] | None) -> int | None:
+    if payload is None or "code" not in payload:
+        return None
+    try:
+        return int(payload["code"])
+    except (TypeError, ValueError):
+        return None
+
+
+def _classify_profile_api_response(
+    status_code: int,
+    payload: Mapping[str, Any] | None,
+) -> tuple[CapabilityProbeStatus, str]:
+    api_code = _profile_api_code(payload)
+    if status_code == 200 and api_code == 0:
+        return CapabilityProbeStatus.SUPPORTED, "PROFILE_API_READABLE"
+    if status_code in {401, 403} or api_code in {401, 403}:
+        return (
+            CapabilityProbeStatus.UNKNOWN,
+            "PROFILE_API_PERMISSION_DENIED",
+        )
+    if status_code in {502, 503, 504}:
+        return (
+            CapabilityProbeStatus.DEGRADED,
+            "PROFILE_API_UNREACHABLE",
+        )
+    if status_code == 200:
+        return (
+            CapabilityProbeStatus.UNKNOWN,
+            "PROFILE_API_INVALID_RESPONSE",
+        )
+    return CapabilityProbeStatus.UNSUPPORTED, "PROFILE_API_UNSUPPORTED"
+
+
+def _adbc_probe_evidence(
+    *,
+    driver_status: CapabilityProbeStatus,
+    driver_reason: str,
+    endpoint_status: CapabilityProbeStatus,
+    endpoint_reason: str,
+) -> dict[str, CapabilityProbeEvidence]:
+    return {
+        "adbc_driver_ready": CapabilityProbeEvidence(
+            probe_id="adbc_driver_ready",
+            status=driver_status,
+            reason_code=driver_reason,
+            evidence_sources=("adbc_runtime_probe",),
+        ),
+        "flight_sql_reachable": CapabilityProbeEvidence(
+            probe_id="flight_sql_reachable",
+            status=endpoint_status,
+            reason_code=endpoint_reason,
+            evidence_sources=("adbc_runtime_probe",),
+        ),
+        "flight_sql": CapabilityProbeEvidence(
+            probe_id="flight_sql",
+            status=endpoint_status,
+            reason_code=endpoint_reason,
+            evidence_sources=("adbc_runtime_probe",),
+        ),
+    }
+
+
+def _combine_query_evidence_probe(
+    probes: Mapping[str, CapabilityProbeEvidence],
+) -> CapabilityProbeEvidence:
+    candidates = tuple(
+        probe
+        for probe_id in (
+            "query_profile_api_readable",
+            "audit_log_readable",
+        )
+        if (probe := probes.get(probe_id)) is not None
+    )
+    if any(probe.status is CapabilityProbeStatus.SUPPORTED for probe in candidates):
+        status = CapabilityProbeStatus.SUPPORTED
+        reason = "PROFILE_OR_AUDIT_EVIDENCE_READABLE"
+    elif any(probe.status is CapabilityProbeStatus.DEGRADED for probe in candidates):
+        status = CapabilityProbeStatus.DEGRADED
+        reason = "PROFILE_OR_AUDIT_EVIDENCE_DEGRADED"
+    elif any(
+        probe.status is CapabilityProbeStatus.MISCONFIGURED for probe in candidates
+    ):
+        status = CapabilityProbeStatus.MISCONFIGURED
+        reason = "PROFILE_OR_AUDIT_EVIDENCE_MISCONFIGURED"
+    elif any(probe.status is CapabilityProbeStatus.UNSUPPORTED for probe in candidates):
+        status = CapabilityProbeStatus.UNSUPPORTED
+        reason = "PROFILE_OR_AUDIT_EVIDENCE_UNSUPPORTED"
+    else:
+        status = CapabilityProbeStatus.UNKNOWN
+        reason = "PROFILE_OR_AUDIT_EVIDENCE_UNKNOWN"
+    return CapabilityProbeEvidence(
+        probe_id="profile_or_audit_readable",
+        status=status,
+        reason_code=reason,
+        evidence_sources=("runtime_probe",),
+    )
 
 
 def _row_value(
@@ -564,9 +880,7 @@ def _frontend_versions(
 ) -> tuple[DorisVersion, tuple[DorisVersion, ...]]:
     observed: list[tuple[DorisVersion, bool]] = []
     for row in rows:
-        version = _component_version(
-            _row_value(row, "Version", "FeVersion")
-        )
+        version = _component_version(_row_value(row, "Version", "FeVersion"))
         observed.append(
             (
                 version,
@@ -574,11 +888,7 @@ def _frontend_versions(
             )
         )
     master_index = next(
-        (
-            index
-            for index, (_, is_master) in enumerate(observed)
-            if is_master
-        ),
+        (index for index, (_, is_master) in enumerate(observed) if is_master),
         None,
     )
     if master_index is None:
@@ -588,9 +898,7 @@ def _frontend_versions(
     if not master.raw:
         master = fallback
     followers = tuple(
-        version
-        for index, (version, _) in enumerate(observed)
-        if index != master_index
+        version for index, (version, _) in enumerate(observed) if index != master_index
     )
     return master, followers
 
@@ -599,8 +907,7 @@ def _backend_versions(
     rows: Sequence[Mapping[str, Any]],
 ) -> tuple[DorisVersion, ...]:
     return tuple(
-        _component_version(_row_value(row, "Version", "BeVersion"))
-        for row in rows
+        _component_version(_row_value(row, "Version", "BeVersion")) for row in rows
     )
 
 
@@ -617,8 +924,7 @@ def _cluster_fingerprint(
         for row in rows:
             values.append(
                 "\x1f".join(
-                    str(_row_value(row, identifier) or "")
-                    for identifier in identifiers
+                    str(_row_value(row, identifier) or "") for identifier in identifiers
                 )
             )
         return sorted(values)

--- a/doris_mcp_server/tools/capability_registry.py
+++ b/doris_mcp_server/tools/capability_registry.py
@@ -117,12 +117,12 @@ class CapabilityProviderRegistry:
             providers[provider_id] = CapabilityProviderEvidence(
                 provider_id=provider_id,
                 status=(
-                    CapabilityProbeStatus.DEGRADED
+                    CapabilityProbeStatus.SUPPORTED
                     if configured
                     else CapabilityProbeStatus.MISCONFIGURED
                 ),
                 reason_code=(
-                    "PROVIDER_CONFIGURED_UNPROBED"
+                    "PROVIDER_CONFIGURED"
                     if configured
                     else "PROVIDER_NOT_CONFIGURED"
                 ),

--- a/doris_mcp_server/tools/domain_catalog.py
+++ b/doris_mcp_server/tools/domain_catalog.py
@@ -111,16 +111,17 @@ class LegacyToolMigration(ContractModel):
     def _validate_mode(self) -> Self:
         if self.mode is LegacyMigrationMode.COMPOSITE_SECTION:
             if self.target_section is None:
-                raise ValueError(
-                    "composite-section migrations require target_section"
-                )
+                raise ValueError("composite-section migrations require target_section")
         elif self.target_section is not None:
             raise ValueError(
                 "target_section is only valid for composite-section migrations"
             )
         if self.mode is LegacyMigrationMode.ADAPTED and self.adapter_name is None:
             raise ValueError("adapted migrations require adapter_name")
-        if self.mode is not LegacyMigrationMode.ADAPTED and self.adapter_name is not None:
+        if (
+            self.mode is not LegacyMigrationMode.ADAPTED
+            and self.adapter_name is not None
+        ):
             raise ValueError("adapter_name is only valid for adapted migrations")
         return self
 
@@ -184,9 +185,7 @@ class DorisDomainCatalog(ContractModel):
         )
         _require_unique(child_feature_ids, "formal child feature IDs")
         handler_names = tuple(
-            child.handler_name
-            for domain in self.domains
-            for child in domain.children
+            child.handler_name for domain in self.domains for child in domain.children
         )
         _require_unique(handler_names, "formal child handler bindings")
 
@@ -265,9 +264,10 @@ class DorisDomainCatalog(ContractModel):
             "indexes",
             "basic",
         )
-        if tuple(
-            migration.target_section for migration in table_context_migrations
-        ) != expected_sections:
+        if (
+            tuple(migration.target_section for migration in table_context_migrations)
+            != expected_sections
+        ):
             raise DomainCatalogError(
                 "get_table_context must merge the exact five legacy handlers "
                 "into schema, comments, indexes, and basic sections"
@@ -367,8 +367,7 @@ class DorisDomainCatalog(ContractModel):
         for domain in self.domains:
             for child in domain.children:
                 variants = ", ".join(
-                    f"`{variant.name}`"
-                    for variant in child.support_contract.variants
+                    f"`{variant.name}`" for variant in child.support_contract.variants
                 )
                 lines.append(
                     f"| `{domain.name}.{child.name}` | `{child.handler_name}` | "
@@ -413,12 +412,15 @@ def _string(
     *,
     enum: tuple[str, ...] | None = None,
     pattern: str | None = None,
+    max_length: int | None = None,
 ) -> dict[str, Any]:
     schema: dict[str, Any] = {"type": "string", "description": description}
     if enum is not None:
         schema["enum"] = list(enum)
     if pattern is not None:
         schema["pattern"] = pattern
+    if max_length is not None:
+        schema["maxLength"] = max_length
     return schema
 
 
@@ -495,6 +497,7 @@ def _input_schema(
     *,
     required: tuple[str, ...] = (),
     any_of: tuple[dict[str, Any], ...] = (),
+    one_of: tuple[dict[str, Any], ...] = (),
 ) -> dict[str, Any]:
     schema: dict[str, Any] = {
         "type": "object",
@@ -505,7 +508,26 @@ def _input_schema(
         schema["required"] = list(required)
     if any_of:
         schema["anyOf"] = list(any_of)
+    if one_of:
+        schema["oneOf"] = list(one_of)
     return schema
+
+
+def _query_parameters() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "description": (
+            "Exact values for PyMySQL named placeholders written as "
+            "%(name)s in the SQL text. Supplied keys must match every "
+            "placeholder exactly."
+        ),
+        "propertyNames": {
+            "pattern": r"^[A-Za-z_][A-Za-z0-9_]{0,63}$",
+        },
+        "additionalProperties": {
+            "type": ["string", "integer", "number", "boolean", "null"],
+        },
+    }
 
 
 def _result_schema(
@@ -546,9 +568,7 @@ def _result_schema(
     }
 
 
-_DETAIL_OUTPUT = _result_schema(
-    {"type": "object", "additionalProperties": True}
-)
+_DETAIL_OUTPUT = _result_schema({"type": "object", "additionalProperties": True})
 _DIAGNOSTIC_OUTPUT = _result_schema(
     {"type": "object", "additionalProperties": True},
     evidence=True,
@@ -821,9 +841,7 @@ DOMAIN_DEFINITIONS = (
                 "List visible internal and external Doris catalogs.",
                 _input_schema(
                     {
-                        "include_external": _boolean(
-                            "Include external catalogs."
-                        ),
+                        "include_external": _boolean("Include external catalogs."),
                         "pattern": _string("Optional catalog-name pattern."),
                     }
                 ),
@@ -919,17 +937,28 @@ DOMAIN_DEFINITIONS = (
                 "Execute one read-only Doris SQL statement with bounded results.",
                 _input_schema(
                     {
-                        "sql": _string("Read-only SQL statement."),
-                        "catalog": _string("Catalog context."),
-                        "database": _string("Database context."),
-                        "parameters": _object("Bound query parameters."),
+                        "sql": _string(
+                            "Read-only SQL statement.",
+                            max_length=1024 * 1024,
+                        ),
+                        "catalog": _string(
+                            "Catalog context.",
+                            max_length=64,
+                        ),
+                        "database": _string(
+                            "Database context.",
+                            max_length=64,
+                        ),
+                        "parameters": _query_parameters(),
                         "max_rows": _integer(
                             "Maximum returned rows.",
                             minimum=1,
+                            maximum=100_000,
                         ),
                         "timeout_ms": _integer(
                             "Execution timeout in milliseconds.",
                             minimum=1,
+                            maximum=300_000,
                         ),
                     },
                     required=("sql",),
@@ -944,9 +973,18 @@ DOMAIN_DEFINITIONS = (
                 "pushdown, and index selection.",
                 _input_schema(
                     {
-                        "sql": _string("Read-only SQL statement."),
-                        "catalog": _string("Catalog context."),
-                        "database": _string("Database context."),
+                        "sql": _string(
+                            "Read-only SQL statement.",
+                            max_length=1024 * 1024,
+                        ),
+                        "catalog": _string(
+                            "Catalog context.",
+                            max_length=64,
+                        ),
+                        "database": _string(
+                            "Database context.",
+                            max_length=64,
+                        ),
                         "level": _string(
                             "Explain detail level.",
                             enum=("normal", "verbose", "costs"),
@@ -963,19 +1001,31 @@ DOMAIN_DEFINITIONS = (
                 "Read a Doris query profile by query ID or a bounded SQL run.",
                 _input_schema(
                     {
-                        "query_id": _string("Existing Doris query ID."),
-                        "sql": _string("Read-only SQL to profile."),
+                        "query_id": _string(
+                            "Existing Doris query ID.",
+                            pattern=r"^[A-Za-z0-9_-]+$",
+                            max_length=128,
+                        ),
+                        "sql": _string(
+                            "Read-only SQL to profile.",
+                            max_length=1024 * 1024,
+                        ),
                         "recent_window_minutes": _integer(
                             "Recent lookup window in minutes.",
                             minimum=1,
+                            maximum=129_600,
                         ),
-                        "include_operator_tree": _boolean(
-                            "Include the operator tree."
-                        ),
+                        "include_operator_tree": _boolean("Include the operator tree."),
                     },
-                    any_of=(
-                        {"required": ["query_id"]},
-                        {"required": ["sql"]},
+                    one_of=(
+                        {
+                            "required": ["query_id"],
+                            "not": {"required": ["sql"]},
+                        },
+                        {
+                            "required": ["sql"],
+                            "not": {"required": ["query_id"]},
+                        },
                     ),
                 ),
                 _DIAGNOSTIC_OUTPUT,
@@ -988,16 +1038,32 @@ DOMAIN_DEFINITIONS = (
                 "through deterministic diagnostic rules.",
                 _input_schema(
                     {
-                        "query_id": _string("Existing Doris query ID."),
-                        "sql": _string("Read-only SQL to diagnose."),
-                        "database": _string("Database context."),
+                        "query_id": _string(
+                            "Existing Doris query ID.",
+                            pattern=r"^[A-Za-z0-9_-]+$",
+                            max_length=128,
+                        ),
+                        "sql": _string(
+                            "Read-only SQL to diagnose.",
+                            max_length=1024 * 1024,
+                        ),
+                        "database": _string(
+                            "Database context.",
+                            max_length=64,
+                        ),
                         "include_cluster_context": _boolean(
                             "Include relevant cluster evidence."
                         ),
                     },
-                    any_of=(
-                        {"required": ["query_id"]},
-                        {"required": ["sql"]},
+                    one_of=(
+                        {
+                            "required": ["query_id"],
+                            "not": {"required": ["sql"]},
+                        },
+                        {
+                            "required": ["sql"],
+                            "not": {"required": ["query_id"]},
+                        },
                     ),
                 ),
                 _DIAGNOSTIC_OUTPUT,
@@ -1013,13 +1079,25 @@ DOMAIN_DEFINITIONS = (
                         "window_minutes": _integer(
                             "Lookback window in minutes.",
                             minimum=1,
+                            maximum=129_600,
                         ),
-                        "limit": _integer("Maximum results.", minimum=1),
+                        "limit": _integer(
+                            "Maximum results.",
+                            minimum=1,
+                            maximum=1000,
+                        ),
                         "min_duration_ms": _integer(
-                            "Minimum duration in milliseconds."
+                            "Minimum duration in milliseconds.",
+                            maximum=86_400_000,
                         ),
-                        "database": _string("Database filter."),
-                        "user": _string("User filter."),
+                        "database": _string(
+                            "Database filter.",
+                            max_length=64,
+                        ),
+                        "user": _string(
+                            "User filter.",
+                            max_length=128,
+                        ),
                     }
                 ),
                 _COLLECTION_OUTPUT,
@@ -1038,14 +1116,19 @@ DOMAIN_DEFINITIONS = (
                 "Execute one read-only SQL statement through Arrow Flight SQL.",
                 _input_schema(
                     {
-                        "sql": _string("Read-only SQL statement."),
+                        "sql": _string(
+                            "Read-only SQL statement.",
+                            max_length=1024 * 1024,
+                        ),
                         "max_rows": _integer(
                             "Maximum returned rows.",
                             minimum=1,
+                            maximum=100_000,
                         ),
                         "timeout_ms": _integer(
                             "Execution timeout in milliseconds.",
                             minimum=1,
+                            maximum=300_000,
                         ),
                         "result_format": _string(
                             "Result representation.",
@@ -1098,9 +1181,7 @@ DOMAIN_DEFINITIONS = (
                             "Node types to include.",
                             enum=("fe", "be", "broker"),
                         ),
-                        "include_metrics": _boolean(
-                            "Include bounded node metrics."
-                        ),
+                        "include_metrics": _boolean("Include bounded node metrics."),
                     }
                 ),
                 _COLLECTION_OUTPUT,
@@ -1112,9 +1193,7 @@ DOMAIN_DEFINITIONS = (
                 "List visible query, load, schema-change, and compaction tasks.",
                 _input_schema(
                     {
-                        "task_types": _string_array(
-                            "Task types to include."
-                        ),
+                        "task_types": _string_array("Task types to include."),
                         "states": _string_array("Task states to include."),
                         "limit": _integer("Maximum results.", minimum=1),
                     }
@@ -1158,9 +1237,7 @@ DOMAIN_DEFINITIONS = (
                     {
                         "scope": _string("Cache scope."),
                         "node_ids": _string_array("Node identifiers."),
-                        "include_queues": _boolean(
-                            "Include queue statistics."
-                        ),
+                        "include_queues": _boolean("Include queue statistics."),
                     }
                 ),
             ),
@@ -1186,9 +1263,7 @@ DOMAIN_DEFINITIONS = (
                 _input_schema(
                     {
                         "name": _string("Workload-group name."),
-                        "include_usage": _boolean(
-                            "Include current resource usage."
-                        ),
+                        "include_usage": _boolean("Include current resource usage."),
                     }
                 ),
             ),
@@ -1425,12 +1500,8 @@ DOMAIN_DEFINITIONS = (
                 _input_schema(
                     {
                         "sql": _string("Read-only search SQL."),
-                        "search_request": _object(
-                            "Structured search request."
-                        ),
-                        "include_profile": _boolean(
-                            "Include query-profile evidence."
-                        ),
+                        "search_request": _object("Structured search request."),
+                        "include_profile": _boolean("Include query-profile evidence."),
                     },
                     any_of=(
                         {"required": ["sql"]},
@@ -1478,9 +1549,7 @@ DOMAIN_DEFINITIONS = (
                     {
                         "database": _string("Database name."),
                         "table": _string("Table name."),
-                        "include_partitions": _boolean(
-                            "Include partition details."
-                        ),
+                        "include_partitions": _boolean("Include partition details."),
                         "include_indexes": _boolean("Include index details."),
                     },
                     required=("database", "table"),
@@ -1590,9 +1659,7 @@ DOMAIN_DEFINITIONS = (
                             "Authentication provider.",
                             enum=("ldap", "oidc"),
                         ),
-                        "include_roles": _boolean(
-                            "Include authorized role mappings."
-                        ),
+                        "include_roles": _boolean("Include authorized role mappings."),
                     }
                 ),
                 _DIAGNOSTIC_OUTPUT,
@@ -1613,9 +1680,7 @@ DOMAIN_DEFINITIONS = (
                 _input_schema(
                     {
                         "catalog": _string("External catalog name."),
-                        "include_objects": _boolean(
-                            "Include a bounded object sample."
-                        ),
+                        "include_objects": _boolean("Include a bounded object sample."),
                         "object_limit": _integer(
                             "Maximum sampled objects.",
                             minimum=1,

--- a/doris_mcp_server/tools/domain_dispatcher.py
+++ b/doris_mcp_server/tools/domain_dispatcher.py
@@ -44,6 +44,7 @@ from ..schema_validation import (
 from ..state_handles import StateHandleCodec, StateHandleError
 from ..utils.catalog_metadata import CatalogMetadataFailure
 from ..utils.logger import get_audit_logger, get_logger
+from ..utils.query_runtime import QueryRuntimeFailure
 from . import domain_catalog as domain_catalog_module
 from .domain_catalog import (
     DorisDomainCatalog,
@@ -116,7 +117,16 @@ class _AtomicBinding:
     migration: LegacyToolMigration
 
 
-_Binding = _AtomicBinding | tuple[LegacyToolMigration, ...]
+@dataclass(frozen=True)
+class _FormalBinding:
+    handler_name: str
+
+
+_Binding = _AtomicBinding | _FormalBinding | tuple[LegacyToolMigration, ...]
+
+
+def _formal_handler_name(domain_name: str, child_name: str) -> str:
+    return f"_formal_{domain_name}_{child_name}_tool"
 
 
 def _build_bindings(
@@ -153,6 +163,15 @@ def _build_bindings(
                 f"{feature_id} has ambiguous atomic handler bindings"
             )
         bindings[feature_id] = _AtomicBinding(migrations[0])
+
+    for domain in catalog.domains:
+        for child in domain.children:
+            feature_id = f"{domain.name}.{child.name}"
+            if feature_id in bindings:
+                continue
+            handler_name = _formal_handler_name(domain.name, child.name)
+            if callable(getattr(owner, handler_name, None)):
+                bindings[feature_id] = _FormalBinding(handler_name)
     return bindings
 
 
@@ -539,6 +558,11 @@ class DomainDispatcher:
                     adapter_warnings,
                     auth_context,
                 )
+            elif isinstance(binding, _FormalBinding):
+                data = await self._call_formal(
+                    binding.handler_name,
+                    arguments,
+                )
             else:
                 data = await self._call_table_context(
                     child,
@@ -563,6 +587,30 @@ class DomainDispatcher:
                 details={
                     "rediscover": False,
                     "violations": violations,
+                },
+            )
+        except QueryRuntimeFailure as exc:
+            self._audit(feature_id, arguments, "error", started)
+            if exc.reason_code in {
+                "QUERY_ARGUMENT_INVALID",
+                "QUERY_READ_ONLY_VIOLATION",
+            }:
+                code = DomainErrorCode.CHILD_ARGUMENTS_INVALID
+            elif exc.reason_code == "QUERY_TIMEOUT":
+                code = DomainErrorCode.CHILD_EXECUTION_TIMEOUT
+            else:
+                code = DomainErrorCode.CHILD_EXECUTION_FAILED
+            return self._error(
+                domain.name,
+                code,
+                str(exc),
+                child_tool=child.name,
+                manifest_version=manifest.manifest_version,
+                retryable=exc.retryable,
+                details={
+                    "rediscover": False,
+                    "reason_code": exc.reason_code,
+                    "status_code": exc.status_code,
                 },
             )
         except CatalogMetadataFailure as exc:
@@ -673,6 +721,17 @@ class DomainDispatcher:
         ):
             raise _failure_from_legacy_response(raw)
         return raw, warnings
+
+    async def _call_formal(
+        self,
+        handler_name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        handler = getattr(self._owner, handler_name)
+        raw = await handler(dict(arguments))
+        if not isinstance(raw, dict):
+            raise TypeError("formal child handler must return an object")
+        return raw
 
     async def _call_table_context(
         self,
@@ -835,6 +894,14 @@ class DomainDispatcher:
         adapter_warnings: tuple[str, ...],
         auth_context: Any | None = None,
     ) -> dict[str, Any]:
+        if (
+            raw.get("status") in {"success", "partial"}
+            and isinstance(raw.get("data"), dict)
+            and isinstance(raw.get("warnings"), list)
+            and isinstance(raw.get("metadata"), dict)
+        ):
+            return dict(raw)
+
         output = cast(
             dict[str, Any],
             child.to_wire()["output_schema"],
@@ -1043,10 +1110,6 @@ def _adapt_arguments(
     }
 
     if adapter_name == "adapt:query_arguments":
-        if prepared.pop("parameters", None):
-            raise ChildArgumentsAdapterError(
-                "bound query parameters are not yet supported"
-            )
         timeout_ms = prepared.pop("timeout_ms", None)
         if timeout_ms is not None:
             prepared["timeout"] = max(1, math.ceil(timeout_ms / 1000))
@@ -1059,19 +1122,11 @@ def _adapt_arguments(
     elif adapter_name == "adapt:explain_arguments":
         level = prepared.pop("level", None)
         if level == "costs":
-            raise ChildArgumentsAdapterError(
-                "cost explain is not supported by the active handler"
-            )
-        if level is not None:
+            prepared["level"] = "costs"
+        elif level is not None:
             prepared["verbose"] = level == "verbose"
     elif adapter_name == "adapt:profile_arguments":
-        query_id = prepared.pop("query_id", None)
-        prepared.pop("recent_window_minutes", None)
-        prepared.pop("include_operator_tree", None)
-        if query_id is not None and "sql" not in prepared:
-            raise ChildArgumentsAdapterError(
-                "query-id profile lookup is not yet supported"
-            )
+        pass
     elif adapter_name == "adapt:table_size_arguments":
         prepared["single_replica"] = False
         prepared["_formal_catalog"] = True
@@ -1158,12 +1213,6 @@ def _adapt_arguments(
             "min_duration_ms",
             1000,
         )
-        for unsupported in ("db_name", "user"):
-            if prepared.pop(unsupported, None) is not None:
-                warnings.append(
-                    "One or more slow-query filters are not supported by the "
-                    "active handler."
-                )
     elif adapter_name == "adapt:resource_growth_arguments":
         resource = prepared.pop("resource", None)
         prepared["days"] = prepared.pop("window_days", 30)

--- a/doris_mcp_server/tools/doris_feature_matrix.py
+++ b/doris_mcp_server/tools/doris_feature_matrix.py
@@ -990,7 +990,7 @@ FEATURE_DEFINITIONS = (
     _feature(
         "doris_query",
         "diagnose_query_performance",
-        A,
+        P,
         _variant(
             "deterministic_query_diagnosis",
             providers=("query_evidence_provider",),
@@ -1030,7 +1030,11 @@ FEATURE_DEFINITIONS = (
             "adbc_read_only",
             endpoints=("flight_sql",),
             providers=("adbc_provider",),
-            probes=("adbc_driver_ready", "read_only_sql_guard_ready"),
+            probes=(
+                "adbc_driver_ready",
+                "flight_sql_reachable",
+                "read_only_sql_guard_ready",
+            ),
             sources=("ARROW_ADBC_FLIGHT_SQL",),
         ),
     ),

--- a/doris_mcp_server/tools/query_handlers.py
+++ b/doris_mcp_server/tools/query_handlers.py
@@ -1,0 +1,184 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Formal Query-domain handlers backed by one strict runtime."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, cast
+
+from ..utils.adbc_query_tools import DorisADBCQueryTools
+from ..utils.db import DorisConnectionManager
+from ..utils.query_runtime import DorisQueryRuntime
+
+
+class _QueryHandlerOwner(Protocol):
+    """State supplied by ``DorisToolsManager`` to the mixin."""
+
+    query_runtime: DorisQueryRuntime
+
+    @staticmethod
+    def _required_string(arguments: dict[str, Any], name: str) -> str: ...
+
+
+class QueryToolHandlersMixin:
+    """Route every Query child through the strict formal runtime."""
+
+    def _initialize_query_handlers(
+        self: _QueryHandlerOwner,
+        connection_manager: DorisConnectionManager,
+        adbc_query_tools: DorisADBCQueryTools,
+    ) -> None:
+        self.query_runtime = DorisQueryRuntime(
+            connection_manager,
+            adbc_query_tools,
+        )
+
+    async def _exec_query_tool(
+        self: _QueryHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        sql = self._required_string(arguments, "sql")
+        timeout_ms = arguments.get("timeout_ms")
+        if timeout_ms is None and arguments.get("timeout") is not None:
+            timeout_ms = int(arguments["timeout"]) * 1000
+        return await self.query_runtime.execute_query(
+            sql=sql,
+            catalog=cast(
+                str | None,
+                arguments.get("catalog", arguments.get("catalog_name")),
+            ),
+            database=cast(
+                str | None,
+                arguments.get("database", arguments.get("db_name")),
+            ),
+            parameters=arguments.get("parameters"),
+            max_rows=cast(int | None, arguments.get("max_rows")),
+            timeout_ms=cast(int | None, timeout_ms),
+        )
+
+    async def _get_sql_explain_tool(
+        self: _QueryHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        sql = self._required_string(arguments, "sql")
+        level = arguments.get("level")
+        if level is None:
+            level = "verbose" if arguments.get("verbose") else "normal"
+        return await self.query_runtime.explain_query(
+            sql=sql,
+            catalog=cast(
+                str | None,
+                arguments.get("catalog", arguments.get("catalog_name")),
+            ),
+            database=cast(
+                str | None,
+                arguments.get("database", arguments.get("db_name")),
+            ),
+            level=cast(str, level),
+        )
+
+    async def _get_sql_profile_tool(
+        self: _QueryHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.query_runtime.get_query_profile(
+            query_id=cast(str | None, arguments.get("query_id")),
+            sql=cast(str | None, arguments.get("sql")),
+            recent_window_minutes=cast(
+                int | None,
+                arguments.get("recent_window_minutes"),
+            ),
+            include_operator_tree=bool(
+                arguments.get("include_operator_tree", False)
+            ),
+            database=cast(
+                str | None,
+                arguments.get("database", arguments.get("db_name")),
+            ),
+        )
+
+    async def _analyze_slow_queries_topn_tool(
+        self: _QueryHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        window_minutes = arguments.get("window_minutes")
+        if window_minutes is None and arguments.get("days") is not None:
+            window_minutes = int(arguments["days"]) * 1440
+        return await self.query_runtime.list_slow_queries(
+            window_minutes=cast(int | None, window_minutes),
+            limit=cast(
+                int | None,
+                arguments.get("limit", arguments.get("top_n")),
+            ),
+            min_duration_ms=cast(
+                int | None,
+                arguments.get(
+                    "min_duration_ms",
+                    arguments.get("min_execution_time_ms"),
+                ),
+            ),
+            database=cast(
+                str | None,
+                arguments.get("database", arguments.get("db_name")),
+            ),
+            user=cast(str | None, arguments.get("user")),
+        )
+
+    async def _exec_adbc_query_tool(
+        self: _QueryHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        sql = self._required_string(arguments, "sql")
+        timeout_ms = arguments.get("timeout_ms")
+        if timeout_ms is None and arguments.get("timeout") is not None:
+            timeout_ms = int(arguments["timeout"]) * 1000
+        return await self.query_runtime.execute_adbc_query(
+            sql=sql,
+            max_rows=cast(int | None, arguments.get("max_rows")),
+            timeout_ms=cast(int | None, timeout_ms),
+            result_format=cast(
+                str | None,
+                arguments.get(
+                    "result_format",
+                    arguments.get("return_format"),
+                ),
+            ),
+        )
+
+    async def _get_adbc_connection_info_tool(
+        self: _QueryHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        del arguments
+        return await self.query_runtime.get_adbc_connection_info()
+
+    async def _formal_doris_query_diagnose_query_performance_tool(
+        self: _QueryHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.query_runtime.diagnose_query_performance(
+            query_id=cast(str | None, arguments.get("query_id")),
+            sql=cast(str | None, arguments.get("sql")),
+            database=cast(str | None, arguments.get("database")),
+            include_cluster_context=bool(
+                arguments.get("include_cluster_context", False)
+            ),
+        )
+
+
+__all__ = ["QueryToolHandlersMixin"]

--- a/doris_mcp_server/tools/tools_manager.py
+++ b/doris_mcp_server/tools/tools_manager.py
@@ -27,7 +27,6 @@ from typing import Any
 from mcp.types import Tool
 
 from ..auth.operation_policy import authorize_operation
-from ..result_limits import configured_default_result_rows
 from ..state_handles import StateHandleCodec
 from ..utils.adbc_query_tools import DorisADBCQueryTools
 from ..utils.analysis_tools import MemoryTracker, SQLAnalyzer, TableAnalyzer
@@ -64,6 +63,7 @@ from .domain_manifest import (
     DomainManifestService,
 )
 from .doris_feature_matrix import DORIS_FEATURE_MATRIX
+from .query_handlers import QueryToolHandlersMixin
 from .tool_provider import CustomToolProvider, ToolProviderRuntime
 from .tool_registry import ToolRegistryError
 
@@ -71,6 +71,7 @@ logger = get_logger(__name__)
 
 
 class DorisToolsManager(
+    QueryToolHandlersMixin,
     CatalogToolHandlersMixin,
     DomainManifestManagerMixin,
 ):
@@ -109,6 +110,10 @@ class DorisToolsManager(
 
         # Initialize ADBC query tools
         self.adbc_query_tools = DorisADBCQueryTools(connection_manager)
+        self._initialize_query_handlers(
+            connection_manager,
+            self.adbc_query_tools,
+        )
         self._capability_registry: CapabilityRegistry | None = None
         if domain_availability_provider is None:
             bound_handlers = BoundHandlerAvailabilityProvider(self)
@@ -130,6 +135,7 @@ class DorisToolsManager(
                     "stale_grace_seconds",
                     900,
                 ),
+                adbc_query_tools=self.adbc_query_tools,
             )
             provider_registry = CapabilityProviderRegistry.from_runtime(
                 matrix=DORIS_FEATURE_MATRIX,
@@ -292,28 +298,6 @@ class DorisToolsManager(
         )
         return serialize_dispatch_result(result)
 
-    async def _exec_query_tool(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        """SQL query execution tool routing (supports federation queries)"""
-        sql = self._required_string(arguments, "sql")
-        db_name = arguments.get("db_name")
-        catalog_name = arguments.get("catalog_name")
-        max_rows = arguments.get(
-            "max_rows",
-            configured_default_result_rows(self.connection_manager.config),
-        )
-        max_bytes = arguments.get("max_bytes")
-        timeout = arguments.get("timeout", 30)
-
-        # Delegate to metadata extractor for processing
-        return await self.metadata_extractor.exec_query_for_mcp(
-            sql,
-            db_name,
-            catalog_name,
-            max_rows,
-            timeout,
-            max_bytes=max_bytes,
-        )
-
     async def _get_recent_audit_logs_tool(
         self, arguments: dict[str, Any]
     ) -> dict[str, Any]:
@@ -323,30 +307,6 @@ class DorisToolsManager(
 
         # Delegate to metadata extractor for processing
         return await self.metadata_extractor.get_recent_audit_logs_for_mcp(days, limit)
-
-    async def _get_sql_explain_tool(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        """SQL Explain tool routing"""
-        sql = self._required_string(arguments, "sql")
-        verbose = arguments.get("verbose", False)
-        db_name = arguments.get("db_name")
-        catalog_name = arguments.get("catalog_name")
-
-        # Delegate to SQL analyzer for processing
-        return await self.sql_analyzer.get_sql_explain(
-            sql, verbose, db_name, catalog_name
-        )
-
-    async def _get_sql_profile_tool(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        """SQL Profile tool routing"""
-        sql = self._required_string(arguments, "sql")
-        db_name = arguments.get("db_name")
-        catalog_name = arguments.get("catalog_name")
-        timeout = arguments.get("timeout", 30)
-
-        # Delegate to SQL analyzer for processing
-        return await self.sql_analyzer.get_sql_profile(
-            sql, db_name, catalog_name, timeout
-        )
 
     async def _get_monitoring_metrics_tool(
         self, arguments: dict[str, Any]
@@ -655,20 +615,6 @@ class DorisToolsManager(
             target_table, analysis_depth, include_views, catalog_name, db_name
         )
 
-    async def _analyze_slow_queries_topn_tool(
-        self, arguments: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Slow queries Top-N analysis tool routing"""
-        days = arguments.get("days", 7)
-        top_n = arguments.get("top_n", 20)
-        min_execution_time_ms = arguments.get("min_execution_time_ms", 1000)
-        include_patterns = arguments.get("include_patterns", True)
-
-        # Delegate to performance analytics tools for processing
-        return await self.performance_analytics_tools.analyze_slow_queries_topn(
-            days, top_n, min_execution_time_ms, include_patterns
-        )
-
     async def _analyze_resource_growth_curves_tool(
         self, arguments: dict[str, Any]
     ) -> dict[str, Any]:
@@ -684,29 +630,3 @@ class DorisToolsManager(
         return await self.performance_analytics_tools.analyze_resource_growth_curves(
             days, resource_types, include_predictions, detailed_response
         )
-
-    # ==================== ADBC Query Tools Private Methods ====================
-
-    async def _exec_adbc_query_tool(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        """ADBC query execution tool routing"""
-        sql = self._required_string(arguments, "sql")
-        max_rows = arguments.get("max_rows")
-        max_bytes = arguments.get("max_bytes")
-        timeout = arguments.get("timeout")
-        return_format = arguments.get("return_format")
-
-        # Delegate to ADBC query tools for processing
-        return await self.adbc_query_tools.exec_adbc_query(
-            sql,
-            max_rows=max_rows,
-            timeout=timeout,
-            return_format=return_format,
-            max_bytes=max_bytes,
-        )
-
-    async def _get_adbc_connection_info_tool(
-        self, arguments: dict[str, Any]
-    ) -> dict[str, Any]:
-        """ADBC connection information tool routing"""
-        # Delegate to ADBC query tools for processing
-        return await self.adbc_query_tools.get_adbc_connection_info()

--- a/doris_mcp_server/utils/adbc_query_tools.py
+++ b/doris_mcp_server/utils/adbc_query_tools.py
@@ -80,6 +80,16 @@ class DorisADBCQueryTools:
         self._query_lock = asyncio.Lock()
 
     def _token_bound_route_error(self) -> dict[str, Any] | None:
+        auth_context = get_auth_context()
+        if auth_context is not None and auth_context.auth_method == "doris_oauth":
+            return {
+                "success": False,
+                "error": (
+                    "ADBC is unavailable for token-bound database routes; use "
+                    "doris_query.execute_query or a separately configured MCP process"
+                ),
+                "error_type": "token_bound_adbc_unsupported",
+            }
         global_database_config = getattr(
             self.connection_manager.config,
             "database",
@@ -136,9 +146,7 @@ class DorisADBCQueryTools:
                     ),
                     max_bytes=max_bytes,
                     timeout_seconds=(
-                        timeout
-                        if timeout is not None
-                        else adbc_config.default_timeout
+                        timeout if timeout is not None else adbc_config.default_timeout
                     ),
                 )
             except ResultLimitError as exc:
@@ -196,7 +204,7 @@ class DorisADBCQueryTools:
                 "success": False,
                 "error": f"ADBC query execution failed: {str(e)}",
                 "error_type": "execution_error",
-                "timestamp": datetime.now().isoformat()
+                "timestamp": datetime.now().isoformat(),
             }
 
     async def _close_adbc_client(self) -> None:
@@ -209,7 +217,11 @@ class DorisADBCQueryTools:
         except Exception as exc:
             logger.debug(f"Failed to close ADBC client: {exc}")
 
-    async def _check_arrow_flight_ports(self) -> dict[str, Any]:
+    async def _check_arrow_flight_ports(
+        self,
+        *,
+        connectivity_timeout: float | None = None,
+    ) -> dict[str, Any]:
         """Check Arrow Flight SQL port configuration and availability"""
         try:
             # Check environment variables
@@ -220,14 +232,14 @@ class DorisADBCQueryTools:
                 return {
                     "success": False,
                     "error": "Missing environment variable FE_ARROW_FLIGHT_SQL_PORT, please configure Arrow Flight SQL FE port in .env file",
-                    "error_type": "missing_fe_port_config"
+                    "error_type": "missing_fe_port_config",
                 }
 
             if not be_port_raw:
                 return {
                     "success": False,
                     "error": "Missing environment variable BE_ARROW_FLIGHT_SQL_PORT, please configure Arrow Flight SQL BE port in .env file",
-                    "error_type": "missing_be_port_config"
+                    "error_type": "missing_be_port_config",
                 }
 
             # Convert to integer and validate
@@ -238,21 +250,26 @@ class DorisADBCQueryTools:
                 return {
                     "success": False,
                     "error": "Invalid Arrow Flight SQL port configuration, please ensure FE_ARROW_FLIGHT_SQL_PORT and BE_ARROW_FLIGHT_SQL_PORT are valid numbers",
-                    "error_type": "invalid_port_format"
+                    "error_type": "invalid_port_format",
                 }
 
             # Get host address
             fe_host = self.connection_manager.host
 
             # Check FE Arrow Flight SQL port availability
-            fe_available = self._check_port_connectivity(fe_host, fe_port)
+            fe_available = await asyncio.to_thread(
+                self._check_port_connectivity,
+                fe_host,
+                fe_port,
+                connectivity_timeout,
+            )
             if not fe_available:
                 return {
                     "success": False,
                     "error": f"Cannot connect to FE Arrow Flight SQL port {fe_host}:{fe_port}, please check if service is running",
                     "error_type": "fe_port_unavailable",
                     "fe_host": fe_host,
-                    "fe_port": fe_port
+                    "fe_port": fe_port,
                 }
 
             # Get BE host list
@@ -261,7 +278,7 @@ class DorisADBCQueryTools:
                 return {
                     "success": False,
                     "error": "Cannot get BE node information, please check cluster status",
-                    "error_type": "no_be_hosts"
+                    "error_type": "no_be_hosts",
                 }
 
             # Check at least one BE Arrow Flight SQL port availability
@@ -269,12 +286,15 @@ class DorisADBCQueryTools:
             be_check_results = []
 
             for be_host in be_hosts[:3]:  # Check first 3 BE nodes
-                be_available = self._check_port_connectivity(be_host, be_port)
-                be_check_results.append({
-                    "host": be_host,
-                    "port": be_port,
-                    "available": be_available
-                })
+                be_available = await asyncio.to_thread(
+                    self._check_port_connectivity,
+                    be_host,
+                    be_port,
+                    connectivity_timeout,
+                )
+                be_check_results.append(
+                    {"host": be_host, "port": be_port, "available": be_available}
+                )
                 if be_available:
                     be_available_count += 1
 
@@ -283,7 +303,7 @@ class DorisADBCQueryTools:
                     "success": False,
                     "error": f"Cannot connect to any BE Arrow Flight SQL port (port: {be_port}), please check if BE services are running",
                     "error_type": "no_be_ports_available",
-                    "be_check_results": be_check_results
+                    "be_check_results": be_check_results,
                 }
 
             return {
@@ -293,7 +313,7 @@ class DorisADBCQueryTools:
                 "be_port": be_port,
                 "be_hosts": be_hosts,
                 "be_available_count": be_available_count,
-                "be_check_results": be_check_results
+                "be_check_results": be_check_results,
             }
 
         except Exception as e:
@@ -301,10 +321,15 @@ class DorisADBCQueryTools:
             return {
                 "success": False,
                 "error": f"Arrow Flight port check failed: {str(e)}",
-                "error_type": "port_check_error"
+                "error_type": "port_check_error",
             }
 
-    def _check_port_connectivity(self, host: str, port: int, timeout: int | None = None) -> bool:
+    def _check_port_connectivity(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+    ) -> bool:
         """Check port connectivity"""
         try:
             # Use config timeout if not specified
@@ -328,10 +353,14 @@ class DorisADBCQueryTools:
                 return db_config.be_hosts
 
             # Get BE nodes via SHOW BACKENDS
-            logger.info("No BE hosts configured, getting BE node information via SHOW BACKENDS")
+            logger.info(
+                "No BE hosts configured, getting BE node information via SHOW BACKENDS"
+            )
             connection = await self.connection_manager.get_connection("query")
             auth_context = get_auth_context()
-            result = await connection.execute("SHOW BACKENDS", auth_context=auth_context)
+            result = await connection.execute(
+                "SHOW BACKENDS", auth_context=auth_context
+            )
 
             be_hosts = []
             for row in result.data:
@@ -359,29 +388,33 @@ class DorisADBCQueryTools:
             # Import ADBC Driver Manager
             try:
                 import adbc_driver_manager
+
                 self.adbc_manager_module = adbc_driver_manager
             except ImportError:
                 return {
                     "success": False,
                     "error": "Missing adbc_driver_manager module, please install: pip install adbc_driver_manager",
-                    "error_type": "missing_adbc_manager"
+                    "error_type": "missing_adbc_manager",
                 }
 
             # Import ADBC Flight SQL Driver
             try:
                 import adbc_driver_flightsql.dbapi as flight_sql
+
                 self.flight_sql_module = flight_sql
             except ImportError:
                 return {
                     "success": False,
                     "error": "Missing adbc_driver_flightsql module, please install: pip install adbc_driver_flightsql",
-                    "error_type": "missing_flight_sql_driver"
+                    "error_type": "missing_flight_sql_driver",
                 }
 
             return {
                 "success": True,
-                "adbc_manager_version": getattr(adbc_driver_manager, '__version__', 'unknown'),
-                "flight_sql_version": getattr(flight_sql, '__version__', 'unknown')
+                "adbc_manager_version": getattr(
+                    adbc_driver_manager, "__version__", "unknown"
+                ),
+                "flight_sql_version": getattr(flight_sql, "__version__", "unknown"),
             }
 
         except Exception as e:
@@ -389,16 +422,13 @@ class DorisADBCQueryTools:
             return {
                 "success": False,
                 "error": f"ADBC module import failed: {str(e)}",
-                "error_type": "import_error"
+                "error_type": "import_error",
             }
 
     async def _create_adbc_connection(self) -> dict[str, Any]:
         """Create ADBC connection"""
         try:
-            if (
-                self.adbc_manager_module is None
-                or self.flight_sql_module is None
-            ):
+            if self.adbc_manager_module is None or self.flight_sql_module is None:
                 return {
                     "success": False,
                     "error": "ADBC modules have not been loaded",
@@ -426,22 +456,17 @@ class DorisADBCQueryTools:
 
             # Create connection
             self.adbc_client = self.flight_sql_module.connect(
-                uri=uri,
-                db_kwargs=db_kwargs
+                uri=uri, db_kwargs=db_kwargs
             )
 
-            return {
-                "success": True,
-                "uri": uri,
-                "connection_established": True
-            }
+            return {"success": True, "uri": uri, "connection_established": True}
 
         except Exception as e:
             logger.error(f"Failed to create ADBC connection: {str(e)}")
             return {
                 "success": False,
                 "error": f"Failed to create ADBC connection: {str(e)}",
-                "error_type": "connection_error"
+                "error_type": "connection_error",
             }
 
     async def _execute_query_with_adbc(
@@ -456,7 +481,7 @@ class DorisADBCQueryTools:
                 return {
                     "success": False,
                     "error": "ADBC connection not established",
-                    "error_type": "no_connection"
+                    "error_type": "no_connection",
                 }
 
             # SECURITY FIX: Perform SQL security validation before executing
@@ -464,13 +489,15 @@ class DorisADBCQueryTools:
             if self.connection_manager.security_manager:
                 # Always perform security validation, even without auth_context
                 # Use a default context for basic SQL security checks
-                validation_result = await self.connection_manager.security_manager.validate_sql_security(sql, auth_context)
+                validation_result = await self.connection_manager.security_manager.validate_sql_security(
+                    sql, auth_context
+                )
                 if not validation_result.is_valid:
                     return {
                         "success": False,
                         "error": f"SQL security validation failed: {validation_result.error_message}",
                         "error_type": "security_violation",
-                        "risk_level": validation_result.risk_level
+                        "risk_level": validation_result.risk_level,
                     }
 
             cursor = self.adbc_client.cursor()
@@ -509,7 +536,7 @@ class DorisADBCQueryTools:
                 "success": False,
                 "error": f"ADBC query execution failed: {str(e)}",
                 "error_type": "query_execution_error",
-                "sql": sql
+                "sql": sql,
             }
 
     async def _cancel_adbc_worker(
@@ -671,11 +698,11 @@ class DorisADBCQueryTools:
                     "fe_host": self.connection_manager.host,
                     "fe_arrow_flight_port": fe_port,
                     "be_arrow_flight_port": be_port,
-                    "user": db_config.user
+                    "user": db_config.user,
                 },
                 "port_status": port_status,
                 "module_status": module_status,
-                "timestamp": datetime.now().isoformat()
+                "timestamp": datetime.now().isoformat(),
             }
 
             if port_status["success"] and module_status["success"]:
@@ -697,7 +724,7 @@ class DorisADBCQueryTools:
             return {
                 "status": "error",
                 "error": f"Failed to get ADBC connection information: {str(e)}",
-                "timestamp": datetime.now().isoformat()
+                "timestamp": datetime.now().isoformat(),
             }
 
     def __del__(self) -> None:

--- a/doris_mcp_server/utils/db.py
+++ b/doris_mcp_server/utils/db.py
@@ -195,6 +195,8 @@ class DorisConnection:
         that must remain machine-readable after authorization.
         """
         start_time = time.time()
+        cursor: Any | None = None
+        bounded_result = max_rows is not None or max_bytes is not None
 
         try:
             # If security manager exists, perform SQL security check
@@ -213,109 +215,148 @@ class DorisConnection:
                     "blocked_operations": validation_result.blocked_operations,
                 }
 
-            bounded_result = max_rows is not None or max_bytes is not None
             cursor_type = (
                 aiomysql.SSDictCursor if bounded_result else aiomysql.DictCursor
             )
-            async with self.connection.cursor(cursor_type) as cursor:
-                await cursor.execute(sql, params)
+            cursor = await self.connection.cursor(cursor_type)
+            await cursor.execute(sql, params)
 
-                # cursor.description is set by the DB driver for any statement that returns rows,
-                # avoiding a brittle hardcoded keyword list (e.g. missing WITH/CTE, comments before keywords).
-                result_bytes: int | None = None
-                truncated = False
-                truncation_reason: str | None = None
-                if cursor.description:
-                    if bounded_result:
-                        (
-                            final_data,
-                            result_bytes,
-                            truncated,
-                            truncation_reason,
-                        ) = await self._fetch_bounded_rows(
-                            cursor,
-                            auth_context=auth_context,
-                            mask_result=mask_result,
-                            max_rows=max_rows,
-                            max_bytes=max_bytes,
-                        )
-                        data = final_data
-                        row_count = len(final_data)
-                    else:
-                        data = await cursor.fetchall()
-                        row_count = len(data)
-                else:
-                    data = []
-                    row_count = cursor.rowcount
-
-                execution_time = time.time() - start_time
-                self.last_used = utc_now()
-                self.query_count += 1
-
-                # Get column information
-                columns = []
-                if cursor.description:
-                    columns = [desc[0] for desc in cursor.description]
-
-                # If security manager exists and has auth context, apply data masking
-                final_data = list(data) if data else []
-                if (
-                    not bounded_result
-                    and
-                    self.security_manager
-                    and auth_context
-                    and final_data
-                    and mask_result
-                ):
-                    final_data = await self.security_manager.apply_data_masking(
-                        final_data,
-                        auth_context,
-                    )
-
-                metadata: dict[str, Any] = {
-                    "columns": columns,
-                    "query": sql,
-                    "params": params,
-                }
-                if security_result:
-                    metadata["security_check"] = security_result
+            # cursor.description is set by the DB driver for any statement that returns rows,
+            # avoiding a brittle hardcoded keyword list (e.g. missing WITH/CTE, comments before keywords).
+            result_bytes: int | None = None
+            truncated = False
+            truncation_reason: str | None = None
+            if cursor.description:
                 if bounded_result:
-                    metadata.update(
-                        {
-                            "result_bytes": result_bytes or 2,
-                            "truncated": truncated,
-                            "truncation_reason": truncation_reason,
-                        }
+                    (
+                        final_data,
+                        result_bytes,
+                        truncated,
+                        truncation_reason,
+                    ) = await self._fetch_bounded_rows(
+                        cursor,
+                        auth_context=auth_context,
+                        mask_result=mask_result,
+                        max_rows=max_rows,
+                        max_bytes=max_bytes,
                     )
+                    data = final_data
+                    row_count = len(final_data)
+                else:
+                    data = await cursor.fetchall()
+                    row_count = len(data)
+            else:
+                data = []
+                row_count = cursor.rowcount
 
-                if truncated:
-                    # An unbuffered cursor still has unread rows.  Closing the
-                    # physical connection avoids draining an attacker-sized
-                    # result and prevents it from returning to the pool.
+            execution_time = time.time() - start_time
+            self.last_used = utc_now()
+            self.query_count += 1
+
+            # Get column information
+            columns = []
+            if cursor.description:
+                columns = [desc[0] for desc in cursor.description]
+
+            # If security manager exists and has auth context, apply data masking
+            final_data = list(data) if data else []
+            if (
+                not bounded_result
+                and self.security_manager
+                and auth_context
+                and final_data
+                and mask_result
+            ):
+                final_data = await self.security_manager.apply_data_masking(
+                    final_data,
+                    auth_context,
+                )
+
+            metadata: dict[str, Any] = {
+                "columns": columns,
+                "query": sql,
+                "params": params,
+            }
+            if security_result:
+                metadata["security_check"] = security_result
+            if bounded_result:
+                metadata.update(
+                    {
+                        "result_bytes": result_bytes or 2,
+                        "truncated": truncated,
+                        "truncation_reason": truncation_reason,
+                    }
+                )
+
+            if truncated:
+                # An unbuffered cursor still has unread rows.  Closing the
+                # physical connection avoids draining an attacker-sized
+                # result and prevents it from returning to the pool.  Clear
+                # the local cursor first so cleanup never calls SSCursor.close,
+                # which would otherwise drain the unread result.
+                self.is_healthy = False
+                cursor = None
+                await self.connection.ensure_closed()
+            else:
+                cursor_to_close = cursor
+                cursor = None
+                try:
+                    await cursor_to_close.close()
+                except Exception:
                     self.is_healthy = False
                     await self.connection.ensure_closed()
+                    raise
 
-                return QueryResult(
-                    data=final_data,
-                    metadata=metadata,
-                    execution_time=execution_time,
-                    row_count=row_count,
-                    sql=sql,
-                )
+            return QueryResult(
+                data=final_data,
+                metadata=metadata,
+                execution_time=execution_time,
+                row_count=row_count,
+                sql=sql,
+            )
 
         except asyncio.CancelledError:
             # MCP cancellation and asyncio timeouts both arrive here as task
             # cancellation.  A running MySQL command cannot safely be returned
             # to the pool, so terminate its physical connection first.
             self.is_healthy = False
+            cursor = None
             try:
                 await self.connection.ensure_closed()
             finally:
                 raise
         except Exception as e:
             self.is_healthy = False
+            if bounded_result and cursor is not None:
+                # SSCursor.close() drains unread rows.  A bounded fetch that
+                # fails must terminate its physical connection instead.
+                cursor = None
+                try:
+                    await self.connection.ensure_closed()
+                except Exception as close_error:
+                    self.logger.warning(
+                        "Failed to close connection after bounded query failure: %s",
+                        close_error,
+                    )
             logging.error(f"Query execution failed: {e}")
             raise
+        finally:
+            if cursor is not None:
+                try:
+                    await cursor.close()
+                except Exception as cleanup_error:
+                    self.is_healthy = False
+                    self.logger.warning(
+                        "Failed to close cursor after query failure: %s",
+                        cleanup_error,
+                    )
+                    try:
+                        await self.connection.ensure_closed()
+                    except Exception as close_error:
+                        self.logger.warning(
+                            "Failed to close connection after cursor cleanup failure: %s",
+                            close_error,
+                        )
 
     async def _fetch_bounded_rows(
         self,
@@ -615,7 +656,11 @@ class DorisConnectionManager:
     @staticmethod
     def _ordered_hosts(primary: str, configured: object) -> list[str]:
         hosts = (
-            [host.strip() for host in configured if isinstance(host, str) and host.strip()]
+            [
+                host.strip()
+                for host in configured
+                if isinstance(host, str) and host.strip()
+            ]
             if isinstance(configured, list)
             else []
         )
@@ -2367,9 +2412,7 @@ class DorisConnectionManager:
             effective_context is not None
             and effective_context.auth_method == "doris_oauth"
         ):
-            doris_user = self._validate_doris_user(
-                effective_context.doris_user
-            )
+            doris_user = self._validate_doris_user(effective_context.doris_user)
             route_key = self._doris_user_route_key(doris_user)
             meta = self.doris_user_pool_meta.get(doris_user)
             generation = meta.generation if meta is not None else 0
@@ -2378,9 +2421,7 @@ class DorisConnectionManager:
             route_key = f"static_token:{token_hash}"
             generation = self._token_pool_generations.get(token_hash, 0)
 
-        database_config = self.get_database_config_for_auth_context(
-            effective_context
-        )
+        database_config = self.get_database_config_for_auth_context(effective_context)
 
         def config_value(name: str, default: Any = "") -> Any:
             if isinstance(database_config, Mapping):
@@ -2402,16 +2443,12 @@ class DorisConnectionManager:
         endpoint_fingerprint = hashlib.sha256(
             endpoint_material.encode("utf-8")
         ).hexdigest()
-        route_material = (
-            f"{route_key}\x1f{generation}\x1f{endpoint_fingerprint}"
-        )
+        route_material = f"{route_key}\x1f{generation}\x1f{endpoint_fingerprint}"
         return DorisRouteIdentity(
             route_key=route_key,
             generation=generation,
             endpoint_fingerprint=endpoint_fingerprint,
-            fingerprint=hashlib.sha256(
-                route_material.encode("utf-8")
-            ).hexdigest(),
+            fingerprint=hashlib.sha256(route_material.encode("utf-8")).hexdigest(),
         )
 
     async def _get_connection_for_auth_context(
@@ -2576,6 +2613,12 @@ class DorisConnectionManager:
 
         raw_connection = connection.connection
         owner_pool = getattr(connection, "owner_pool", None)
+        if getattr(connection, "is_healthy", True) is False:
+            await self._force_close_raw_connection(
+                raw_connection,
+                "unhealthy routed connection",
+            )
+            return
         if owner_pool is None:
             self.logger.warning(
                 "Connection %s has no captured owner pool; force closing raw connection",

--- a/doris_mcp_server/utils/doris_http_client.py
+++ b/doris_mcp_server/utils/doris_http_client.py
@@ -210,9 +210,7 @@ def configured_fe_http_hosts(database_config: Any) -> tuple[str, ...]:
             ):
                 raise DorisHTTPPolicyError("Configured Doris FE SQL hosts are invalid")
             if len(sql_hosts) > MAX_CONFIGURED_HOSTS:
-                raise DorisHTTPPolicyError(
-                    "Too many Doris FE SQL hosts are configured"
-                )
+                raise DorisHTTPPolicyError("Too many Doris FE SQL hosts are configured")
             candidates = sql_hosts or [database_config.host]
 
     return tuple(dict.fromkeys(_normalize_host(host) for host in candidates))
@@ -220,6 +218,13 @@ def configured_fe_http_hosts(database_config: Any) -> tuple[str, ...]:
 
 def database_config_for_request(connection_manager: Any) -> Any:
     """Resolve a token-bound endpoint config with legacy-manager fallback."""
+    from .security import get_current_auth_context
+
+    auth_context = get_current_auth_context()
+    if auth_context is not None and auth_context.auth_method == "doris_oauth":
+        raise DorisHTTPPolicyError(
+            "Doris OAuth credentials are unavailable for HTTP Basic requests"
+        )
     resolver = getattr(
         connection_manager,
         "get_database_config_for_auth_context",

--- a/doris_mcp_server/utils/query_runtime.py
+++ b/doris_mcp_server/utils/query_runtime.py
@@ -1,0 +1,1846 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Strict read-only execution and evidence collection for the Query domain."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import re
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import Any
+from urllib.parse import quote
+
+import sqlparse
+from sqlparse import tokens as sql_tokens
+
+from ..result_limits import (
+    ResultLimitError,
+    ResultLimits,
+    configured_default_result_rows,
+    configured_result_limits,
+    resolve_result_limits,
+)
+from .adbc_query_tools import DorisADBCQueryTools
+from .db import DorisConnectionManager, QueryResult
+from .doris_http_client import (
+    DorisHTTPClient,
+    DorisHTTPResponse,
+    configured_fe_http_hosts,
+    database_config_for_request,
+)
+from .security import get_current_auth_context
+from .sql_security_utils import (
+    SQLSecurityError,
+    quote_identifier,
+    validate_identifier,
+)
+
+_MAX_SQL_LENGTH = 1024 * 1024
+_MAX_QUERY_ID_LENGTH = 128
+_MAX_SLOW_QUERY_LIMIT = 1000
+_MAX_SLOW_QUERY_WINDOW_MINUTES = 90 * 24 * 60
+_MAX_SLOW_QUERY_TEXT = 8192
+_QUERY_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+_NAMED_PARAMETER_RE = re.compile(r"(?<!%)%\(([A-Za-z_][A-Za-z0-9_]*)\)s")
+_POSITIONAL_PARAMETER_RE = re.compile(r"(?<!%)%s")
+_SIDE_EFFECT_FUNCTIONS = (
+    "BENCHMARK",
+    "GET_LOCK",
+    "LOAD_FILE",
+    "MASTER_POS_WAIT",
+    "RELEASE_LOCK",
+    "SLEEP",
+)
+
+
+class QueryRuntimeFailure(RuntimeError):
+    """Sanitized Query-domain failure with a stable reason code."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        status_code: int,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.status_code = status_code
+        self.retryable = retryable
+
+
+@dataclass(frozen=True, slots=True)
+class ReadOnlyStatement:
+    """One canonical, single-statement read-only SQL request."""
+
+    sql: str
+    operation: str
+
+
+class ReadOnlySQLGuard:
+    """Fail-closed SQL parser used by every formal Query execution path."""
+
+    @classmethod
+    def validate(
+        cls,
+        sql: str,
+        *,
+        query_target: bool = False,
+    ) -> ReadOnlyStatement:
+        if not isinstance(sql, str) or not sql.strip():
+            raise _argument_failure("SQL must be a non-empty string.")
+        if len(sql.encode("utf-8")) > _MAX_SQL_LENGTH:
+            raise _argument_failure("SQL exceeds the maximum accepted size.")
+        if "/*!" in sql:
+            raise _read_only_failure("Executable version comments are not allowed.")
+
+        statements = [
+            statement
+            for statement in sqlparse.parse(sql)
+            if _has_executable_sql(statement)
+        ]
+        if len(statements) != 1:
+            raise _read_only_failure("Exactly one read-only SQL statement is required.")
+
+        statement = statements[0]
+        canonical = str(statement).strip()
+        if canonical.endswith(";"):
+            canonical = canonical[:-1].rstrip()
+        code_tokens = [
+            token
+            for token in statement.flatten()
+            if not token.is_whitespace
+            and token.ttype not in sql_tokens.Comment
+            and token.ttype not in sql_tokens.Literal.String
+        ]
+        if not code_tokens:
+            raise _argument_failure("SQL contains no executable statement.")
+
+        parsed_type = statement.get_type().upper()
+        first = str(code_tokens[0].value).strip().upper()
+        operation = parsed_type if parsed_type != "UNKNOWN" else first
+        if first == "WITH" and parsed_type == "SELECT":
+            operation = "SELECT"
+        if operation not in {"SELECT", "SHOW", "DESC", "DESCRIBE", "EXPLAIN"}:
+            raise _read_only_failure(
+                f"SQL operation {operation or 'UNKNOWN'} is not read-only."
+            )
+        if query_target and operation not in {"SELECT", "SHOW", "DESC", "DESCRIBE"}:
+            raise _read_only_failure(
+                "This operation requires a query target, not an EXPLAIN statement."
+            )
+
+        if operation == "EXPLAIN":
+            executable_sql = "".join(
+                str(token.value)
+                for token in statement.flatten()
+                if token.ttype not in sql_tokens.Comment
+            )
+            target = re.fullmatch(
+                r"\s*EXPLAIN(?:\s+VERBOSE)?\s+(.+?)\s*",
+                executable_sql,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            if target is None:
+                raise _read_only_failure(
+                    "EXPLAIN must contain one supported read-only query target."
+                )
+            cls.validate(target.group(1), query_target=True)
+
+        code = " ".join(str(token.value) for token in code_tokens)
+        upper_code = code.upper()
+        if re.search(r"\bINTO\s+(OUTFILE|DUMPFILE)\b", upper_code):
+            raise _read_only_failure("Result export clauses are not allowed.")
+        if ":=" in code:
+            raise _read_only_failure("Session-variable assignment is not allowed.")
+        if re.search(r"\bFOR\s+UPDATE\b", upper_code):
+            raise _read_only_failure("Locking reads are not allowed.")
+        if re.search(r"\bLOCK\s+IN\s+SHARE\s+MODE\b", upper_code):
+            raise _read_only_failure("Locking reads are not allowed.")
+
+        if operation == "SELECT":
+            contains_nested_mutation = any(
+                (
+                    token.ttype in sql_tokens.Keyword.DML
+                    and str(token.value).strip().upper() != "SELECT"
+                )
+                or token.ttype in sql_tokens.Keyword.DDL
+                for token in code_tokens
+            )
+            if contains_nested_mutation:
+                raise _read_only_failure("SQL contains a disallowed operation.")
+        for function_name in _SIDE_EFFECT_FUNCTIONS:
+            if re.search(
+                rf"\b{re.escape(function_name)}\s*\(",
+                upper_code,
+            ):
+                raise _read_only_failure(
+                    "SQL contains a disallowed side-effecting function."
+                )
+
+        return ReadOnlyStatement(sql=canonical, operation=operation)
+
+    @staticmethod
+    def validate_parameters(
+        sql: str,
+        parameters: Mapping[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        parameter_code = _parameter_code(sql)
+        placeholders = set(_NAMED_PARAMETER_RE.findall(parameter_code))
+        if _POSITIONAL_PARAMETER_RE.search(parameter_code):
+            raise _argument_failure(
+                "Positional SQL parameters are not supported; use named "
+                "%(name)s placeholders."
+            )
+        if parameters is None:
+            if placeholders:
+                raise _argument_failure("SQL parameters are missing.")
+            return None
+        if not isinstance(parameters, Mapping):
+            raise _argument_failure("Query parameters must be an object.")
+
+        normalized: dict[str, Any] = {}
+        for raw_name, value in parameters.items():
+            if not isinstance(raw_name, str) or not re.fullmatch(
+                r"[A-Za-z_][A-Za-z0-9_]{0,63}",
+                raw_name,
+            ):
+                raise _argument_failure("Query parameter names are invalid.")
+            if value is not None and not isinstance(
+                value,
+                str | int | float | bool,
+            ):
+                raise _argument_failure("Query parameter values must be JSON scalars.")
+            if isinstance(value, float) and not math.isfinite(value):
+                raise _argument_failure("Query parameter numbers must be finite.")
+            normalized[raw_name] = value
+
+        supplied = set(normalized)
+        if supplied != placeholders:
+            raise _argument_failure(
+                "SQL placeholders and supplied parameters must match exactly."
+            )
+        return normalized
+
+    @staticmethod
+    def prepare_driver_sql(
+        sql: str,
+        parameters: Mapping[str, Any] | None,
+    ) -> str:
+        """Escape non-placeholder percent signs for the PyMySQL formatter."""
+        if parameters is None:
+            return sql
+        parameter_code = _parameter_code(sql)
+        placeholder_ends = {
+            match.start(): match.end()
+            for match in _NAMED_PARAMETER_RE.finditer(parameter_code)
+        }
+        output: list[str] = []
+        offset = 0
+        while offset < len(sql):
+            placeholder_end = placeholder_ends.get(offset)
+            if placeholder_end is not None:
+                output.append(sql[offset:placeholder_end])
+                offset = placeholder_end
+                continue
+            character = sql[offset]
+            output.append("%%" if character == "%" else character)
+            offset += 1
+        return "".join(output)
+
+
+class DorisQueryRuntime:
+    """Production Query-domain runtime shared by hierarchical and flat tools."""
+
+    def __init__(
+        self,
+        connection_manager: DorisConnectionManager,
+        adbc_query_tools: DorisADBCQueryTools,
+    ) -> None:
+        self._connection_manager = connection_manager
+        self._adbc_query_tools = adbc_query_tools
+        self._session_prefix = f"formal_query_{uuid.uuid4().hex[:8]}"
+
+    async def execute_query(
+        self,
+        *,
+        sql: str,
+        catalog: str | None = None,
+        database: str | None = None,
+        parameters: Mapping[str, Any] | None = None,
+        max_rows: int | None = None,
+        timeout_ms: int | None = None,
+    ) -> dict[str, Any]:
+        """Execute one bounded read-only statement over the MySQL protocol."""
+        statement = ReadOnlySQLGuard.validate(sql)
+        bound_parameters = ReadOnlySQLGuard.validate_parameters(
+            statement.sql,
+            parameters,
+        )
+        driver_sql = ReadOnlySQLGuard.prepare_driver_sql(
+            statement.sql,
+            bound_parameters,
+        )
+        limits = self._resolve_limits(max_rows=max_rows, timeout_ms=timeout_ms)
+        result = await self._execute_statement(
+            driver_sql,
+            parameters=bound_parameters,
+            catalog=catalog,
+            database=database,
+            limits=limits,
+            purpose="execute",
+        )
+        return _query_result(
+            result,
+            limits=limits,
+            protocol="mysql",
+            operation=statement.operation,
+        )
+
+    async def explain_query(
+        self,
+        *,
+        sql: str,
+        catalog: str | None = None,
+        database: str | None = None,
+        level: str | None = None,
+    ) -> dict[str, Any]:
+        """Return a bounded plan plus deterministic, evidence-only facets."""
+        statement = ReadOnlySQLGuard.validate(sql, query_target=True)
+        ReadOnlySQLGuard.validate_parameters(statement.sql, None)
+        requested_level = "normal" if level is None else level
+        if requested_level not in {"normal", "verbose", "costs"}:
+            raise _argument_failure("Explain level is invalid.")
+
+        warnings: list[str] = []
+        effective_level = requested_level
+        if requested_level == "normal":
+            explain_prefix = "EXPLAIN"
+        else:
+            explain_prefix = "EXPLAIN VERBOSE"
+            if requested_level == "costs":
+                effective_level = "verbose"
+                warnings.append(
+                    "Doris has no EXPLAIN COSTS keyword; the verbose plan and "
+                    "its reported cardinality/cost fields were returned."
+                )
+
+        explain_row_budget = min(
+            10_000,
+            configured_result_limits(self._connection_manager.config).max_rows,
+        )
+        limits = self._resolve_limits(
+            max_rows=explain_row_budget,
+            timeout_ms=None,
+        )
+        result = await self._execute_statement(
+            f"{explain_prefix} {statement.sql}",
+            parameters=None,
+            catalog=catalog,
+            database=database,
+            limits=limits,
+            purpose="explain",
+            mask_result=False,
+        )
+        plan_rows = [_json_mapping(row) for row in (result.data or [])]
+        plan_truncated = bool(result.metadata.get("truncated"))
+        truncation_reason = result.metadata.get("truncation_reason")
+        if plan_truncated:
+            warnings.append(
+                "The EXPLAIN output was truncated at the configured result "
+                f"boundary ({truncation_reason or 'unknown limit'})."
+            )
+        plan_text = "\n".join(
+            " | ".join(str(value) for value in row.values()) for row in plan_rows
+        )
+        data = {
+            "requested_level": requested_level,
+            "effective_level": effective_level,
+            "plan_rows": plan_rows,
+            "plan_text": plan_text,
+            "facets": _explain_facets(plan_text),
+        }
+        metadata = {
+            "source": "doris_explain",
+            "plan_row_count": len(plan_rows),
+            "plan_truncated": plan_truncated,
+            "truncation_reason": truncation_reason,
+            "execution_time_seconds": getattr(result, "execution_time", 0.0),
+        }
+        return _diagnostic_result(
+            data,
+            status="partial" if warnings else "success",
+            warnings=warnings,
+            metadata=metadata,
+            evidence=(
+                {
+                    "source": "doris_sql",
+                    "kind": "explain",
+                    "operation": statement.operation,
+                },
+            ),
+        )
+
+    async def get_query_profile(
+        self,
+        *,
+        query_id: str | None = None,
+        sql: str | None = None,
+        recent_window_minutes: int | None = None,
+        include_operator_tree: bool = False,
+        database: str | None = None,
+    ) -> dict[str, Any]:
+        """Read one profile by ID or execute one bounded query with profiling."""
+        if bool(query_id) == bool(sql):
+            raise _argument_failure("Provide exactly one of query_id or sql.")
+        window = _bounded_integer(
+            (60 if recent_window_minutes is None else recent_window_minutes),
+            "recent_window_minutes",
+            minimum=1,
+            maximum=_MAX_SLOW_QUERY_WINDOW_MINUTES,
+        )
+        warnings: list[str] = []
+        query_summary: dict[str, Any] | None = None
+        resolved_query_id = query_id
+
+        if query_id is not None:
+            resolved_query_id = _validate_query_id(query_id)
+        else:
+            statement = ReadOnlySQLGuard.validate(str(sql), query_target=True)
+            ReadOnlySQLGuard.validate_parameters(statement.sql, None)
+            limits = self._resolve_limits(max_rows=1, timeout_ms=None)
+            trace_id = str(uuid.uuid4())
+            query_result = await self._execute_profiled_statement(
+                statement.sql,
+                trace_id=trace_id,
+                database=database,
+                limits=limits,
+            )
+            query_summary = {
+                "row_count": len(query_result.data or []),
+                "execution_time_seconds": query_result.execution_time,
+                "truncated": bool(query_result.metadata.get("truncated")),
+            }
+            resolved_query_id = await self._wait_for_query_id(trace_id)
+            if resolved_query_id is None:
+                return _diagnostic_result(
+                    {
+                        "query_id": None,
+                        "profile": None,
+                        "operator_tree": [],
+                        "query_summary": query_summary,
+                    },
+                    status="partial",
+                    warnings=(
+                        "The query completed, but Doris did not publish a "
+                        "query ID before the bounded lookup expired.",
+                    ),
+                    metadata={
+                        "source": "doris_profile_api",
+                        "recent_window_minutes": window,
+                    },
+                    evidence=(
+                        {
+                            "source": "doris_sql",
+                            "kind": "profiled_query",
+                        },
+                    ),
+                )
+
+        profile = await self._fetch_profile(_validate_query_id(resolved_query_id))
+        profile_text = profile["profile_text"]
+        maximum = _profile_text_limit(self._connection_manager.config)
+        truncated = len(profile_text) > maximum
+        visible_profile = profile_text[:maximum]
+        if truncated:
+            warnings.append(
+                "Profile text was truncated at the configured response limit."
+            )
+        operator_tree = (
+            _profile_operator_tree(visible_profile) if include_operator_tree else []
+        )
+        return _diagnostic_result(
+            {
+                "query_id": resolved_query_id,
+                "profile": visible_profile,
+                "profile_facets": _profile_facets(visible_profile),
+                "operator_tree": operator_tree,
+                "query_summary": query_summary,
+            },
+            status="partial" if warnings else "success",
+            warnings=warnings,
+            metadata={
+                "source": "doris_profile_api",
+                "profile_size": len(profile_text),
+                "profile_truncated": truncated,
+                "recent_window_minutes": window,
+            },
+            evidence=(
+                {
+                    "source": "doris_fe_http",
+                    "kind": "query_profile",
+                    "query_id": resolved_query_id,
+                },
+            ),
+        )
+
+    async def list_slow_queries(
+        self,
+        *,
+        window_minutes: int | None = None,
+        limit: int | None = None,
+        min_duration_ms: int | None = None,
+        database: str | None = None,
+        user: str | None = None,
+    ) -> dict[str, Any]:
+        """List bounded audit-log records without swallowing provider failures."""
+        window = _bounded_integer(
+            60 if window_minutes is None else window_minutes,
+            "window_minutes",
+            minimum=1,
+            maximum=_MAX_SLOW_QUERY_WINDOW_MINUTES,
+        )
+        row_limit = _bounded_integer(
+            20 if limit is None else limit,
+            "limit",
+            minimum=1,
+            maximum=_MAX_SLOW_QUERY_LIMIT,
+        )
+        duration = _bounded_integer(
+            1000 if min_duration_ms is None else min_duration_ms,
+            "min_duration_ms",
+            minimum=0,
+            maximum=86_400_000,
+        )
+        if database is not None:
+            try:
+                validate_identifier(database, "database name")
+            except SQLSecurityError as exc:
+                raise _argument_failure(
+                    "Slow-query database filter is invalid."
+                ) from exc
+        if user is not None and (not user.strip() or len(user) > 128):
+            raise _argument_failure("User filter is invalid.")
+
+        start_time = datetime.now() - timedelta(minutes=window)
+        normalized_user = user.strip() if user is not None else None
+        sql = (
+            "SELECT `query_id`, `time`, `user`, `catalog`, `db`, `state`, "
+            "`query_time`, `cpu_time_ms`, `scan_bytes`, `scan_rows`, "
+            "`return_rows`, `peak_memory_bytes`, `sql_hash`, `sql_digest`, "
+            "`stmt` FROM internal.__internal_schema.audit_log "
+            "WHERE `time` >= %s AND `query_time` >= %s AND `is_query` = 1 "
+            "AND (%s IS NULL OR `db` = %s) "
+            "AND (%s IS NULL OR `user` = %s) "
+            "ORDER BY `query_time` DESC, `time` DESC, `query_id` "
+            "LIMIT %s"
+        )
+        params = (
+            start_time,
+            duration,
+            database,
+            database,
+            normalized_user,
+            normalized_user,
+            row_limit + 1,
+        )
+        limits = ResultLimits(
+            max_rows=row_limit + 1,
+            max_bytes=configured_result_limits(
+                self._connection_manager.config
+            ).max_bytes,
+            timeout_seconds=min(
+                30,
+                configured_result_limits(
+                    self._connection_manager.config
+                ).timeout_seconds,
+            ),
+        )
+        result = await self._execute_statement(
+            sql,
+            parameters=tuple(params),
+            catalog=None,
+            database=None,
+            limits=limits,
+            purpose="slow_queries",
+            mask_result=False,
+            trusted_internal=True,
+        )
+        raw_rows = list(result.data or [])
+        truncated = len(raw_rows) > row_limit
+        raw_rows = await self._mask_audit_rows(raw_rows)
+        items = [_slow_query_item(row) for row in raw_rows[:row_limit]]
+        return _collection_result(
+            items,
+            truncated=truncated,
+            metadata={
+                "source": "internal.__internal_schema.audit_log",
+                "window_minutes": window,
+                "min_duration_ms": duration,
+                "returned_items": len(items),
+            },
+        )
+
+    async def get_adbc_connection_info(self) -> dict[str, Any]:
+        """Return a secret-free summary of the optional ADBC provider."""
+        raw = await self._adbc_query_tools.get_adbc_connection_info()
+        if not isinstance(raw, Mapping):
+            raise QueryRuntimeFailure(
+                "ADBC provider returned an invalid status response.",
+                reason_code="ADBC_PROVIDER_INVALID_RESPONSE",
+                status_code=502,
+            )
+        port_status = raw.get("port_status")
+        module_status = raw.get("module_status")
+        port_data = port_status if isinstance(port_status, Mapping) else {}
+        module_data = module_status if isinstance(module_status, Mapping) else {}
+        configuration = raw.get("configuration")
+        configuration_data = configuration if isinstance(configuration, Mapping) else {}
+        status = str(raw.get("status", "not_ready"))
+        data = {
+            "enabled": bool(
+                getattr(
+                    getattr(self._connection_manager.config, "adbc", None),
+                    "enabled",
+                    False,
+                )
+            ),
+            "status": status,
+            "driver_ready": bool(module_data.get("success")),
+            "flight_sql_reachable": bool(port_data.get("success")),
+            "fe_port_configured": bool(configuration_data.get("fe_arrow_flight_port")),
+            "be_port_configured": bool(configuration_data.get("be_arrow_flight_port")),
+            "reachable_be_count": int(port_data.get("be_available_count", 0) or 0),
+            "driver_versions": {
+                "manager": str(module_data.get("adbc_manager_version", "unknown")),
+                "flight_sql": str(module_data.get("flight_sql_version", "unknown")),
+            },
+        }
+        warnings = (
+            ()
+            if status == "ready"
+            else ("ADBC is not ready on the active Doris route.",)
+        )
+        return _detail_result(
+            data,
+            status="partial" if warnings else "success",
+            warnings=warnings,
+            metadata={"source": "adbc_runtime_probe"},
+        )
+
+    async def execute_adbc_query(
+        self,
+        *,
+        sql: str,
+        max_rows: int | None = None,
+        timeout_ms: int | None = None,
+        result_format: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute one strict read-only query through Arrow Flight SQL."""
+        statement = ReadOnlySQLGuard.validate(sql)
+        ReadOnlySQLGuard.validate_parameters(statement.sql, None)
+        if result_format not in {None, "arrow", "pandas", "dict"}:
+            raise _argument_failure("ADBC result format is invalid.")
+        timeout = (
+            math.ceil(
+                _bounded_integer(
+                    timeout_ms,
+                    "timeout_ms",
+                    minimum=1,
+                    maximum=300_000,
+                )
+                / 1000
+            )
+            if timeout_ms is not None
+            else None
+        )
+        raw = await self._adbc_query_tools.exec_adbc_query(
+            statement.sql,
+            max_rows=max_rows,
+            timeout=timeout,
+            return_format=result_format,
+        )
+        if not isinstance(raw, Mapping) or raw.get("success") is not True:
+            raise _classify_adbc_failure(raw)
+
+        result = raw.get("result")
+        result_data = result if isinstance(result, Mapping) else {}
+        column_names = list(result_data.get("column_names", []) or [])
+        column_types = list(result_data.get("column_types", []) or [])
+        rows_value = result_data.get("data")
+        if not isinstance(rows_value, list):
+            rows_value = result_data.get("data_preview")
+        rows = [
+            _json_mapping(row)
+            for row in (rows_value if isinstance(rows_value, list) else [])
+            if isinstance(row, Mapping)
+        ]
+        source_row_count = int(result_data.get("num_rows", len(rows)) or 0)
+        representation_truncated = source_row_count > len(rows)
+        truncated = bool(raw.get("truncated")) or representation_truncated
+        warnings: list[str] = []
+        if representation_truncated:
+            warnings.append(
+                "The Arrow representation exposes a bounded row preview in "
+                "the MCP JSON response."
+            )
+        return _query_output(
+            columns=[
+                {
+                    "name": str(name),
+                    "type": (
+                        str(column_types[index])
+                        if index < len(column_types)
+                        else "unknown"
+                    ),
+                }
+                for index, name in enumerate(column_names)
+            ],
+            rows=rows,
+            truncated=truncated,
+            warnings=warnings,
+            metadata={
+                "source": "adbc_arrow_flight_sql",
+                "protocol": "adbc",
+                "result_format": str(result_data.get("format", result_format or "")),
+                "source_row_count": source_row_count,
+                "truncation_reason": raw.get("truncation_reason"),
+                "execution_time_seconds": raw.get("execution_time"),
+            },
+        )
+
+    async def diagnose_query_performance(
+        self,
+        *,
+        query_id: str | None = None,
+        sql: str | None = None,
+        database: str | None = None,
+        include_cluster_context: bool = False,
+    ) -> dict[str, Any]:
+        """Compose deterministic evidence without model-generated guesses."""
+        if bool(query_id) == bool(sql):
+            raise _argument_failure("Provide exactly one of query_id or sql.")
+
+        audit_row: dict[str, Any] | None = None
+        audit_record: dict[str, Any] | None = None
+        resolved_query_id = query_id
+        target_sql = sql
+        resolved_catalog: str | None = None
+        resolved_database = database
+        warnings: list[str] = []
+        steps: dict[str, Any] = {}
+
+        if query_id is not None:
+            resolved_query_id = _validate_query_id(query_id)
+            audit_row = await self._find_audit_record(resolved_query_id)
+            if audit_row is not None:
+                audit_record = _slow_query_item(audit_row)
+                candidate = audit_record.get("sql")
+                target_sql = str(candidate) if candidate else None
+                resolved_catalog = _optional_identifier(audit_record.get("catalog"))
+                if resolved_database is None:
+                    resolved_database = _optional_identifier(
+                        audit_record.get("database")
+                    )
+            if not target_sql or bool(
+                audit_record and audit_record.get("sql_truncated")
+            ):
+                target_sql = await self._fetch_query_sql(resolved_query_id)
+            if not target_sql:
+                raise QueryRuntimeFailure(
+                    "Doris did not expose SQL evidence for the requested query ID.",
+                    reason_code="QUERY_SQL_EVIDENCE_NOT_FOUND",
+                    status_code=404,
+                )
+
+        statement = ReadOnlySQLGuard.validate(str(target_sql), query_target=True)
+        explain = await self.explain_query(
+            sql=statement.sql,
+            catalog=resolved_catalog,
+            database=resolved_database,
+            level="verbose",
+        )
+        warnings.extend(_result_warnings(explain))
+        steps["explain"] = {
+            "status": explain["status"],
+            "source": explain["metadata"].get("source"),
+        }
+
+        profile: dict[str, Any] | None = None
+        try:
+            profile = await self.get_query_profile(
+                query_id=resolved_query_id,
+                sql=None if resolved_query_id else statement.sql,
+                include_operator_tree=True,
+                database=resolved_database,
+            )
+        except QueryRuntimeFailure as exc:
+            warnings.append(
+                f"Query profile evidence is unavailable ({exc.reason_code})."
+            )
+            steps["profile"] = {
+                "status": "unavailable",
+                "reason_code": exc.reason_code,
+            }
+        else:
+            warnings.extend(_result_warnings(profile))
+            steps["profile"] = {
+                "status": profile["status"],
+                "source": profile["metadata"].get("source"),
+            }
+            if resolved_query_id is None:
+                candidate_id = profile["data"].get("query_id")
+                if isinstance(candidate_id, str):
+                    resolved_query_id = candidate_id
+
+        if audit_row is None and resolved_query_id is not None:
+            audit_row = await self._find_audit_record(resolved_query_id)
+            if audit_row is not None:
+                audit_record = _slow_query_item(audit_row)
+        steps["slow_query"] = {
+            "status": "success" if audit_record is not None else "unavailable",
+            "source": (
+                "internal.__internal_schema.audit_log"
+                if audit_record is not None
+                else None
+            ),
+        }
+        if audit_record is None:
+            warnings.append("No matching audit-log evidence was found.")
+
+        cluster_context: dict[str, Any] | None = None
+        if include_cluster_context:
+            cluster_context = {
+                "status": "unavailable",
+                "reason_code": "CLUSTER_DOMAIN_NOT_YET_IMPLEMENTED",
+            }
+            warnings.append(
+                "Cluster context is deferred to the dedicated Cluster-domain "
+                "implementation."
+            )
+        steps["cluster_context"] = (
+            dict(cluster_context)
+            if cluster_context is not None
+            else {"status": "not_requested"}
+        )
+
+        explain_data = explain["data"]
+        profile_data = profile["data"] if profile is not None else {}
+        findings = _diagnostic_findings(
+            explain_text=str(explain_data.get("plan_text", "")),
+            profile_text=str(profile_data.get("profile") or ""),
+            audit_record=audit_record,
+        )
+        recommendations = _diagnostic_recommendations(findings)
+        evidence = list(explain.get("evidence", []))
+        if profile is not None:
+            evidence.extend(profile.get("evidence", []))
+        if audit_record is not None:
+            evidence.append(
+                {
+                    "source": "doris_audit_log",
+                    "kind": "query_record",
+                    "query_id": resolved_query_id,
+                }
+            )
+        visible_audit_record = audit_record
+        if audit_row is not None:
+            visible_rows = await self._mask_audit_rows([audit_row])
+            visible_audit_record = (
+                _slow_query_item(visible_rows[0]) if visible_rows else None
+            )
+        warnings = list(dict.fromkeys(warnings))
+        evidence_is_partial = any(
+            step.get("status") == "partial"
+            for step in steps.values()
+            if isinstance(step, Mapping)
+        )
+        status = "partial" if warnings or evidence_is_partial else "success"
+        return _diagnostic_result(
+            {
+                "query_id": resolved_query_id,
+                "steps": steps,
+                "findings": findings,
+                "recommendations": recommendations,
+                "audit_record": visible_audit_record,
+                "cluster_context": cluster_context,
+            },
+            status=status,
+            warnings=warnings,
+            metadata={
+                "source": "deterministic_query_diagnosis",
+                "rule_version": "query-diagnosis-v1",
+            },
+            evidence=tuple(evidence),
+        )
+
+    async def _mask_audit_rows(
+        self,
+        rows: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Apply request-scoped masking before audit evidence becomes visible."""
+        if not rows:
+            return []
+        auth_context = get_current_auth_context()
+        security_manager = getattr(
+            self._connection_manager,
+            "security_manager",
+            None,
+        )
+        if auth_context is None or security_manager is None:
+            return [dict(row) for row in rows]
+        masked = await security_manager.apply_data_masking(
+            [dict(row) for row in rows],
+            auth_context,
+        )
+        return [dict(row) for row in masked]
+
+    def _resolve_limits(
+        self,
+        *,
+        max_rows: int | None,
+        timeout_ms: int | None,
+    ) -> ResultLimits:
+        default_rows = configured_default_result_rows(self._connection_manager.config)
+        ceilings = configured_result_limits(self._connection_manager.config)
+        if timeout_ms is None:
+            timeout = min(30, ceilings.timeout_seconds)
+        else:
+            bounded_timeout_ms = _bounded_integer(
+                timeout_ms,
+                "timeout_ms",
+                minimum=1,
+                maximum=300_000,
+            )
+            timeout = math.ceil(bounded_timeout_ms / 1000)
+        try:
+            return resolve_result_limits(
+                self._connection_manager.config,
+                max_rows=max_rows if max_rows is not None else default_rows,
+                max_bytes=None,
+                timeout_seconds=timeout,
+            )
+        except ResultLimitError as exc:
+            raise _argument_failure(str(exc)) from exc
+
+    async def _execute_statement(
+        self,
+        sql: str,
+        *,
+        parameters: Mapping[str, Any] | tuple[Any, ...] | None,
+        catalog: str | None,
+        database: str | None,
+        limits: ResultLimits,
+        purpose: str,
+        mask_result: bool = True,
+        trusted_internal: bool = False,
+    ) -> QueryResult:
+        context_statements = _context_statements(catalog, database)
+        auth_context = get_current_auth_context()
+        session_id = f"{self._session_prefix}_{purpose}"
+        try:
+            async with asyncio.timeout(limits.timeout_seconds):
+                async with (
+                    self._connection_manager.get_connection_context_for_auth_context(
+                        session_id,
+                        auth_context,
+                    ) as connection
+                ):
+                    try:
+                        for context_sql in context_statements:
+                            await connection.execute(
+                                context_sql,
+                                auth_context=None,
+                                mask_result=False,
+                            )
+                        return await connection.execute(
+                            sql,
+                            params=parameters,
+                            auth_context=(None if trusted_internal else auth_context),
+                            mask_result=mask_result,
+                            max_rows=limits.max_rows,
+                            max_bytes=limits.max_bytes,
+                        )
+                    finally:
+                        if context_statements:
+                            connection.is_healthy = False
+        except TimeoutError as exc:
+            raise QueryRuntimeFailure(
+                "Doris query execution timed out.",
+                reason_code="QUERY_TIMEOUT",
+                status_code=504,
+                retryable=True,
+            ) from exc
+        except QueryRuntimeFailure:
+            raise
+        except Exception as exc:
+            raise _classify_query_failure(exc) from exc
+
+    async def _execute_profiled_statement(
+        self,
+        sql: str,
+        *,
+        trace_id: str,
+        database: str | None,
+        limits: ResultLimits,
+    ) -> QueryResult:
+        context_statements = _context_statements(None, database)
+        auth_context = get_current_auth_context()
+        session_id = f"{self._session_prefix}_profile"
+        try:
+            async with asyncio.timeout(limits.timeout_seconds):
+                async with (
+                    self._connection_manager.get_connection_context_for_auth_context(
+                        session_id,
+                        auth_context,
+                    ) as connection
+                ):
+                    try:
+                        for context_sql in context_statements:
+                            await connection.execute(
+                                context_sql,
+                                auth_context=None,
+                                mask_result=False,
+                            )
+                        await connection.execute(
+                            f'SET session_context="trace_id:{trace_id}"',
+                            auth_context=None,
+                            mask_result=False,
+                        )
+                        await connection.execute(
+                            "SET enable_profile=true",
+                            auth_context=None,
+                            mask_result=False,
+                        )
+                        return await connection.execute(
+                            sql,
+                            auth_context=auth_context,
+                            max_rows=limits.max_rows,
+                            max_bytes=limits.max_bytes,
+                        )
+                    finally:
+                        connection.is_healthy = False
+        except TimeoutError as exc:
+            raise QueryRuntimeFailure(
+                "Profiled Doris query timed out.",
+                reason_code="QUERY_TIMEOUT",
+                status_code=504,
+                retryable=True,
+            ) from exc
+        except Exception as exc:
+            raise _classify_query_failure(exc) from exc
+
+    async def _wait_for_query_id(self, trace_id: str) -> str | None:
+        for delay in (0.0, 0.2, 0.5):
+            if delay:
+                await asyncio.sleep(delay)
+            query_id = await self._fetch_query_id(trace_id)
+            if query_id is not None:
+                return query_id
+        return None
+
+    async def _fetch_query_id(self, trace_id: str) -> str | None:
+        response = await self._profile_http_get(
+            f"/rest/v2/manager/query/trace_id/{quote(trace_id, safe='')}"
+        )
+        payload = _http_json_if_present(response)
+        api_code = _api_code(payload) if payload is not None else None
+        if api_code in {401, 403}:
+            return None
+        if api_code == 404 or response.status == 404:
+            return None
+        if response.status != 200:
+            raise _profile_http_failure(response.status)
+        if payload is None:
+            raise QueryRuntimeFailure(
+                "Doris query profile service returned an invalid response.",
+                reason_code="QUERY_PROFILE_INVALID_RESPONSE",
+                status_code=502,
+            )
+        if api_code not in {None, 0}:
+            raise QueryRuntimeFailure(
+                "Doris query profile service returned an invalid response.",
+                reason_code="QUERY_PROFILE_INVALID_RESPONSE",
+                status_code=502,
+            )
+        data = payload.get("data")
+        if isinstance(data, str) and data:
+            return _validate_query_id(data)
+        if isinstance(data, Mapping):
+            query_ids = data.get("query_ids")
+            if isinstance(query_ids, list) and query_ids:
+                return _validate_query_id(str(query_ids[0]))
+        return None
+
+    async def _fetch_profile(self, query_id: str) -> dict[str, str]:
+        response = await self._profile_http_get(
+            f"/rest/v2/manager/query/profile/text/{quote(query_id, safe='')}"
+        )
+        payload = _http_json_if_present(response)
+        api_code = _api_code(payload) if payload is not None else None
+        if api_code in {401, 403}:
+            raise QueryRuntimeFailure(
+                "Doris denied access to query profile evidence.",
+                reason_code="QUERY_PROFILE_PERMISSION_DENIED",
+                status_code=403,
+            )
+        if api_code == 404 or response.status == 404:
+            raise QueryRuntimeFailure(
+                "The requested Doris query profile was not found.",
+                reason_code="QUERY_PROFILE_NOT_FOUND",
+                status_code=404,
+            )
+        if response.status != 200:
+            raise _profile_http_failure(response.status)
+        text = response.text()
+        if payload is not None:
+            if api_code not in {None, 0}:
+                raise QueryRuntimeFailure(
+                    "Doris query profile service returned an invalid response.",
+                    reason_code="QUERY_PROFILE_INVALID_RESPONSE",
+                    status_code=502,
+                )
+            data = payload.get("data")
+            if isinstance(data, str):
+                text = data
+            elif isinstance(data, Mapping):
+                text = str(data.get("profile", ""))
+        if not text.strip():
+            raise QueryRuntimeFailure(
+                "The requested Doris query profile was not found.",
+                reason_code="QUERY_PROFILE_NOT_FOUND",
+                status_code=404,
+            )
+        return {"query_id": query_id, "profile_text": text}
+
+    async def _fetch_query_sql(self, query_id: str) -> str:
+        response = await self._profile_http_get(
+            f"/rest/v2/manager/query/sql/{quote(query_id, safe='')}"
+        )
+        payload = _http_json_if_present(response)
+        api_code = _api_code(payload) if payload is not None else None
+        if api_code in {401, 403}:
+            raise QueryRuntimeFailure(
+                "Doris denied access to query SQL evidence.",
+                reason_code="QUERY_PROFILE_PERMISSION_DENIED",
+                status_code=403,
+            )
+        if api_code == 404 or response.status == 404:
+            raise QueryRuntimeFailure(
+                "SQL evidence for the requested Doris query was not found.",
+                reason_code="QUERY_SQL_EVIDENCE_NOT_FOUND",
+                status_code=404,
+            )
+        if response.status != 200:
+            raise _profile_http_failure(response.status)
+        if payload is None:
+            raise QueryRuntimeFailure(
+                "Doris query profile service returned an invalid response.",
+                reason_code="QUERY_PROFILE_INVALID_RESPONSE",
+                status_code=502,
+            )
+        if api_code not in {None, 0}:
+            raise QueryRuntimeFailure(
+                "Doris query profile service returned an invalid response.",
+                reason_code="QUERY_PROFILE_INVALID_RESPONSE",
+                status_code=502,
+            )
+        data = payload.get("data")
+        sql = str(data.get("sql", "")) if isinstance(data, Mapping) else str(data or "")
+        if not sql.strip():
+            raise QueryRuntimeFailure(
+                "SQL evidence for the requested Doris query was not found.",
+                reason_code="QUERY_SQL_EVIDENCE_NOT_FOUND",
+                status_code=404,
+            )
+        return sql
+
+    async def _profile_http_get(self, path: str) -> DorisHTTPResponse:
+        try:
+            auth_context = get_current_auth_context()
+            if auth_context is not None and auth_context.auth_method == "doris_oauth":
+                raise QueryRuntimeFailure(
+                    "Query profile HTTP access is unavailable for this "
+                    "credential route.",
+                    reason_code="QUERY_PROFILE_CREDENTIAL_ROUTE_UNAVAILABLE",
+                    status_code=503,
+                )
+            db_config = database_config_for_request(self._connection_manager)
+            hosts = configured_fe_http_hosts(db_config)
+            client = DorisHTTPClient.from_database_config(db_config)
+            return await client.get_first_available(
+                role="fe",
+                hosts=hosts,
+                port=db_config.fe_http_port,
+                path=path,
+                headers={"Accept": "application/json, text/plain"},
+            )
+        except QueryRuntimeFailure:
+            raise
+        except Exception as exc:
+            raise QueryRuntimeFailure(
+                "Doris query profile service is temporarily unavailable.",
+                reason_code="QUERY_PROFILE_BACKEND_UNAVAILABLE",
+                status_code=503,
+                retryable=True,
+            ) from exc
+
+    async def _find_audit_record(
+        self,
+        query_id: str,
+    ) -> dict[str, Any] | None:
+        limits = ResultLimits(
+            max_rows=1,
+            max_bytes=configured_result_limits(
+                self._connection_manager.config
+            ).max_bytes,
+            timeout_seconds=min(
+                30,
+                configured_result_limits(
+                    self._connection_manager.config
+                ).timeout_seconds,
+            ),
+        )
+        sql = (
+            "SELECT `query_id`, `time`, `user`, `catalog`, `db`, `state`, "
+            "`query_time`, `cpu_time_ms`, `scan_bytes`, `scan_rows`, "
+            "`return_rows`, `peak_memory_bytes`, `sql_hash`, `sql_digest`, "
+            "`stmt` FROM internal.__internal_schema.audit_log "
+            "WHERE `query_id` = %s ORDER BY `time` DESC LIMIT 1"
+        )
+        try:
+            result = await self._execute_statement(
+                sql,
+                parameters=(query_id,),
+                catalog=None,
+                database=None,
+                limits=limits,
+                purpose="query_audit",
+                mask_result=False,
+                trusted_internal=True,
+            )
+        except QueryRuntimeFailure:
+            return None
+        if not result.data:
+            return None
+        return dict(result.data[0])
+
+
+def _argument_failure(message: str) -> QueryRuntimeFailure:
+    return QueryRuntimeFailure(
+        message,
+        reason_code="QUERY_ARGUMENT_INVALID",
+        status_code=400,
+    )
+
+
+def _parameter_code(sql: str) -> str:
+    """Return executable SQL text while blanking comments and string literals."""
+    statements = sqlparse.parse(sql)
+    if len(statements) != 1:
+        return sql
+    return "".join(
+        (
+            " " * len(str(token.value))
+            if token.ttype in sql_tokens.Comment
+            or token.ttype in sql_tokens.Literal.String
+            else str(token.value)
+        )
+        for token in statements[0].flatten()
+    )
+
+
+def _has_executable_sql(statement: Any) -> bool:
+    """Return whether a parsed statement contains more than comments or delimiters."""
+    return any(
+        not token.is_whitespace
+        and token.ttype not in sql_tokens.Comment
+        and not (
+            token.ttype in sql_tokens.Punctuation and str(token.value).strip() == ";"
+        )
+        for token in statement.flatten()
+    )
+
+
+def _optional_identifier(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _result_warnings(result: Mapping[str, Any]) -> list[str]:
+    warnings = result.get("warnings")
+    if not isinstance(warnings, list | tuple):
+        return []
+    return [str(warning) for warning in warnings if str(warning).strip()]
+
+
+def _read_only_failure(message: str) -> QueryRuntimeFailure:
+    return QueryRuntimeFailure(
+        message,
+        reason_code="QUERY_READ_ONLY_VIOLATION",
+        status_code=400,
+    )
+
+
+def _validate_query_id(query_id: str) -> str:
+    if (
+        not isinstance(query_id, str)
+        or len(query_id) > _MAX_QUERY_ID_LENGTH
+        or _QUERY_ID_RE.fullmatch(query_id.strip()) is None
+    ):
+        raise _argument_failure("Query ID is invalid.")
+    return query_id.strip()
+
+
+def _bounded_integer(
+    value: Any,
+    name: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise _argument_failure(f"{name} must be an integer.")
+    if not minimum <= value <= maximum:
+        raise _argument_failure(f"{name} must be between {minimum} and {maximum}.")
+    return int(value)
+
+
+def _context_statements(
+    catalog: str | None,
+    database: str | None,
+) -> tuple[str, ...]:
+    statements: list[str] = []
+    try:
+        if catalog is not None:
+            validate_identifier(catalog, "catalog name")
+            statements.append(f"SWITCH {quote_identifier(catalog, 'catalog name')}")
+        if database is not None:
+            validate_identifier(database, "database name")
+            statements.append(f"USE {quote_identifier(database, 'database name')}")
+    except SQLSecurityError as exc:
+        raise _argument_failure("Doris query context is invalid.") from exc
+    return tuple(statements)
+
+
+def _query_result(
+    result: QueryResult,
+    *,
+    limits: ResultLimits,
+    protocol: str,
+    operation: str,
+) -> dict[str, Any]:
+    rows = [
+        _json_mapping(row) for row in (result.data or []) if isinstance(row, Mapping)
+    ]
+    raw_columns = result.metadata.get("columns", [])
+    columns = [
+        column if isinstance(column, dict) else {"name": str(column)}
+        for column in (
+            raw_columns
+            if isinstance(raw_columns, list)
+            else list(rows[0])
+            if rows
+            else []
+        )
+    ]
+    truncated = bool(result.metadata.get("truncated"))
+    return _query_output(
+        columns=columns,
+        rows=rows,
+        truncated=truncated,
+        metadata={
+            "source": "doris_query",
+            "protocol": protocol,
+            "operation": operation,
+            "execution_time_seconds": result.execution_time,
+            "result_bytes": result.metadata.get("result_bytes"),
+            "truncation_reason": result.metadata.get("truncation_reason"),
+            "limits": {
+                "max_rows": limits.max_rows,
+                "max_bytes": limits.max_bytes,
+                "timeout_seconds": limits.timeout_seconds,
+            },
+        },
+    )
+
+
+def _query_output(
+    *,
+    columns: list[dict[str, Any]],
+    rows: list[dict[str, Any]],
+    truncated: bool,
+    warnings: list[str] | tuple[str, ...] = (),
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    warning_list = list(warnings)
+    return {
+        "status": "partial" if warning_list or truncated else "success",
+        "data": {
+            "columns": columns,
+            "rows": rows,
+            "row_count": len(rows),
+            "truncated": truncated,
+        },
+        "warnings": warning_list,
+        "metadata": dict(metadata or {}),
+    }
+
+
+def _detail_result(
+    data: Mapping[str, Any],
+    *,
+    status: str = "success",
+    warnings: list[str] | tuple[str, ...] = (),
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "data": dict(data),
+        "warnings": list(warnings),
+        "metadata": dict(metadata or {}),
+    }
+
+
+def _diagnostic_result(
+    data: Mapping[str, Any],
+    *,
+    status: str = "success",
+    warnings: list[str] | tuple[str, ...] = (),
+    metadata: Mapping[str, Any] | None = None,
+    evidence: tuple[Mapping[str, Any], ...] = (),
+) -> dict[str, Any]:
+    return {
+        **_detail_result(
+            data,
+            status=status,
+            warnings=warnings,
+            metadata=metadata,
+        ),
+        "evidence": [dict(item) for item in evidence],
+    }
+
+
+def _collection_result(
+    items: list[dict[str, Any]],
+    *,
+    truncated: bool,
+    metadata: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "status": "partial" if truncated else "success",
+        "data": {
+            "items": items,
+            "next_cursor": None,
+            "truncated": truncated,
+        },
+        "warnings": (
+            ["Additional slow-query records matched the bounded request."]
+            if truncated
+            else []
+        ),
+        "metadata": dict(metadata),
+    }
+
+
+def _json_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): _json_value(item) for key, item in value.items()}
+
+
+def _json_value(value: Any) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    if isinstance(value, Mapping):
+        return _json_mapping(value)
+    if isinstance(value, list | tuple):
+        return [_json_value(item) for item in value]
+    return str(value)
+
+
+def _slow_query_item(row: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = {str(key).lower(): value for key, value in row.items()}
+    sql = str(normalized.get("stmt") or "")
+    return {
+        "query_id": _json_value(normalized.get("query_id")),
+        "time": _json_value(normalized.get("time")),
+        "user": _json_value(normalized.get("user")),
+        "catalog": _json_value(normalized.get("catalog")),
+        "database": _json_value(normalized.get("db")),
+        "state": _json_value(normalized.get("state")),
+        "duration_ms": _optional_int(normalized.get("query_time")),
+        "cpu_time_ms": _optional_int(normalized.get("cpu_time_ms")),
+        "scan_bytes": _optional_int(normalized.get("scan_bytes")),
+        "scan_rows": _optional_int(normalized.get("scan_rows")),
+        "return_rows": _optional_int(normalized.get("return_rows")),
+        "peak_memory_bytes": _optional_int(normalized.get("peak_memory_bytes")),
+        "sql_hash": _json_value(normalized.get("sql_hash")),
+        "sql_digest": _json_value(normalized.get("sql_digest")),
+        "sql": sql[:_MAX_SLOW_QUERY_TEXT],
+        "sql_truncated": len(sql) > _MAX_SLOW_QUERY_TEXT,
+        "statement_fingerprint": hashlib.sha256(sql.encode("utf-8")).hexdigest()[:16],
+    }
+
+
+def _optional_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _explain_facets(plan_text: str) -> dict[str, Any]:
+    upper = plan_text.upper()
+    return {
+        "has_join": "JOIN" in upper,
+        "has_cross_join": "CROSS JOIN" in upper,
+        "has_sort": "SORT" in upper or "ORDER BY" in upper,
+        "has_exchange": "EXCHANGE" in upper,
+        "has_runtime_filter": "RUNTIME FILTER" in upper,
+        "has_partition_pruning": ("PARTITION" in upper and "PRUN" in upper),
+        "mentions_inverted_index": "INVERTED" in upper,
+        "mentions_ann_index": "ANN" in upper or "HNSW" in upper,
+    }
+
+
+def _profile_operator_tree(profile_text: str) -> list[str]:
+    lines = []
+    for raw_line in profile_text.splitlines():
+        line = raw_line.rstrip()
+        upper = line.upper()
+        if any(
+            marker in upper
+            for marker in (
+                "SCAN",
+                "JOIN",
+                "AGGREGATE",
+                "EXCHANGE",
+                "SORT",
+                "SINK",
+            )
+        ):
+            lines.append(line[:512])
+        if len(lines) >= 256:
+            break
+    return lines
+
+
+def _profile_facets(profile_text: str) -> dict[str, Any]:
+    upper = profile_text.upper()
+    return {
+        "mentions_spill": "SPILL" in upper,
+        "mentions_shuffle": "SHUFFLE" in upper or "EXCHANGE" in upper,
+        "mentions_runtime_filter": "RUNTIME FILTER" in upper,
+        "mentions_cache": "CACHE" in upper,
+        "mentions_peak_memory": "PEAKMEMORY" in upper or "PEAK MEMORY" in upper,
+    }
+
+
+def _diagnostic_findings(
+    *,
+    explain_text: str,
+    profile_text: str,
+    audit_record: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    upper_plan = explain_text.upper()
+    upper_profile = profile_text.upper()
+    if "CROSS JOIN" in upper_plan:
+        findings.append(
+            {
+                "code": "CROSS_JOIN_OBSERVED",
+                "severity": "high",
+                "evidence": "The Doris explain plan contains CROSS JOIN.",
+            }
+        )
+    if "SPILL" in upper_profile and not re.search(
+        r"SPILL[^\n]*[:=]\s*0(?:\D|$)",
+        upper_profile,
+    ):
+        findings.append(
+            {
+                "code": "PROFILE_SPILL_OBSERVED",
+                "severity": "medium",
+                "evidence": "The Doris profile reports spill-related operators.",
+            }
+        )
+    if audit_record is not None:
+        scan_rows = _optional_int(audit_record.get("scan_rows")) or 0
+        return_rows = _optional_int(audit_record.get("return_rows")) or 0
+        duration = _optional_int(audit_record.get("duration_ms")) or 0
+        peak_memory = _optional_int(audit_record.get("peak_memory_bytes")) or 0
+        if scan_rows >= 1_000_000 and scan_rows > max(return_rows, 1) * 100:
+            findings.append(
+                {
+                    "code": "HIGH_SCAN_TO_RETURN_RATIO",
+                    "severity": "medium",
+                    "evidence": {
+                        "scan_rows": scan_rows,
+                        "return_rows": return_rows,
+                    },
+                }
+            )
+        if duration >= 10_000:
+            findings.append(
+                {
+                    "code": "LONG_RECORDED_DURATION",
+                    "severity": "medium",
+                    "evidence": {"duration_ms": duration},
+                }
+            )
+        if peak_memory >= 1024**3:
+            findings.append(
+                {
+                    "code": "HIGH_PEAK_MEMORY",
+                    "severity": "medium",
+                    "evidence": {"peak_memory_bytes": peak_memory},
+                }
+            )
+    return findings
+
+
+def _diagnostic_recommendations(
+    findings: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    recommendations = {
+        "CROSS_JOIN_OBSERVED": (
+            "Review join predicates and verify that the Cartesian join is intentional."
+        ),
+        "PROFILE_SPILL_OBSERVED": (
+            "Inspect high-cardinality joins, aggregations, and memory limits "
+            "for the spilling operator."
+        ),
+        "HIGH_SCAN_TO_RETURN_RATIO": (
+            "Review partition pruning, predicate pushdown, and available indexes."
+        ),
+        "LONG_RECORDED_DURATION": (
+            "Compare operator time in the profile with scan and shuffle evidence."
+        ),
+        "HIGH_PEAK_MEMORY": (
+            "Inspect operator cardinality estimates and memory-intensive joins "
+            "or aggregations."
+        ),
+    }
+    return [
+        {
+            "finding_code": str(finding["code"]),
+            "recommendation": recommendations[str(finding["code"])],
+        }
+        for finding in findings
+        if str(finding.get("code")) in recommendations
+    ]
+
+
+def _profile_text_limit(config: Any) -> int:
+    performance = getattr(config, "performance", None)
+    value = getattr(performance, "max_response_content_size", 4096)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return 4096
+    return min(value, 1024 * 1024)
+
+
+def _http_json(response: DorisHTTPResponse) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(response.text())
+    except json.JSONDecodeError as exc:
+        raise QueryRuntimeFailure(
+            "Doris query profile service returned an invalid response.",
+            reason_code="QUERY_PROFILE_INVALID_RESPONSE",
+            status_code=502,
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise QueryRuntimeFailure(
+            "Doris query profile service returned an invalid response.",
+            reason_code="QUERY_PROFILE_INVALID_RESPONSE",
+            status_code=502,
+        )
+    return payload
+
+
+def _http_json_if_present(
+    response: DorisHTTPResponse,
+) -> Mapping[str, Any] | None:
+    content_type = response.headers.get("content-type", "")
+    text = response.text()
+    if "json" not in content_type.lower() and not text.lstrip().startswith("{"):
+        return None
+    return _http_json(response)
+
+
+def _api_code(payload: Mapping[str, Any]) -> int | None:
+    value = payload.get("code")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return -1
+
+
+def _profile_http_failure(status: int) -> QueryRuntimeFailure:
+    if status in {401, 403}:
+        return QueryRuntimeFailure(
+            "Doris denied access to query profile evidence.",
+            reason_code="QUERY_PROFILE_PERMISSION_DENIED",
+            status_code=403,
+        )
+    return QueryRuntimeFailure(
+        "Doris query profile service is temporarily unavailable.",
+        reason_code="QUERY_PROFILE_BACKEND_UNAVAILABLE",
+        status_code=503,
+        retryable=True,
+    )
+
+
+def _classify_adbc_failure(raw: Any) -> QueryRuntimeFailure:
+    error_type = str(raw.get("error_type", "")) if isinstance(raw, Mapping) else ""
+    if error_type in {
+        "invalid_result_limits",
+        "security_violation",
+    }:
+        return QueryRuntimeFailure(
+            "ADBC rejected the query request.",
+            reason_code=(
+                "QUERY_READ_ONLY_VIOLATION"
+                if error_type == "security_violation"
+                else "QUERY_ARGUMENT_INVALID"
+            ),
+            status_code=400,
+        )
+    if error_type == "timeout":
+        return QueryRuntimeFailure(
+            "ADBC query execution timed out.",
+            reason_code="QUERY_TIMEOUT",
+            status_code=504,
+            retryable=True,
+        )
+    if error_type in {
+        "missing_fe_port_config",
+        "missing_be_port_config",
+        "missing_adbc_manager",
+        "missing_flight_sql_driver",
+        "token_bound_adbc_unsupported",
+    }:
+        return QueryRuntimeFailure(
+            "ADBC is not configured for the active Doris route.",
+            reason_code="ADBC_PROVIDER_NOT_CONFIGURED",
+            status_code=503,
+        )
+    return QueryRuntimeFailure(
+        "ADBC query execution failed.",
+        reason_code="ADBC_EXECUTION_FAILED",
+        status_code=502,
+    )
+
+
+def _classify_query_failure(exc: Exception) -> QueryRuntimeFailure:
+    if isinstance(exc, QueryRuntimeFailure):
+        return exc
+    if isinstance(exc, SQLSecurityError | ResultLimitError):
+        return _argument_failure("Query arguments are invalid.")
+    numeric_code = next(
+        (value for value in getattr(exc, "args", ()) if isinstance(value, int)),
+        None,
+    )
+    message = str(exc).lower()
+    if numeric_code in {1044, 1045, 1142, 1227} or any(
+        marker in message
+        for marker in (
+            "access denied",
+            "permission denied",
+            "not authorized",
+            "privilege",
+        )
+    ):
+        return QueryRuntimeFailure(
+            "Doris denied the query on the active route.",
+            reason_code="QUERY_PERMISSION_DENIED",
+            status_code=403,
+        )
+    if numeric_code in {1049, 1054, 1146} or any(
+        marker in message
+        for marker in (
+            "doesn't exist",
+            "does not exist",
+            "unknown column",
+            "unknown database",
+            "unknown table",
+        )
+    ):
+        return QueryRuntimeFailure(
+            "A referenced Doris query object was not found.",
+            reason_code="QUERY_OBJECT_NOT_FOUND",
+            status_code=404,
+        )
+    if numeric_code == 1064 or "syntax error" in message:
+        return QueryRuntimeFailure(
+            "Doris rejected the SQL syntax.",
+            reason_code="QUERY_SYNTAX_ERROR",
+            status_code=400,
+        )
+    if isinstance(exc, TimeoutError | asyncio.TimeoutError):
+        return QueryRuntimeFailure(
+            "Doris query execution timed out.",
+            reason_code="QUERY_TIMEOUT",
+            status_code=504,
+            retryable=True,
+        )
+    if isinstance(exc, ConnectionError | OSError) or any(
+        marker in message
+        for marker in (
+            "connection reset",
+            "broken pipe",
+            "server has gone away",
+            "lost connection",
+        )
+    ):
+        return QueryRuntimeFailure(
+            "Doris query execution is temporarily unavailable.",
+            reason_code="QUERY_BACKEND_UNAVAILABLE",
+            status_code=503,
+            retryable=True,
+        )
+    return QueryRuntimeFailure(
+        "Doris query execution failed.",
+        reason_code="QUERY_EXECUTION_FAILED",
+        status_code=502,
+    )
+
+
+__all__ = [
+    "DorisQueryRuntime",
+    "QueryRuntimeFailure",
+    "ReadOnlySQLGuard",
+    "ReadOnlyStatement",
+]

--- a/test/security/test_doris_http_ssrf.py
+++ b/test/security/test_doris_http_ssrf.py
@@ -35,8 +35,14 @@ from doris_mcp_server.utils.doris_http_client import (
     DorisHTTPPolicyError,
     DorisHTTPRequestError,
     DorisHTTPResponseTooLarge,
+    database_config_for_request,
 )
 from doris_mcp_server.utils.monitoring_tools import DorisMonitoringTools
+from doris_mcp_server.utils.security import (
+    AuthContext,
+    reset_auth_context,
+    set_current_auth_context,
+)
 
 
 def _database_config(
@@ -141,6 +147,29 @@ def _http_client(
         total_timeout_seconds=total_timeout,
         max_response_bytes=max_response_bytes,
     )
+
+
+def test_http_config_fails_closed_for_doris_oauth_route() -> None:
+    manager = _manager(
+        _database_config(
+            host="127.0.0.1",
+            fe_http_port=8030,
+        )
+    )
+    context_token = set_current_auth_context(
+        AuthContext(
+            auth_method="doris_oauth",
+            doris_user="analyst",
+        )
+    )
+    try:
+        with pytest.raises(
+            DorisHTTPPolicyError,
+            match="credentials are unavailable",
+        ):
+            database_config_for_request(manager)
+    finally:
+        reset_auth_context(context_token)
 
 
 @pytest.mark.parametrize(

--- a/test/tools/test_capability_detector.py
+++ b/test/tools/test_capability_detector.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -29,9 +30,11 @@ from doris_mcp_server.tools.capability_detector import (
     CapabilityProbeStatus,
     CapabilityRouteChangedError,
     DorisCapabilityDetector,
+    _classify_profile_api_response,
 )
 from doris_mcp_server.tools.doris_feature_matrix import DORIS_FEATURE_MATRIX
 from doris_mcp_server.utils.db import DorisRouteIdentity
+from doris_mcp_server.utils.security import AuthContext
 
 
 class _ProbeConnection:
@@ -54,16 +57,9 @@ class _ProbeConnection:
             raise self.failures[sql]
         rows: dict[str, list[dict[str, Any]]] = {
             "SELECT @@version_comment;": [
-                {
-                    "@@version_comment": (
-                        "Doris version "
-                        "doris-4.0.5-rc01-59de8c4c524"
-                    )
-                }
+                {"@@version_comment": ("Doris version doris-4.0.5-rc01-59de8c4c524")}
             ],
-            "SELECT 1 AS capability_probe": [
-                {"capability_probe": 1}
-            ],
+            "SELECT 1 AS capability_probe": [{"capability_probe": 1}],
             "SHOW FRONTENDS": [
                 {
                     "Name": "fe-1",
@@ -94,13 +90,8 @@ class _ProbeConnection:
             (
                 "SELECT 1 AS table_metadata_probe "
                 "FROM information_schema.tables LIMIT 1"
-            ): [
-                {"table_metadata_probe": 1}
-            ],
-            (
-                "SELECT COLUMN_NAME, DATA_TYPE "
-                "FROM information_schema.columns LIMIT 1"
-            ): [
+            ): [{"table_metadata_probe": 1}],
+            ("SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.columns LIMIT 1"): [
                 {"COLUMN_NAME": "id", "DATA_TYPE": "bigint"}
             ],
             (
@@ -114,14 +105,18 @@ class _ProbeConnection:
                 }
             ],
         }
-        return SimpleNamespace(
-            data=self.row_overrides.get(sql, rows.get(sql, []))
-        )
+        return SimpleNamespace(data=self.row_overrides.get(sql, rows.get(sql, [])))
 
 
 class _ProbeConnectionManager:
     def __init__(self, connection: _ProbeConnection) -> None:
         self.connection = connection
+        database_config = SimpleNamespace()
+        self.config = SimpleNamespace(
+            adbc=SimpleNamespace(enabled=False),
+            database=database_config,
+        )
+        self.selected_database_config = database_config
         self.route = DorisRouteIdentity(
             route_key="global",
             generation=1,
@@ -132,6 +127,12 @@ class _ProbeConnectionManager:
 
     def get_route_identity(self, _auth_context: Any) -> DorisRouteIdentity:
         return self.route
+
+    def get_database_config_for_auth_context(
+        self,
+        _auth_context: Any,
+    ) -> Any:
+        return self.selected_database_config
 
     @asynccontextmanager
     async def get_connection_context_for_auth_context(
@@ -165,17 +166,26 @@ async def test_detector_builds_version_vector_and_extends_domains_lazily() -> No
     assert len(base.version_vector.backends) == 2
     assert base.mixed_versions is False
     assert (
-        base.probe("version_probe_completed").status
-        is CapabilityProbeStatus.SUPPORTED
+        base.probe("version_probe_completed").status is CapabilityProbeStatus.SUPPORTED
     )
     assert (
-        base.probe("query_execution_readable").status
-        is CapabilityProbeStatus.SUPPORTED
+        base.probe("query_execution_readable").status is CapabilityProbeStatus.SUPPORTED
     )
     assert query.probed_domains == frozenset({"doris_query"})
     assert (
-        query.probe("explain_output_readable").status
+        query.probe("explain_output_readable").status is CapabilityProbeStatus.SUPPORTED
+    )
+    assert query.probe("audit_log_readable").status is CapabilityProbeStatus.SUPPORTED
+    assert (
+        query.probe("profile_or_audit_readable").status
         is CapabilityProbeStatus.SUPPORTED
+    )
+    assert (
+        query.probe("query_profile_api_readable").status
+        is CapabilityProbeStatus.UNKNOWN
+    )
+    assert (
+        query.probe("adbc_driver_ready").status is CapabilityProbeStatus.MISCONFIGURED
     )
     assert catalog.probed_domains == frozenset({"doris_catalog"})
     assert (
@@ -215,6 +225,219 @@ async def test_detector_marks_permission_failure_unknown_not_unsupported() -> No
     assert evidence.status is CapabilityProbeStatus.UNKNOWN
     assert evidence.reason_code == "PROBE_PERMISSION_DENIED"
     assert snapshot.version_vector.backends == ()
+
+
+@pytest.mark.asyncio
+async def test_detector_marks_adbc_callable_only_after_live_probes() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    manager.config.adbc.enabled = True
+    adbc_tools = SimpleNamespace(
+        _import_adbc_modules=AsyncMock(return_value={"success": True}),
+        _check_arrow_flight_ports=AsyncMock(
+            return_value={
+                "success": True,
+                "be_available_count": 1,
+            }
+        ),
+    )
+    detector = DorisCapabilityDetector(
+        manager,  # type: ignore[arg-type]
+        adbc_query_tools=adbc_tools,
+    )
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    query = await detector.detect_domain(base, "doris_query", None)
+
+    assert query.probe("adbc_driver_ready").status is CapabilityProbeStatus.SUPPORTED
+    assert query.probe("flight_sql_reachable").status is CapabilityProbeStatus.SUPPORTED
+    assert query.probe("flight_sql").status is CapabilityProbeStatus.SUPPORTED
+    adbc_tools._import_adbc_modules.assert_awaited_once_with()
+    adbc_tools._check_arrow_flight_ports.assert_awaited_once_with(
+        connectivity_timeout=1.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_detector_isolates_optional_adbc_probe_timeout() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    manager.config.adbc.enabled = True
+    detector = DorisCapabilityDetector(
+        manager,  # type: ignore[arg-type]
+        adbc_query_tools=SimpleNamespace(),
+    )
+    detector._probe_adbc_services = AsyncMock(  # type: ignore[method-assign]
+        side_effect=TimeoutError
+    )
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    query = await detector.detect_domain(base, "doris_query", None)
+
+    assert (
+        query.probe("query_execution_readable").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert (
+        query.probe("explain_output_readable").status is CapabilityProbeStatus.SUPPORTED
+    )
+    assert query.probe("adbc_driver_ready").status is CapabilityProbeStatus.DEGRADED
+    assert (
+        query.probe("adbc_driver_ready").reason_code == "ADBC_RUNTIME_PROBE_TIMED_OUT"
+    )
+
+
+@pytest.mark.asyncio
+async def test_detector_marks_oauth_http_and_adbc_routes_unavailable() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    manager.config.adbc.enabled = True
+    adbc_tools = SimpleNamespace(
+        _import_adbc_modules=AsyncMock(
+            side_effect=AssertionError("ADBC import probe must not run")
+        ),
+        _check_arrow_flight_ports=AsyncMock(
+            side_effect=AssertionError("ADBC endpoint probe must not run")
+        ),
+    )
+    detector = DorisCapabilityDetector(
+        manager,  # type: ignore[arg-type]
+        adbc_query_tools=adbc_tools,
+    )
+    auth_context = AuthContext(
+        auth_method="doris_oauth",
+        doris_user="analyst",
+    )
+    base = await detector.detect_base(
+        auth_context,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    query = await detector.detect_domain(
+        base,
+        "doris_query",
+        auth_context,
+    )
+
+    assert (
+        query.probe("query_execution_readable").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert (
+        query.probe("query_profile_api_readable").reason_code
+        == "PROFILE_API_CREDENTIAL_ROUTE_UNAVAILABLE"
+    )
+    assert (
+        query.probe("adbc_driver_ready").reason_code
+        == "ADBC_CREDENTIAL_ROUTE_UNAVAILABLE"
+    )
+    adbc_tools._import_adbc_modules.assert_not_awaited()
+    adbc_tools._check_arrow_flight_ports.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_detector_marks_static_token_adbc_route_unavailable() -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    manager.config.adbc.enabled = True
+    manager.selected_database_config = SimpleNamespace()
+    adbc_tools = SimpleNamespace(
+        _import_adbc_modules=AsyncMock(
+            side_effect=AssertionError("ADBC import probe must not run")
+        ),
+        _check_arrow_flight_ports=AsyncMock(
+            side_effect=AssertionError("ADBC endpoint probe must not run")
+        ),
+    )
+    detector = DorisCapabilityDetector(
+        manager,  # type: ignore[arg-type]
+        adbc_query_tools=adbc_tools,
+    )
+    auth_context = AuthContext(
+        auth_method="token",
+        token="tenant-token",
+    )
+    base = await detector.detect_base(
+        auth_context,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    query = await detector.detect_domain(
+        base,
+        "doris_query",
+        auth_context,
+    )
+
+    assert (
+        query.probe("query_execution_readable").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert (
+        query.probe("adbc_driver_ready").reason_code
+        == "ADBC_CREDENTIAL_ROUTE_UNAVAILABLE"
+    )
+    adbc_tools._import_adbc_modules.assert_not_awaited()
+    adbc_tools._check_arrow_flight_ports.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("http_status", "payload", "expected_status", "expected_reason"),
+    [
+        (
+            200,
+            {"code": 0},
+            CapabilityProbeStatus.SUPPORTED,
+            "PROFILE_API_READABLE",
+        ),
+        (
+            200,
+            {"code": "403"},
+            CapabilityProbeStatus.UNKNOWN,
+            "PROFILE_API_PERMISSION_DENIED",
+        ),
+        (
+            200,
+            None,
+            CapabilityProbeStatus.UNKNOWN,
+            "PROFILE_API_INVALID_RESPONSE",
+        ),
+        (
+            503,
+            None,
+            CapabilityProbeStatus.DEGRADED,
+            "PROFILE_API_UNREACHABLE",
+        ),
+        (
+            404,
+            None,
+            CapabilityProbeStatus.UNSUPPORTED,
+            "PROFILE_API_UNSUPPORTED",
+        ),
+    ],
+)
+def test_profile_api_probe_classification_is_fail_closed(
+    http_status: int,
+    payload: dict[str, Any] | None,
+    expected_status: CapabilityProbeStatus,
+    expected_reason: str,
+) -> None:
+    status, reason = _classify_profile_api_response(
+        http_status,
+        payload,
+    )
+
+    assert status is expected_status
+    assert reason == expected_reason
 
 
 @pytest.mark.asyncio

--- a/test/tools/test_capability_registry.py
+++ b/test/tools/test_capability_registry.py
@@ -196,9 +196,7 @@ def test_evaluator_requires_version_probes_handler_and_call_permission() -> None
 def test_evaluator_normalizes_system_object_probe_evidence_for_manifest() -> None:
     evaluator = CapabilityEvaluator(
         matrix=DORIS_FEATURE_MATRIX,
-        bound_handlers=_BoundHandlers(
-            "doris_catalog.get_table_context"
-        ),  # type: ignore[arg-type]
+        bound_handlers=_BoundHandlers("doris_catalog.get_table_context"),  # type: ignore[arg-type]
     )
     domain = DORIS_DOMAIN_CATALOG.resolve_domain("doris_catalog")
     child = DORIS_DOMAIN_CATALOG.resolve_child(
@@ -261,7 +259,7 @@ def test_evaluator_distinguishes_provider_misconfiguration() -> None:
     [
         (False, True, CapabilityProbeStatus.MISCONFIGURED),
         (True, False, CapabilityProbeStatus.MISCONFIGURED),
-        (True, True, CapabilityProbeStatus.DEGRADED),
+        (True, True, CapabilityProbeStatus.SUPPORTED),
     ],
 )
 def test_adbc_provider_requires_configuration_and_bound_consumer(
@@ -287,10 +285,30 @@ def test_adbc_provider_requires_configuration_and_bound_consumer(
 
     assert provider.status is expected_status
     assert provider.reason_code == (
-        "PROVIDER_CONFIGURED_UNPROBED"
-        if expected_status is CapabilityProbeStatus.DEGRADED
+        "PROVIDER_CONFIGURED"
+        if expected_status is CapabilityProbeStatus.SUPPORTED
         else "PROVIDER_NOT_CONFIGURED"
     )
+
+
+def test_builtin_query_evidence_providers_are_ready_when_bound() -> None:
+    handlers = _BoundHandlers(
+        "doris_query.diagnose_query_performance",
+        "doris_query.list_slow_queries",
+    )
+    registry = CapabilityProviderRegistry.from_runtime(
+        matrix=DORIS_FEATURE_MATRIX,
+        bound_handlers=handlers,  # type: ignore[arg-type]
+        config=SimpleNamespace(adbc=SimpleNamespace(enabled=False)),
+    )
+
+    providers = registry.snapshot().providers
+
+    assert (
+        providers["query_evidence_provider"].status is CapabilityProbeStatus.SUPPORTED
+    )
+    assert providers["audit_log_provider"].status is CapabilityProbeStatus.SUPPORTED
+    assert providers["query_evidence_provider"].reason_code == ("PROVIDER_CONFIGURED")
 
 
 class _MutableClock:
@@ -534,6 +552,7 @@ async def test_provider_down_advances_generation_and_fails_closed() -> None:
             for probe_id in (
                 "adbc_driver_ready",
                 "flight_sql",
+                "flight_sql_reachable",
                 "read_only_sql_guard_ready",
             )
         },
@@ -599,6 +618,7 @@ async def test_manifest_uses_one_provider_generation_during_refresh() -> None:
             for probe_id in (
                 "adbc_driver_ready",
                 "flight_sql",
+                "flight_sql_reachable",
                 "read_only_sql_guard_ready",
             )
         },
@@ -617,9 +637,7 @@ async def test_manifest_uses_one_provider_generation_during_refresh() -> None:
         provider_registry=providers,
         evaluator=CapabilityEvaluator(
             matrix=DORIS_FEATURE_MATRIX,
-            bound_handlers=_BoundHandlers(
-                "doris_query.execute_adbc_query"
-            ),  # type: ignore[arg-type]
+            bound_handlers=_BoundHandlers("doris_query.execute_adbc_query"),  # type: ignore[arg-type]
         ),
         clock=clock,
     )
@@ -637,19 +655,13 @@ async def test_manifest_uses_one_provider_generation_during_refresh() -> None:
     coherent_old = await service.discover(domain, None)
     current = await service.discover(domain, None)
     old_child = next(
-        child
-        for child in coherent_old.children
-        if child.name == "execute_adbc_query"
+        child for child in coherent_old.children if child.name == "execute_adbc_query"
     )
     current_child = next(
-        child
-        for child in current.children
-        if child.name == "execute_adbc_query"
+        child for child in current.children if child.name == "execute_adbc_query"
     )
 
     assert old_child.availability.callable is True
     assert current_child.availability.callable is False
-    assert current_child.availability.reason_code == (
-        "PROVIDER_HEALTHCHECK_FAILED"
-    )
+    assert current_child.availability.reason_code == ("PROVIDER_HEALTHCHECK_FAILED")
     assert coherent_old.manifest_version != current.manifest_version

--- a/test/tools/test_domain_catalog.py
+++ b/test/tools/test_domain_catalog.py
@@ -85,8 +85,7 @@ def _copy_catalog(
     return DORIS_DOMAIN_CATALOG.model_copy(
         update={
             "domains": domains or DORIS_DOMAIN_CATALOG.domains,
-            "legacy_migrations": migrations
-            or DORIS_DOMAIN_CATALOG.legacy_migrations,
+            "legacy_migrations": migrations or DORIS_DOMAIN_CATALOG.legacy_migrations,
         }
     )
 
@@ -108,21 +107,26 @@ def test_catalog_has_exact_ordered_eight_domain_forty_seven_child_shape() -> Non
     assert tuple(domain.name for domain in summary.domains) == tuple(
         EXPECTED_DOMAIN_CHILDREN
     )
-    assert {
-        domain.name: domain.child_names for domain in summary.domains
-    } == dict(EXPECTED_DOMAIN_CHILDREN)
-    assert tuple(
-        len(domain.children) for domain in DORIS_DOMAIN_CATALOG.domains
-    ) == (5, 7, 11, 5, 4, 8, 3, 4)
+    assert {domain.name: domain.child_names for domain in summary.domains} == dict(
+        EXPECTED_DOMAIN_CHILDREN
+    )
+    assert tuple(len(domain.children) for domain in DORIS_DOMAIN_CATALOG.domains) == (
+        5,
+        7,
+        11,
+        5,
+        4,
+        8,
+        3,
+        4,
+    )
 
 
 def test_adbc_is_inside_query_and_cluster_has_exactly_eleven_children() -> None:
     query = DORIS_DOMAIN_CATALOG.resolve_domain("doris_query")
     cluster = DORIS_DOMAIN_CATALOG.resolve_domain("doris_cluster")
 
-    assert "get_adbc_connection_info" in {
-        child.name for child in query.children
-    }
+    assert "get_adbc_connection_info" in {child.name for child in query.children}
     assert "execute_adbc_query" in {child.name for child in query.children}
     assert len(cluster.children) == 11
 
@@ -170,6 +174,35 @@ def test_every_child_schema_is_valid_closed_and_non_placeholder() -> None:
 
 
 @pytest.mark.parametrize(
+    "child_name",
+    ["get_query_profile", "diagnose_query_performance"],
+)
+def test_query_evidence_inputs_require_exactly_one_reference(
+    child_name: str,
+) -> None:
+    child = DORIS_DOMAIN_CATALOG.resolve_child(
+        "doris_query",
+        child_name,
+    )
+    validator = Draft202012Validator(_wire_input(child))
+
+    assert list(validator.iter_errors({"query_id": "query_1"})) == []
+    assert list(validator.iter_errors({"sql": "SELECT 1"})) == []
+    assert list(validator.iter_errors({"query_id": "query_1", "sql": "SELECT 1"}))
+    assert list(validator.iter_errors({}))
+
+
+def test_query_schemas_publish_bounded_execution_limits() -> None:
+    query = DORIS_DOMAIN_CATALOG.resolve_domain("doris_query")
+    schemas = {child.name: _wire_input(child) for child in query.children}
+
+    assert schemas["execute_query"]["properties"]["sql"]["maxLength"] == 1024 * 1024
+    assert schemas["execute_query"]["properties"]["max_rows"]["maximum"] == 100_000
+    assert schemas["execute_query"]["properties"]["timeout_ms"]["maximum"] == 300_000
+    assert schemas["list_slow_queries"]["properties"]["limit"]["maximum"] == 1000
+
+
+@pytest.mark.parametrize(
     ("domain_name", "child_name", "required"),
     [
         ("doris_catalog", "list_tables", {"database"}),
@@ -177,7 +210,11 @@ def test_every_child_schema_is_valid_closed_and_non_placeholder() -> None:
         ("doris_query", "execute_query", {"sql"}),
         ("doris_query", "execute_adbc_query", {"sql"}),
         ("doris_pipeline", "monitor_data_freshness", {"database", "table"}),
-        ("doris_lakehouse", "inspect_lakehouse_table", {"catalog", "database", "table"}),
+        (
+            "doris_lakehouse",
+            "inspect_lakehouse_table",
+            {"catalog", "database", "table"},
+        ),
         (
             "doris_semantic",
             "get_semantic_model_summary",
@@ -203,9 +240,7 @@ def test_important_child_required_parameters_are_explicit(
 
 def test_semantic_content_children_require_explicit_model_ref() -> None:
     semantic = DORIS_DOMAIN_CATALOG.resolve_domain("doris_semantic")
-    schemas = {
-        child.name: _wire_input(child) for child in semantic.children
-    }
+    schemas = {child.name: _wire_input(child) for child in semantic.children}
 
     assert "required" not in schemas["list_semantic_models"]
     for name in (
@@ -254,6 +289,17 @@ def test_table_context_has_four_sections_and_five_deterministic_steps() -> None:
     }
 
 
+def test_query_parameter_schema_discloses_exact_placeholder_syntax() -> None:
+    child = DORIS_DOMAIN_CATALOG.resolve_child(
+        "doris_query",
+        "execute_query",
+    )
+    parameters = _wire_input(child)["properties"]["parameters"]
+
+    assert "%(name)s" in parameters["description"]
+    assert "match every placeholder exactly" in parameters["description"]
+
+
 @pytest.mark.parametrize(
     ("domain_name", "child_name", "required_steps"),
     [
@@ -295,15 +341,21 @@ def test_legacy_migrations_cover_exact_flat_baseline_and_real_handlers() -> None
     manager = _manager()
     registry = _migration_registry(manager)
 
-    assert tuple(
-        migration.legacy_tool_name
-        for migration in DORIS_DOMAIN_CATALOG.legacy_migrations
-    ) == CURRENT_FLAT_TOOL_NAMES
-    assert tuple(
-        definition.name
-        for definition in registry.advertised_definitions
-        if definition.provider_name is None
-    ) == CURRENT_FLAT_TOOL_NAMES
+    assert (
+        tuple(
+            migration.legacy_tool_name
+            for migration in DORIS_DOMAIN_CATALOG.legacy_migrations
+        )
+        == CURRENT_FLAT_TOOL_NAMES
+    )
+    assert (
+        tuple(
+            definition.name
+            for definition in registry.advertised_definitions
+            if definition.provider_name is None
+        )
+        == CURRENT_FLAT_TOOL_NAMES
+    )
     DORIS_DOMAIN_CATALOG.validate_legacy_registry(
         registry,
         manager,
@@ -346,9 +398,7 @@ def test_renamed_or_reshaped_migrations_declare_adapters() -> None:
 
     assert adapted
     assert all(migration.adapter_name for migration in adapted)
-    assert all(
-        migration.target_section is None for migration in adapted
-    )
+    assert all(migration.target_section is None for migration in adapted)
 
 
 def test_catalog_markdown_is_deterministic_and_complete() -> None:
@@ -398,9 +448,7 @@ def test_duplicate_child_is_rejected_even_when_validation_was_bypassed() -> None
     invalid_domain = domain.model_copy(
         update={"children": (*domain.children, domain.children[0])}
     )
-    invalid = _copy_catalog(
-        domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:])
-    )
+    invalid = _copy_catalog(domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:]))
 
     with pytest.raises(DomainCatalogError, match="exact ordered"):
         invalid.validate_integrity()
@@ -434,9 +482,7 @@ def test_noncanonical_handler_binding_is_rejected() -> None:
     invalid_domain = domain.model_copy(
         update={"children": (child, *domain.children[1:])}
     )
-    invalid = _copy_catalog(
-        domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:])
-    )
+    invalid = _copy_catalog(domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:]))
 
     with pytest.raises(DomainCatalogError, match="non-canonical handler"):
         invalid.validate_integrity()
@@ -450,9 +496,7 @@ def test_noncanonical_authorization_policy_is_rejected() -> None:
     invalid_domain = domain.model_copy(
         update={"children": (child, *domain.children[1:])}
     )
-    invalid = _copy_catalog(
-        domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:])
-    )
+    invalid = _copy_catalog(domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:]))
 
     with pytest.raises(DomainCatalogError, match="authorization policy"):
         invalid.validate_integrity()
@@ -470,9 +514,7 @@ def test_wrong_feature_matrix_contract_is_rejected() -> None:
     invalid_domain = domain.model_copy(
         update={"children": (child, *domain.children[1:])}
     )
-    invalid = _copy_catalog(
-        domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:])
-    )
+    invalid = _copy_catalog(domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:]))
 
     with pytest.raises(DomainCatalogError, match="feature-matrix contract"):
         invalid.validate_integrity()
@@ -480,48 +522,32 @@ def test_wrong_feature_matrix_contract_is_rejected() -> None:
 
 def test_non_read_only_domain_and_child_are_rejected() -> None:
     domain = DORIS_DOMAIN_CATALOG.domains[0]
-    writable_annotations = domain.annotations.model_copy(
-        update={"read_only": False}
-    )
-    invalid_domain = domain.model_copy(
-        update={"annotations": writable_annotations}
-    )
-    invalid = _copy_catalog(
-        domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:])
-    )
+    writable_annotations = domain.annotations.model_copy(update={"read_only": False})
+    invalid_domain = domain.model_copy(update={"annotations": writable_annotations})
+    invalid = _copy_catalog(domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:]))
 
     with pytest.raises(DomainCatalogError, match="not marked read-only"):
         invalid.validate_integrity()
 
-    child = domain.children[0].model_copy(
-        update={"annotations": writable_annotations}
-    )
+    child = domain.children[0].model_copy(update={"annotations": writable_annotations})
     invalid_domain = domain.model_copy(
         update={"children": (child, *domain.children[1:])}
     )
-    invalid = _copy_catalog(
-        domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:])
-    )
+    invalid = _copy_catalog(domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:]))
     with pytest.raises(DomainCatalogError, match="risk contract"):
         invalid.validate_integrity()
 
 
 def test_migration_baseline_drift_is_rejected() -> None:
-    invalid = _copy_catalog(
-        migrations=DORIS_DOMAIN_CATALOG.legacy_migrations[:-1]
-    )
+    invalid = _copy_catalog(migrations=DORIS_DOMAIN_CATALOG.legacy_migrations[:-1])
 
     with pytest.raises(DomainCatalogError, match="exact ordered 25-tool"):
         invalid.validate_integrity()
 
 
 def test_unknown_migration_target_is_rejected() -> None:
-    first = LEGACY_TOOL_MIGRATIONS[0].model_copy(
-        update={"child_name": "missing_child"}
-    )
-    invalid = _copy_catalog(
-        migrations=(first, *LEGACY_TOOL_MIGRATIONS[1:])
-    )
+    first = LEGACY_TOOL_MIGRATIONS[0].model_copy(update={"child_name": "missing_child"})
+    invalid = _copy_catalog(migrations=(first, *LEGACY_TOOL_MIGRATIONS[1:]))
 
     with pytest.raises(DomainCatalogError, match="targets unknown child"):
         invalid.validate_integrity()
@@ -534,9 +560,7 @@ def test_composite_migration_requires_composite_target() -> None:
             "target_section": "schema",
         }
     )
-    invalid = _copy_catalog(
-        migrations=(first, *LEGACY_TOOL_MIGRATIONS[1:])
-    )
+    invalid = _copy_catalog(migrations=(first, *LEGACY_TOOL_MIGRATIONS[1:]))
 
     with pytest.raises(DomainCatalogError, match="non-composite child"):
         invalid.validate_integrity()
@@ -544,9 +568,7 @@ def test_composite_migration_requires_composite_target() -> None:
 
 def test_table_context_section_mapping_drift_is_rejected() -> None:
     migrations = list(LEGACY_TOOL_MIGRATIONS)
-    migrations[1] = migrations[1].model_copy(
-        update={"target_section": "basic"}
-    )
+    migrations[1] = migrations[1].model_copy(update={"target_section": "basic"})
     invalid = _copy_catalog(migrations=tuple(migrations))
 
     with pytest.raises(DomainCatalogError, match="exact five legacy handlers"):
@@ -590,9 +612,7 @@ def test_runtime_registry_handler_name_drift_is_rejected() -> None:
     first = LEGACY_TOOL_MIGRATIONS[0].model_copy(
         update={"legacy_handler_name": "_changed_handler"}
     )
-    invalid = _copy_catalog(
-        migrations=(first, *LEGACY_TOOL_MIGRATIONS[1:])
-    )
+    invalid = _copy_catalog(migrations=(first, *LEGACY_TOOL_MIGRATIONS[1:]))
 
     with pytest.raises(DomainCatalogError, match="changed handler"):
         invalid.validate_legacy_registry(registry, manager)
@@ -626,9 +646,7 @@ def test_server_startup_rejects_injected_duplicate_catalog(
     invalid_domain = domain.model_copy(
         update={"children": (*domain.children, domain.children[0])}
     )
-    invalid = _copy_catalog(
-        domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:])
-    )
+    invalid = _copy_catalog(domains=(invalid_domain, *DORIS_DOMAIN_CATALOG.domains[1:]))
     monkeypatch.setattr(domain_catalog_module, "DORIS_DOMAIN_CATALOG", invalid)
 
     with pytest.raises(DomainCatalogError, match="exact ordered"):

--- a/test/tools/test_domain_dispatcher.py
+++ b/test/tools/test_domain_dispatcher.py
@@ -51,6 +51,7 @@ from doris_mcp_server.tools.domain_models import (
 )
 from doris_mcp_server.tools.tools_manager import DorisToolsManager
 from doris_mcp_server.utils.config import DorisConfig
+from doris_mcp_server.utils.query_runtime import QueryRuntimeFailure
 from doris_mcp_server.utils.security import AuthContext
 
 
@@ -153,7 +154,7 @@ async def test_default_manager_fails_closed_without_capability_snapshot() -> Non
     assert children["diagnose_query_performance"].availability.callable is False
     assert (
         children["diagnose_query_performance"].availability.reason_code
-        == "HANDLER_NOT_BOUND"
+        == "DORIS_VERSION_UNKNOWN"
     )
 
     manager._exec_query_tool.assert_not_awaited()
@@ -665,17 +666,42 @@ async def test_flat_dispatch_cannot_bypass_discovery_only_grant() -> None:
 
 
 @pytest.mark.asyncio
-async def test_active_adapter_rejections_are_child_argument_errors() -> None:
+async def test_query_adapters_support_formal_query_capabilities() -> None:
     manager = _manager(
         "doris_query.execute_query",
         "doris_query.explain_query",
         "doris_query.get_query_profile",
     )
+    manager._exec_query_tool = AsyncMock(
+        return_value={
+            "status": "success",
+            "data": {
+                "columns": [{"name": "value"}],
+                "rows": [{"value": 1}],
+                "row_count": 1,
+                "truncated": False,
+            },
+            "warnings": [],
+            "metadata": {},
+        }
+    )
+    diagnostic = {
+        "status": "success",
+        "data": {},
+        "warnings": [],
+        "metadata": {},
+        "evidence": [],
+    }
+    manager._get_sql_explain_tool = AsyncMock(return_value=diagnostic)
+    manager._get_sql_profile_tool = AsyncMock(return_value=diagnostic)
 
     cases = (
         (
             "execute_query",
-            {"sql": "SELECT ?", "parameters": {"value": 1}},
+            {
+                "sql": "SELECT %(value)s",
+                "parameters": {"value": 1},
+            },
         ),
         (
             "explain_query",
@@ -692,11 +718,104 @@ async def test_active_adapter_rejections_are_child_argument_errors() -> None:
             {"child_tool": child_name, "arguments": arguments},
             None,
         )
-        assert result.mode == "error"
-        assert result.error.code is DomainErrorCode.CHILD_ARGUMENTS_INVALID
-        assert result.to_wire()["error"]["details"]["violations"] == [
-            {"instancePath": "/", "keyword": "activeHandler"},
-        ]
+        assert result.mode == "result"
+
+    manager._exec_query_tool.assert_awaited_once_with(
+        {
+            "sql": "SELECT %(value)s",
+            "parameters": {"value": 1},
+        }
+    )
+    manager._get_sql_explain_tool.assert_awaited_once_with(
+        {"sql": "SELECT 1", "level": "costs"}
+    )
+    manager._get_sql_profile_tool.assert_awaited_once_with(
+        {"query_id": "query-1"}
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("reason_code", "expected_code"),
+    [
+        (
+            "QUERY_READ_ONLY_VIOLATION",
+            DomainErrorCode.CHILD_ARGUMENTS_INVALID,
+        ),
+        ("QUERY_TIMEOUT", DomainErrorCode.CHILD_EXECUTION_TIMEOUT),
+        (
+            "QUERY_BACKEND_UNAVAILABLE",
+            DomainErrorCode.CHILD_EXECUTION_FAILED,
+        ),
+    ],
+)
+async def test_query_runtime_failures_map_to_stable_domain_errors(
+    reason_code: str,
+    expected_code: DomainErrorCode,
+) -> None:
+    manager = _manager("doris_query.execute_query")
+    manager._exec_query_tool = AsyncMock(
+        side_effect=QueryRuntimeFailure(
+            "Sanitized query failure.",
+            reason_code=reason_code,
+            status_code=504 if reason_code == "QUERY_TIMEOUT" else 400,
+            retryable=reason_code != "QUERY_READ_ONLY_VIOLATION",
+        )
+    )
+
+    result = await manager.domain_dispatcher.call_domain(
+        "doris_query",
+        {
+            "child_tool": "execute_query",
+            "arguments": {"sql": "SELECT 1"},
+        },
+        None,
+    )
+
+    assert result.mode == "error"
+    assert result.error.code is expected_code
+    assert result.error.message == "Sanitized query failure."
+    assert result.error.details["reason_code"] == reason_code
+
+
+@pytest.mark.asyncio
+async def test_new_query_diagnosis_uses_formal_direct_binding() -> None:
+    manager = _manager("doris_query.diagnose_query_performance")
+    manager.query_runtime.diagnose_query_performance = AsyncMock(
+        return_value={
+            "status": "partial",
+            "data": {
+                "query_id": None,
+                "steps": {"cluster_context": {"status": "not_requested"}},
+                "findings": [],
+                "recommendations": [],
+            },
+            "warnings": ["No matching audit-log evidence was found."],
+            "metadata": {
+                "source": "deterministic_query_diagnosis",
+                "rule_version": "query-diagnosis-v1",
+            },
+            "evidence": [],
+        }
+    )
+
+    result = await manager.domain_dispatcher.call_domain(
+        "doris_query",
+        {
+            "child_tool": "diagnose_query_performance",
+            "arguments": {"sql": "SELECT 1"},
+        },
+        None,
+    )
+
+    assert result.mode == "result"
+    assert result.to_wire()["data"]["status"] == "partial"
+    manager.query_runtime.diagnose_query_performance.assert_awaited_once_with(
+        query_id=None,
+        sql="SELECT 1",
+        database=None,
+        include_cluster_context=False,
+    )
 
 
 @pytest.mark.asyncio
@@ -1557,8 +1676,9 @@ def test_detail_result_normalization_adds_formal_evidence() -> None:
                 "days": 1,
                 "top_n": 8,
                 "min_execution_time_ms": 500,
+                "db_name": "db",
             },
-            1,
+            0,
         ),
         (
             "adapt:resource_growth_arguments",

--- a/test/tools/test_doris_feature_matrix.py
+++ b/test/tools/test_doris_feature_matrix.py
@@ -102,6 +102,15 @@ def test_adbc_is_inside_query_and_variant_is_inside_lakehouse() -> None:
     assert "execute_adbc_query" in query_children
     assert "inspect_variant_column" in lakehouse_children
     assert "doris_adbc" not in EXPECTED_DOMAIN_CHILDREN
+    execute_adbc = DORIS_FEATURE_MATRIX.get_feature(
+        "doris_query",
+        "execute_adbc_query",
+    )
+    assert execute_adbc.support_contract.variants[0].required_probes == (
+        "adbc_driver_ready",
+        "flight_sql_reachable",
+        "read_only_sql_guard_ready",
+    )
 
 
 def test_every_contract_is_fail_closed_and_has_resolvable_sources() -> None:
@@ -425,6 +434,20 @@ def test_table_size_uses_master_fe_metadata_with_unknown_backend_version() -> No
     )
 
     assert result.version_scope is CapabilityVersionScope.MASTER_FE
+    assert result.effective_version == "4.0.5"
+    assert result.compatible is True
+
+
+def test_query_diagnosis_uses_provider_with_master_fe_baseline() -> None:
+    result = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_query",
+        child_name="diagnose_query_performance",
+        versions=_vector("4.0.5"),
+    )
+
+    assert result.version_scope is (
+        CapabilityVersionScope.PROVIDER_WITH_MASTER_FE_BASELINE
+    )
     assert result.effective_version == "4.0.5"
     assert result.compatible is True
 

--- a/test/tools/test_tools_manager.py
+++ b/test/tools/test_tools_manager.py
@@ -30,6 +30,7 @@ from doris_mcp_server.tools.doris_feature_matrix import (
 )
 from doris_mcp_server.tools.tools_manager import DorisToolsManager
 from doris_mcp_server.utils.config import DorisConfig
+from doris_mcp_server.utils.query_runtime import QueryRuntimeFailure
 
 
 class TestDorisToolsManager:
@@ -86,17 +87,22 @@ class TestDorisToolsManager:
     async def test_exec_query_tool(self, tools_manager):
         """Test exec_query tool"""
         with patch.object(
-            tools_manager.metadata_extractor,
-            "exec_query_for_mcp",
+            tools_manager.query_runtime,
+            "execute_query",
         ) as mock_execute:
             mock_execute.return_value = {
-                "success": True,
-                "data": [
-                    {"id": 1, "name": "张三"},
-                    {"id": 2, "name": "李四"}
-                ],
-                "row_count": 2,
-                "execution_time": 0.15
+                "status": "success",
+                "data": {
+                    "columns": [{"name": "id"}, {"name": "name"}],
+                    "rows": [
+                        {"id": 1, "name": "Alice"},
+                        {"id": 2, "name": "Bob"},
+                    ],
+                    "row_count": 2,
+                    "truncated": False,
+                },
+                "warnings": [],
+                "metadata": {},
             }
 
             arguments = {
@@ -106,31 +112,39 @@ class TestDorisToolsManager:
 
             result = await tools_manager._exec_query_tool(arguments)
 
-            assert result["success"] is True
-            assert len(result["data"]) == 2
+            assert result["status"] == "success"
+            assert len(result["data"]["rows"]) == 2
             mock_execute.assert_awaited_once_with(
-                arguments["sql"],
-                None,
-                None,
-                100,
-                30,
-                max_bytes=None,
+                sql=arguments["sql"],
+                catalog=None,
+                database=None,
+                parameters=None,
+                max_rows=100,
+                timeout_ms=None,
             )
 
     @pytest.mark.asyncio
     async def test_exec_query_with_error(self, tools_manager):
         """Test exec_query tool with error"""
         with patch.object(
-            tools_manager.metadata_extractor,
-            "exec_query_for_mcp",
+            tools_manager.query_runtime,
+            "execute_query",
         ) as mock_execute:
-            mock_execute.side_effect = Exception("Database connection failed")
+            mock_execute.side_effect = QueryRuntimeFailure(
+                "Doris query execution is temporarily unavailable.",
+                reason_code="QUERY_BACKEND_UNAVAILABLE",
+                status_code=503,
+                retryable=True,
+            )
 
             arguments = {
                 "sql": "SELECT * FROM users"
             }
 
-            with pytest.raises(Exception, match="Database connection failed"):
+            with pytest.raises(
+                QueryRuntimeFailure,
+                match="temporarily unavailable",
+            ):
                 await tools_manager._exec_query_tool(arguments)
 
     @pytest.mark.asyncio

--- a/test/tools/test_tools_operation_guard.py
+++ b/test/tools/test_tools_operation_guard.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -21,6 +22,7 @@ from doris_mcp_server.tools.doris_feature_matrix import (
     EXPECTED_DOMAIN_CHILDREN,
 )
 from doris_mcp_server.tools.tools_manager import DorisToolsManager
+from doris_mcp_server.utils.adbc_query_tools import DorisADBCQueryTools
 from doris_mcp_server.utils.analysis_tools import SQLAnalyzer
 from doris_mcp_server.utils.data_governance_tools import DataGovernanceTools
 from doris_mcp_server.utils.db import QueryResult
@@ -48,7 +50,9 @@ class FakeRoutedConnection:
         *,
         max_rows=None,
         max_bytes=None,
+        mask_result=True,
     ):
+        del mask_result
         return await self.manager.execute_query(
             self.session_id,
             sql,
@@ -98,6 +102,21 @@ class FakeRoutedConnectionManager:
 
     async def release_connection(self, session_id, connection):
         self.connection_releases += 1
+
+    @asynccontextmanager
+    async def get_connection_context_for_auth_context(
+        self,
+        session_id,
+        auth_context,
+    ):
+        connection = await self._get_connection_for_auth_context(
+            session_id,
+            auth_context,
+        )
+        try:
+            yield connection
+        finally:
+            await self.release_connection(session_id, connection)
 
     async def execute_query(
         self,
@@ -253,6 +272,11 @@ def _real_tool_manager_for_routing(tmp_path):
     manager.sql_analyzer = SQLAnalyzer(connection_manager)
     manager._tool_exposure_mode = ToolExposureMode.HIERARCHICAL
     manager._domain_manifest_service = DomainManifestService()
+    manager.adbc_query_tools = DorisADBCQueryTools(connection_manager)
+    manager._initialize_query_handlers(
+        connection_manager,
+        manager.adbc_query_tools,
+    )
     return manager, connection_manager
 
 
@@ -359,13 +383,14 @@ async def test_doris_oauth_exec_query_real_tool_path_uses_doris_user_route(tmp_p
     finally:
         reset_auth_context(token)
 
-    assert result["success"] is True
-    assert result["data"] == [{"one": 1}]
+    assert result["status"] == "success"
+    assert result["data"]["rows"] == [{"one": 1}]
     assert connection_manager.global_calls == 0
     assert connection_manager.token_calls == 0
     assert len(connection_manager.routed_calls) == 1
     assert connection_manager.routed_calls[0]["doris_user"] == "alice"
-    assert connection_manager.routed_calls[0]["sql"] == "SELECT 1 LIMIT 5"
+    assert connection_manager.routed_calls[0]["sql"] == "SELECT 1"
+    assert connection_manager.routed_calls[0]["max_rows"] == 5
 
 
 @pytest.mark.asyncio
@@ -397,14 +422,15 @@ async def test_doris_oauth_exec_query_with_db_catalog_uses_one_routed_connection
     finally:
         reset_auth_context(token)
 
-    assert result["success"] is True
+    assert result["status"] == "success"
     assert connection_manager.connection_acquires == 1
     assert connection_manager.connection_releases == 1
     assert [call["sql"] for call in connection_manager.routed_calls] == [
-        "USE CATALOG `ctl1`",
+        "SWITCH `ctl1`",
         "USE `db1`",
-        "SELECT * FROM orders LIMIT 5",
+        "SELECT * FROM orders",
     ]
+    assert connection_manager.routed_calls[-1]["max_rows"] == 5
     assert {call["doris_user"] for call in connection_manager.routed_calls} == {"alice"}
 
 
@@ -428,8 +454,8 @@ async def test_doris_oauth_sql_explain_real_tool_path_uses_doris_user_route(tmp_
     finally:
         reset_auth_context(token)
 
-    assert result["success"] is True
-    assert "EXPLAIN SELECT 1" in result["content"]
+    assert result["status"] == "success"
+    assert result["data"]["plan_text"] == "SCAN"
     assert connection_manager.global_calls == 0
     assert connection_manager.token_calls == 0
     assert len(connection_manager.routed_calls) == 1
@@ -463,11 +489,11 @@ async def test_doris_oauth_sql_explain_with_db_catalog_uses_one_routed_connectio
     finally:
         reset_auth_context(token)
 
-    assert result["success"] is True
+    assert result["status"] == "success"
     assert connection_manager.connection_acquires == 1
     assert connection_manager.connection_releases == 1
     assert [call["sql"] for call in connection_manager.routed_calls] == [
-        "USE CATALOG `ctl1`",
+        "SWITCH `ctl1`",
         "USE `db1`",
         "EXPLAIN SELECT * FROM orders",
     ]

--- a/test/utils/test_adbc_query_tools.py
+++ b/test/utils/test_adbc_query_tools.py
@@ -22,11 +22,17 @@ import asyncio
 import threading
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 from doris_mcp_server.result_limits import ResultLimits
 from doris_mcp_server.utils.adbc_query_tools import DorisADBCQueryTools
+from doris_mcp_server.utils.security import (
+    AuthContext,
+    reset_auth_context,
+    set_current_auth_context,
+)
 
 
 def _manager() -> SimpleNamespace:
@@ -41,8 +47,15 @@ def _manager() -> SimpleNamespace:
                 default_max_rows=20,
                 default_timeout=10,
                 default_return_format="dict",
+                connection_timeout=30,
+            ),
+            database=SimpleNamespace(
+                be_hosts=["be-1"],
+                user="root",
+                password="",
             ),
         ),
+        host="fe-1",
         security_manager=None,
     )
 
@@ -101,9 +114,7 @@ class _BlockingCursor:
 
 @pytest.mark.asyncio
 async def test_adbc_streams_to_row_limit_without_fetchall() -> None:
-    cursor = _StreamingCursor(
-        [(1, "one"), (2, "two"), (3, "three")]
-    )
+    cursor = _StreamingCursor([(1, "one"), (2, "two"), (3, "three")])
     tools = DorisADBCQueryTools(_manager())
     tools.adbc_client = SimpleNamespace(cursor=lambda: cursor)
 
@@ -127,9 +138,7 @@ async def test_adbc_streams_to_row_limit_without_fetchall() -> None:
 
 @pytest.mark.asyncio
 async def test_adbc_streams_to_byte_limit() -> None:
-    cursor = _StreamingCursor(
-        [(1, "x" * 180), (2, "y" * 180)]
-    )
+    cursor = _StreamingCursor([(1, "x" * 180), (2, "y" * 180)])
     tools = DorisADBCQueryTools(_manager())
     tools.adbc_client = SimpleNamespace(cursor=lambda: cursor)
 
@@ -183,6 +192,47 @@ async def test_adbc_rejects_limit_escalation_before_network_checks() -> None:
 
     assert result["success"] is False
     assert result["error_type"] == "invalid_result_limits"
-    assert result["error"] == (
-        "max_rows exceeds the configured maximum of 50"
+    assert result["error"] == ("max_rows exceeds the configured maximum of 50")
+
+
+@pytest.mark.asyncio
+async def test_adbc_fails_closed_for_doris_oauth_before_probing() -> None:
+    tools = DorisADBCQueryTools(_manager())
+    tools._check_arrow_flight_ports = MagicMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("ADBC endpoint probe must not run")
     )
+    context_token = set_current_auth_context(
+        AuthContext(
+            auth_method="doris_oauth",
+            doris_user="analyst",
+        )
+    )
+    try:
+        result = await tools.exec_adbc_query("SELECT 1")
+    finally:
+        reset_auth_context(context_token)
+
+    assert result["success"] is False
+    assert result["error_type"] == "token_bound_adbc_unsupported"
+    tools._check_arrow_flight_ports.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_adbc_capability_probe_uses_bounded_socket_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tools = DorisADBCQueryTools(_manager())
+    connectivity = MagicMock(return_value=True)
+    tools._check_port_connectivity = connectivity  # type: ignore[method-assign]
+    monkeypatch.setenv("FE_ARROW_FLIGHT_SQL_PORT", "8070")
+    monkeypatch.setenv("BE_ARROW_FLIGHT_SQL_PORT", "8060")
+
+    result = await tools._check_arrow_flight_ports(
+        connectivity_timeout=0.25,
+    )
+
+    assert result["success"] is True
+    assert connectivity.call_args_list == [
+        (("fe-1", 8070, 0.25),),
+        (("be-1", 8060, 0.25),),
+    ]

--- a/test/utils/test_db.py
+++ b/test/utils/test_db.py
@@ -19,7 +19,6 @@ def session_cache():
 
 
 class TestDorisSessionCache:
-
     def test_initialization(self, session_cache):
         cache, _ = session_cache
         assert cache.cache_system_session is True
@@ -141,15 +140,13 @@ def _make_doris_connection(cursor_description, fetchall_rows, rowcount=0):
     cursor = MagicMock()
     cursor.execute = AsyncMock(return_value=None)
     cursor.fetchall = AsyncMock(return_value=fetchall_rows)
+    cursor.close = AsyncMock(return_value=None)
     cursor.description = cursor_description
     cursor.rowcount = rowcount
 
-    cursor_ctx = MagicMock()
-    cursor_ctx.__aenter__ = AsyncMock(return_value=cursor)
-    cursor_ctx.__aexit__ = AsyncMock(return_value=None)
-
     raw_connection = MagicMock()
-    raw_connection.cursor = MagicMock(return_value=cursor_ctx)
+    raw_connection.cursor = AsyncMock(return_value=cursor)
+    raw_connection.ensure_closed = AsyncMock()
 
     return DorisConnection(connection=raw_connection, session_id="test")
 
@@ -158,15 +155,12 @@ def _make_bounded_doris_connection(cursor_description, fetchmany_rows):
     cursor = MagicMock()
     cursor.execute = AsyncMock(return_value=None)
     cursor.fetchmany = AsyncMock(side_effect=fetchmany_rows)
+    cursor.close = AsyncMock(return_value=None)
     cursor.description = cursor_description
     cursor.rowcount = 0
 
-    cursor_ctx = MagicMock()
-    cursor_ctx.__aenter__ = AsyncMock(return_value=cursor)
-    cursor_ctx.__aexit__ = AsyncMock(return_value=None)
-
     raw_connection = MagicMock()
-    raw_connection.cursor = MagicMock(return_value=cursor_ctx)
+    raw_connection.cursor = AsyncMock(return_value=cursor)
     raw_connection.ensure_closed = AsyncMock()
 
     return (
@@ -314,11 +308,12 @@ class TestBoundedResultFetch:
         assert result.metadata["truncation_reason"] == "row_limit"
         assert result.metadata["result_bytes"] <= 4096
         cursor.fetchall.assert_not_called()
+        cursor.close.assert_not_awaited()
         raw_connection.ensure_closed.assert_awaited_once()
         assert conn.is_healthy is False
 
     async def test_byte_limit_is_measured_after_masking(self):
-        conn, _, raw_connection = _make_bounded_doris_connection(
+        conn, cursor, raw_connection = _make_bounded_doris_connection(
             [("secret", None, None, None, None, None, None)],
             [[{"secret": "x"}], []],
         )
@@ -347,6 +342,7 @@ class TestBoundedResultFetch:
         assert result.metadata["truncation_reason"] == "byte_limit"
         assert result.metadata["result_bytes"] == 2
         security_manager.apply_data_masking.assert_awaited_once()
+        cursor.close.assert_not_awaited()
         raw_connection.ensure_closed.assert_awaited_once()
 
     async def test_task_cancellation_closes_connection_and_propagates(self):
@@ -354,6 +350,7 @@ class TestBoundedResultFetch:
             [("id", None, None, None, None, None, None)],
             [],
         )
+
         async def never_returns(*args, **kwargs):
             del args, kwargs
             await asyncio.Event().wait()
@@ -372,5 +369,24 @@ class TestBoundedResultFetch:
         with pytest.raises(asyncio.CancelledError):
             await task
 
+        raw_connection.ensure_closed.assert_awaited_once()
+        cursor.close.assert_not_awaited()
+        assert conn.is_healthy is False
+
+    async def test_bounded_fetch_failure_closes_physical_connection(self):
+        conn, cursor, raw_connection = _make_bounded_doris_connection(
+            [("id", None, None, None, None, None, None)],
+            [],
+        )
+        cursor.fetchmany.side_effect = RuntimeError("stream failed")
+
+        with pytest.raises(RuntimeError, match="stream failed"):
+            await conn.execute(
+                "SELECT id FROM data",
+                max_rows=10,
+                max_bytes=4096,
+            )
+
+        cursor.close.assert_not_awaited()
         raw_connection.ensure_closed.assert_awaited_once()
         assert conn.is_healthy is False

--- a/test/utils/test_doris_user_pool_manager.py
+++ b/test/utils/test_doris_user_pool_manager.py
@@ -113,7 +113,9 @@ def doris_context(user="alice", token=""):
 
 
 @pytest.mark.asyncio
-async def test_authenticate_doris_user_success_does_not_create_pool(manager, monkeypatch):
+async def test_authenticate_doris_user_success_does_not_create_pool(
+    manager, monkeypatch
+):
     connect = AsyncMock(return_value=FakeAuthConnection())
     create_pool = AsyncMock()
     monkeypatch.setattr(db_module.aiomysql, "connect", connect)
@@ -159,13 +161,20 @@ async def test_repeat_login_reverifies_and_reuses_existing_pool(manager, monkeyp
     assert create_pool.await_count == 1
     assert create_pool.await_args.kwargs["db"] == "information_schema"
     assert manager.doris_user_pools["alice"] is pool
-    assert manager.doris_user_pool_meta["alice"].credential_fingerprint == first_meta.credential_fingerprint
+    assert (
+        manager.doris_user_pool_meta["alice"].credential_fingerprint
+        == first_meta.credential_fingerprint
+    )
 
 
 @pytest.mark.asyncio
-async def test_wrong_password_after_existing_pool_preserves_old_pool(manager, monkeypatch):
+async def test_wrong_password_after_existing_pool_preserves_old_pool(
+    manager, monkeypatch
+):
     old_pool = FakePool("alice-v1")
-    connect = AsyncMock(side_effect=[FakeAuthConnection(), RuntimeError("access denied")])
+    connect = AsyncMock(
+        side_effect=[FakeAuthConnection(), RuntimeError("access denied")]
+    )
     create_pool = AsyncMock(return_value=old_pool)
     monkeypatch.setattr(db_module.aiomysql, "connect", connect)
     monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
@@ -178,12 +187,17 @@ async def test_wrong_password_after_existing_pool_preserves_old_pool(manager, mo
 
     assert manager.doris_user_pools["alice"] is old_pool
     assert manager.doris_user_pool_meta["alice"].owner_id == old_meta.owner_id
-    assert manager.doris_user_pool_meta["alice"].credential_fingerprint == old_meta.credential_fingerprint
+    assert (
+        manager.doris_user_pool_meta["alice"].credential_fingerprint
+        == old_meta.credential_fingerprint
+    )
     assert create_pool.await_count == 1
 
 
 @pytest.mark.asyncio
-async def test_soft_replace_releases_old_checked_out_connection_to_old_owner(manager, monkeypatch):
+async def test_soft_replace_releases_old_checked_out_connection_to_old_owner(
+    manager, monkeypatch
+):
     old_pool = FakePool("alice-v1")
     new_pool = FakePool("alice-v2")
     connect = AsyncMock(side_effect=[FakeAuthConnection(), FakeAuthConnection()])
@@ -221,7 +235,10 @@ async def test_new_pool_create_failure_preserves_existing_pool(manager, monkeypa
 
     assert manager.doris_user_pools["alice"] is old_pool
     assert manager.doris_user_pool_meta["alice"].owner_id == old_meta.owner_id
-    assert manager.doris_user_pool_meta["alice"].credential_fingerprint == old_meta.credential_fingerprint
+    assert (
+        manager.doris_user_pool_meta["alice"].credential_fingerprint
+        == old_meta.credential_fingerprint
+    )
 
 
 @pytest.mark.asyncio
@@ -262,7 +279,9 @@ async def test_execute_query_pool_missing_does_not_fallback_to_global_or_token(m
 
 
 @pytest.mark.asyncio
-async def test_execute_query_releases_to_captured_doris_user_owner(manager, monkeypatch):
+async def test_execute_query_releases_to_captured_doris_user_owner(
+    manager, monkeypatch
+):
     pool = FakePool("alice-v1")
     connect = AsyncMock(return_value=FakeAuthConnection())
     create_pool = AsyncMock(return_value=pool)
@@ -281,7 +300,9 @@ async def test_execute_query_releases_to_captured_doris_user_owner(manager, monk
         max_bytes=None,
     ):
         del max_rows, max_bytes
-        return QueryResult(data=[{"ok": 1}], metadata={}, execution_time=0.0, row_count=1, sql=sql)
+        return QueryResult(
+            data=[{"ok": 1}], metadata={}, execution_time=0.0, row_count=1, sql=sql
+        )
 
     monkeypatch.setattr(DorisConnection, "execute", fake_execute)
 
@@ -362,7 +383,9 @@ async def test_static_token_release_uses_captured_owner_pool(manager, monkeypatc
         database="token_db",
         charset="utf8",
     )
-    manager.token_manager = SimpleNamespace(get_database_config_by_token=lambda raw: token_db_config)
+    manager.token_manager = SimpleNamespace(
+        get_database_config_by_token=lambda raw: token_db_config
+    )
     create_pool = AsyncMock(return_value=old_pool)
     monkeypatch.setattr(db_module.aiomysql, "create_pool", create_pool)
 
@@ -413,6 +436,27 @@ async def test_release_routed_connection_releases_closed_raw_to_captured_owner(
     assert old_owner.release_calls == [raw_connection]
     assert current_pool.release_calls == []
     assert raw_connection.ensure_closed_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_release_routed_connection_force_closes_unhealthy_raw(manager):
+    owner = FakePool("owner")
+    raw_connection = FakeRawConnection("unhealthy-raw")
+    connection = DorisConnection(
+        raw_connection,
+        "s1",
+        pool_kind="static_token",
+        route_key="static_token:tokenhash",
+        owner_id="static_token:tokenhash:gen:1",
+        generation=1,
+        owner_pool=owner,
+    )
+    connection.is_healthy = False
+
+    await manager.release_routed_connection(connection)
+
+    assert owner.release_calls == []
+    assert raw_connection.ensure_closed_calls == 1
 
 
 @pytest.mark.asyncio

--- a/test/utils/test_query_runtime.py
+++ b/test/utils/test_query_runtime.py
@@ -1,0 +1,899 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Security and evidence contracts for the formal Query-domain runtime."""
+
+from __future__ import annotations
+
+import math
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from doris_mcp_server.utils.config import DorisConfig
+from doris_mcp_server.utils.db import QueryResult
+from doris_mcp_server.utils.doris_http_client import DorisHTTPResponse
+from doris_mcp_server.utils.query_runtime import (
+    DorisQueryRuntime,
+    QueryRuntimeFailure,
+    ReadOnlySQLGuard,
+)
+from doris_mcp_server.utils.security import (
+    AuthContext,
+    reset_auth_context,
+    set_current_auth_context,
+)
+
+
+def _query_result(
+    *,
+    sql: str = "SELECT 1",
+    rows: list[dict[str, Any]] | None = None,
+    columns: list[str] | None = None,
+    truncated: bool = False,
+) -> QueryResult:
+    data = rows if rows is not None else [{"answer": 1}]
+    return QueryResult(
+        data=data,
+        metadata={
+            "columns": columns or ["answer"],
+            "truncated": truncated,
+            "result_bytes": 16,
+            "truncation_reason": "row_limit" if truncated else None,
+        },
+        execution_time=0.01,
+        row_count=len(data),
+        sql=sql,
+    )
+
+
+class _Connection:
+    def __init__(
+        self,
+        results: list[QueryResult] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.results = list(results or [_query_result()])
+        self.error = error
+        self.calls: list[tuple[str, Any, dict[str, Any]]] = []
+
+    async def execute(
+        self,
+        sql: str,
+        params: Any = None,
+        **kwargs: Any,
+    ) -> QueryResult:
+        self.calls.append((sql, params, kwargs))
+        if self.error is not None:
+            raise self.error
+        if sql.startswith(("USE ", "SET ", "SWITCH ")):
+            return _query_result(sql=sql, rows=[], columns=[])
+        if self.results:
+            return self.results.pop(0)
+        return _query_result(sql=sql, rows=[], columns=[])
+
+
+class _ConnectionManager:
+    def __init__(self, connection: _Connection) -> None:
+        self.config = DorisConfig()
+        self.connection = connection
+        self.session_ids: list[str] = []
+
+    @asynccontextmanager
+    async def get_connection_context_for_auth_context(
+        self,
+        session_id: str,
+        _auth_context: Any,
+    ):
+        self.session_ids.append(session_id)
+        yield self.connection
+
+
+def _runtime(
+    *,
+    connection: _Connection | None = None,
+    adbc: Any | None = None,
+) -> tuple[DorisQueryRuntime, _ConnectionManager, Any]:
+    manager = _ConnectionManager(connection or _Connection())
+    adbc_tools = adbc or SimpleNamespace(
+        exec_adbc_query=AsyncMock(),
+        get_adbc_connection_info=AsyncMock(),
+    )
+    return DorisQueryRuntime(manager, adbc_tools), manager, adbc_tools
+
+
+@pytest.mark.parametrize(
+    ("sql", "operation"),
+    [
+        ("SELECT 1", "SELECT"),
+        ("WITH value AS (SELECT 1) SELECT * FROM value", "SELECT"),
+        ("SHOW DATABASES", "SHOW"),
+        ("DESC internal.__internal_schema.audit_log", "DESC"),
+        ("DESCRIBE t", "DESCRIBE"),
+        ("EXPLAIN SELECT 1", "EXPLAIN"),
+        ("EXPLAIN SELECT REPLACE(name, 'a', 'b') FROM t", "EXPLAIN"),
+        ("SELECT REPLACE(name, 'a', 'b') FROM t", "SELECT"),
+        ("SELECT admin, load FROM metrics", "SELECT"),
+        ("SELECT 'DROP TABLE t' AS harmless", "SELECT"),
+        ("/* DELETE FROM t */ SELECT 1", "SELECT"),
+        ("SELECT 1; /* trailing comment */", "SELECT"),
+    ],
+)
+def test_read_only_guard_accepts_supported_statements(
+    sql: str,
+    operation: str,
+) -> None:
+    assert ReadOnlySQLGuard.validate(sql).operation == operation
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1; SELECT 2",
+        "INSERT INTO t VALUES (1)",
+        "WITH old AS (SELECT 1) DELETE FROM t",
+        "EXPLAIN DELETE FROM t",
+        "SELECT * FROM t INTO OUTFILE '/tmp/result'",
+        "SELECT SLEEP(1)",
+        "SELECT @value := 1",
+        "SELECT * FROM t FOR UPDATE",
+        "SELECT * FROM t LOCK IN SHARE MODE",
+        "/*!50000 DROP TABLE t */ SELECT 1",
+        "SET enable_profile=true",
+        "USE analytics",
+    ],
+)
+def test_read_only_guard_rejects_mutating_or_side_effecting_sql(
+    sql: str,
+) -> None:
+    with pytest.raises(
+        QueryRuntimeFailure,
+        match="read-only|allowed|assignment|Locking|comments|export|side-effecting",
+    ) as error:
+        ReadOnlySQLGuard.validate(sql)
+
+    assert error.value.reason_code == "QUERY_READ_ONLY_VIOLATION"
+
+
+def test_query_target_rejects_nested_explain() -> None:
+    with pytest.raises(QueryRuntimeFailure) as error:
+        ReadOnlySQLGuard.validate("EXPLAIN SELECT 1", query_target=True)
+
+    assert error.value.reason_code == "QUERY_READ_ONLY_VIOLATION"
+
+
+def test_named_parameters_are_exact_and_ignore_literals_and_comments() -> None:
+    sql = (
+        "SELECT %(customer_id)s AS customer_id, "
+        "'%(literal)s' AS literal /* %(comment)s */"
+    )
+
+    assert ReadOnlySQLGuard.validate_parameters(
+        sql,
+        {"customer_id": 7},
+    ) == {"customer_id": 7}
+
+    with pytest.raises(QueryRuntimeFailure, match="match exactly"):
+        ReadOnlySQLGuard.validate_parameters(
+            "SELECT %(customer_id)s",
+            {"customer_id": 7, "extra": True},
+        )
+    with pytest.raises(QueryRuntimeFailure, match="missing"):
+        ReadOnlySQLGuard.validate_parameters(
+            "SELECT %(customer_id)s",
+            None,
+        )
+    with pytest.raises(QueryRuntimeFailure, match="JSON scalars"):
+        ReadOnlySQLGuard.validate_parameters(
+            "SELECT %(customer_id)s",
+            {"customer_id": {"nested": "not allowed"}},
+        )
+    with pytest.raises(QueryRuntimeFailure, match="finite"):
+        ReadOnlySQLGuard.validate_parameters(
+            "SELECT %(customer_id)s",
+            {"customer_id": math.inf},
+        )
+    with pytest.raises(QueryRuntimeFailure, match="Positional"):
+        ReadOnlySQLGuard.validate_parameters("SELECT %s", None)
+
+
+def test_driver_sql_escapes_non_placeholder_percent_signs() -> None:
+    sql = (
+        "SELECT %(customer_id)s AS customer_id, "
+        "'100%' AS ratio, '%(literal)s' AS literal "
+        "/* %(comment)s and 50% */"
+    )
+    parameters = {"customer_id": 7}
+
+    prepared = ReadOnlySQLGuard.prepare_driver_sql(sql, parameters)
+
+    assert prepared % parameters == (
+        "SELECT 7 AS customer_id, '100%' AS ratio, "
+        "'%(literal)s' AS literal /* %(comment)s and 50% */"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_query_binds_context_parameters_and_result_limits() -> None:
+    runtime, manager, _ = _runtime()
+
+    result = await runtime.execute_query(
+        sql="SELECT %(answer)s AS answer, '100%' AS ratio",
+        catalog="internal",
+        database="analytics",
+        parameters={"answer": 42},
+        max_rows=25,
+        timeout_ms=1500,
+    )
+
+    assert result["status"] == "success"
+    assert result["data"] == {
+        "columns": [{"name": "answer"}],
+        "rows": [{"answer": 1}],
+        "row_count": 1,
+        "truncated": False,
+    }
+    assert [call[0] for call in manager.connection.calls] == [
+        "SWITCH `internal`",
+        "USE `analytics`",
+        "SELECT %(answer)s AS answer, '100%%' AS ratio",
+    ]
+    assert manager.connection.calls[-1][1] == {"answer": 42}
+    assert manager.connection.calls[-1][2]["max_rows"] == 25
+    assert result["metadata"]["limits"]["timeout_seconds"] == 2
+    assert manager.connection.is_healthy is False
+
+
+@pytest.mark.asyncio
+async def test_execute_query_preserves_decimal_precision_as_json_string() -> None:
+    connection = _Connection(
+        results=[
+            _query_result(
+                rows=[{"amount": Decimal("12345678901234567890.123456789012345678")}],
+                columns=["amount"],
+            )
+        ]
+    )
+    runtime, _, _ = _runtime(connection=connection)
+
+    result = await runtime.execute_query(sql="SELECT amount FROM payments")
+
+    assert result["data"]["rows"] == [
+        {"amount": "12345678901234567890.123456789012345678"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_query_sanitizes_backend_errors() -> None:
+    runtime, _, _ = _runtime(
+        connection=_Connection(
+            error=RuntimeError(
+                "access denied for user root password=secret at 10.0.0.8"
+            )
+        )
+    )
+
+    with pytest.raises(QueryRuntimeFailure) as error:
+        await runtime.execute_query(sql="SELECT * FROM restricted")
+
+    assert str(error.value) == "Doris denied the query on the active route."
+    assert error.value.reason_code == "QUERY_PERMISSION_DENIED"
+    assert "secret" not in str(error.value)
+    assert "10.0.0.8" not in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_explain_costs_uses_supported_verbose_syntax() -> None:
+    connection = _Connection(
+        results=[
+            _query_result(
+                sql="EXPLAIN VERBOSE SELECT 1",
+                rows=[{"Explain String": "PLAN FRAGMENT 0\ncardinality=1"}],
+                columns=["Explain String"],
+            )
+        ]
+    )
+    runtime, manager, _ = _runtime(connection=connection)
+    manager.config.security.max_result_rows = 200
+
+    result = await runtime.explain_query(sql="SELECT 1", level="costs")
+
+    assert connection.calls[0][0] == "EXPLAIN VERBOSE SELECT 1"
+    assert connection.calls[0][2]["max_rows"] == 200
+    assert result["status"] == "partial"
+    assert result["data"]["requested_level"] == "costs"
+    assert result["data"]["effective_level"] == "verbose"
+    assert "no EXPLAIN COSTS keyword" in result["warnings"][0]
+
+
+@pytest.mark.asyncio
+async def test_explain_reports_bounded_plan_truncation() -> None:
+    connection = _Connection(
+        results=[
+            _query_result(
+                sql="EXPLAIN SELECT 1",
+                rows=[{"Explain String": "PLAN FRAGMENT 0"}],
+                columns=["Explain String"],
+                truncated=True,
+            )
+        ]
+    )
+    runtime, _, _ = _runtime(connection=connection)
+
+    result = await runtime.explain_query(sql="SELECT 1")
+
+    assert result["status"] == "partial"
+    assert result["metadata"]["plan_truncated"] is True
+    assert result["metadata"]["truncation_reason"] == "row_limit"
+    assert "truncated" in result["warnings"][0]
+
+
+@pytest.mark.asyncio
+async def test_profile_requires_exactly_one_input_and_bounds_text() -> None:
+    runtime, _, _ = _runtime()
+    runtime._fetch_profile = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "query_id": "query_123",
+            "profile_text": "PLAN\n  SCAN\nPeak Memory: 10",
+        }
+    )
+
+    with pytest.raises(QueryRuntimeFailure, match="exactly one"):
+        await runtime.get_query_profile()
+    with pytest.raises(QueryRuntimeFailure, match="exactly one"):
+        await runtime.get_query_profile(
+            query_id="query_123",
+            sql="SELECT 1",
+        )
+    with pytest.raises(QueryRuntimeFailure, match="recent_window_minutes"):
+        await runtime.get_query_profile(
+            query_id="query_123",
+            recent_window_minutes=0,
+        )
+
+    result = await runtime.get_query_profile(
+        query_id="query_123",
+        include_operator_tree=True,
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["query_id"] == "query_123"
+    assert result["data"]["operator_tree"]
+    runtime._fetch_profile.assert_awaited_once_with("query_123")
+
+
+@pytest.mark.asyncio
+async def test_profiled_query_discards_connection_with_session_state() -> None:
+    runtime, manager, _ = _runtime()
+    limits = runtime._resolve_limits(max_rows=1, timeout_ms=1000)
+
+    await runtime._execute_profiled_statement(
+        "SELECT 1",
+        trace_id="trace_1",
+        database=None,
+        limits=limits,
+    )
+
+    assert [call[0] for call in manager.connection.calls] == [
+        'SET session_context="trace_id:trace_1"',
+        "SET enable_profile=true",
+        "SELECT 1",
+    ]
+    assert manager.connection.is_healthy is False
+
+
+@pytest.mark.asyncio
+async def test_profile_http_payload_codes_are_handled_without_leaking_data() -> None:
+    runtime, _, _ = _runtime()
+    runtime._profile_http_get = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            DorisHTTPResponse(
+                status=400,
+                headers={"content-type": "application/json"},
+                body=(
+                    b'{"msg":"Bad Request","code":403,'
+                    b'"data":"internal permission detail"}'
+                ),
+                url="http://configured-fe/profile",
+            ),
+            DorisHTTPResponse(
+                status=200,
+                headers={"content-type": "application/json"},
+                body=(b'{"msg":"success","code":0,"data":{"profile":"PLAN\\nSCAN"}}'),
+                url="http://configured-fe/profile",
+            ),
+            DorisHTTPResponse(
+                status=400,
+                headers={"content-type": "application/json"},
+                body=(
+                    b'{"msg":"Bad Request","code":403,"data":"secret backend detail"}'
+                ),
+                url="http://configured-fe/profile",
+            ),
+        ]
+    )
+
+    assert await runtime._fetch_query_id("trace_1") is None
+    assert await runtime._fetch_profile("query_1") == {
+        "query_id": "query_1",
+        "profile_text": "PLAN\nSCAN",
+    }
+    with pytest.raises(QueryRuntimeFailure) as error:
+        await runtime._fetch_profile("query_2")
+    assert error.value.reason_code == "QUERY_PROFILE_PERMISSION_DENIED"
+    assert "secret" not in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_profile_content_is_not_used_as_a_not_found_sentinel() -> None:
+    runtime, _, _ = _runtime()
+    runtime._profile_http_get = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            DorisHTTPResponse(
+                status=200,
+                headers={"content-type": "application/json"},
+                body=(
+                    b'{"msg":"success","code":0,"data":{"profile":'
+                    b'"SQL: SELECT * FROM messages WHERE state = \\"not found\\"\\nSCAN"}}'
+                ),
+                url="http://configured-fe/profile",
+            ),
+            DorisHTTPResponse(
+                status=200,
+                headers={"content-type": "application/json"},
+                body=b'{"msg":"Not Found","code":404,"data":""}',
+                url="http://configured-fe/profile",
+            ),
+        ]
+    )
+
+    profile = await runtime._fetch_profile("query_1")
+    assert '"not found"' in profile["profile_text"]
+
+    with pytest.raises(QueryRuntimeFailure) as error:
+        await runtime._fetch_profile("query_2")
+    assert error.value.reason_code == "QUERY_PROFILE_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_profile_http_fails_closed_for_doris_oauth_route() -> None:
+    runtime, _, _ = _runtime()
+    context_token = set_current_auth_context(
+        AuthContext(
+            auth_method="doris_oauth",
+            doris_user="analyst",
+        )
+    )
+    try:
+        with pytest.raises(QueryRuntimeFailure) as error:
+            await runtime._profile_http_get(
+                "/rest/v2/manager/query/profile/text/query_1"
+            )
+    finally:
+        reset_auth_context(context_token)
+
+    assert error.value.reason_code == "QUERY_PROFILE_CREDENTIAL_ROUTE_UNAVAILABLE"
+    assert error.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_query_sql_http_evidence_is_validated_and_sanitized() -> None:
+    runtime, _, _ = _runtime()
+    runtime._profile_http_get = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            DorisHTTPResponse(
+                status=200,
+                headers={"content-type": "application/json"},
+                body=(b'{"msg":"success","code":0,"data":{"sql":"SELECT 1"}}'),
+                url="http://configured-fe/sql",
+            ),
+            DorisHTTPResponse(
+                status=400,
+                headers={"content-type": "application/json"},
+                body=(
+                    b'{"msg":"Bad Request","code":403,"data":"secret backend detail"}'
+                ),
+                url="http://configured-fe/sql",
+            ),
+        ]
+    )
+
+    assert await runtime._fetch_query_sql("query_1") == "SELECT 1"
+    with pytest.raises(QueryRuntimeFailure) as error:
+        await runtime._fetch_query_sql("query_2")
+    assert error.value.reason_code == "QUERY_PROFILE_PERMISSION_DENIED"
+    assert "secret" not in str(error.value)
+
+
+@pytest.mark.asyncio
+async def test_list_slow_queries_uses_bound_filters_and_truncates_sql() -> None:
+    long_sql = "SELECT '" + ("x" * 9000) + "'"
+    connection = _Connection(
+        results=[
+            _query_result(
+                rows=[
+                    {
+                        "query_id": "q1",
+                        "time": "2026-07-31 00:00:00",
+                        "user": "analyst",
+                        "catalog": "internal",
+                        "db": "analytics",
+                        "state": "EOF",
+                        "query_time": 2500,
+                        "cpu_time_ms": 125,
+                        "scan_bytes": 2048,
+                        "scan_rows": 100,
+                        "return_rows": 1,
+                        "peak_memory_bytes": 4096,
+                        "sql_hash": "hash",
+                        "sql_digest": "digest",
+                        "stmt": long_sql,
+                    }
+                ],
+                columns=["query_id"],
+            )
+        ]
+    )
+    runtime, _, _ = _runtime(connection=connection)
+
+    result = await runtime.list_slow_queries(
+        window_minutes=15,
+        limit=10,
+        min_duration_ms=2000,
+        database="analytics",
+        user="analyst",
+    )
+
+    sql, params, _ = connection.calls[0]
+    assert "(%s IS NULL OR `db` = %s)" in sql
+    assert "(%s IS NULL OR `user` = %s)" in sql
+    assert "`state` <> 'ERR'" not in sql
+    assert params[1:] == (
+        2000,
+        "analytics",
+        "analytics",
+        "analyst",
+        "analyst",
+        11,
+    )
+    item = result["data"]["items"][0]
+    assert len(item["sql"]) == 8192
+    assert item["sql_truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_slow_queries_rejects_unsafe_filter_before_doris() -> None:
+    runtime, manager, _ = _runtime()
+
+    with pytest.raises(QueryRuntimeFailure) as error:
+        await runtime.list_slow_queries(database="analytics`; DROP TABLE t")
+
+    assert error.value.reason_code == "QUERY_ARGUMENT_INVALID"
+    assert manager.connection.calls == []
+
+
+@pytest.mark.asyncio
+async def test_list_slow_queries_masks_audit_rows_for_requester() -> None:
+    audit_row = {
+        "query_id": "q1",
+        "time": "2026-07-31 00:00:00",
+        "user": "analyst",
+        "catalog": "internal",
+        "db": "analytics",
+        "state": "EOF",
+        "query_time": 2500,
+        "stmt": "SELECT secret_phone FROM customers",
+    }
+    runtime, manager, _ = _runtime(
+        connection=_Connection(
+            results=[_query_result(rows=[audit_row], columns=["query_id"])]
+        )
+    )
+    manager.security_manager = SimpleNamespace(
+        apply_data_masking=AsyncMock(
+            return_value=[{**audit_row, "stmt": "SELECT [MASKED]"}]
+        )
+    )
+    context_token = set_current_auth_context(
+        AuthContext(auth_method="token", user_id="reader")
+    )
+    try:
+        result = await runtime.list_slow_queries(limit=1)
+    finally:
+        reset_auth_context(context_token)
+
+    assert result["data"]["items"][0]["sql"] == "SELECT [MASKED]"
+    manager.security_manager.apply_data_masking.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_slow_query_bounds_distinguish_zero_from_missing_values() -> None:
+    runtime, manager, _ = _runtime(
+        connection=_Connection(results=[_query_result(rows=[])])
+    )
+
+    result = await runtime.list_slow_queries(min_duration_ms=0)
+
+    _, params, _ = manager.connection.calls[0]
+    assert params[1] == 0
+    assert result["status"] == "success"
+
+    with pytest.raises(QueryRuntimeFailure):
+        await runtime.list_slow_queries(window_minutes=0)
+    with pytest.raises(QueryRuntimeFailure):
+        await runtime.list_slow_queries(limit=0)
+
+
+@pytest.mark.asyncio
+async def test_adbc_guard_runs_before_provider_and_normalizes_rows() -> None:
+    adbc = SimpleNamespace(
+        exec_adbc_query=AsyncMock(
+            return_value={
+                "success": True,
+                "result": {
+                    "format": "dict",
+                    "column_names": ["id"],
+                    "column_types": ["BIGINT"],
+                    "num_rows": 1,
+                    "data": [{"id": 1}],
+                },
+                "truncated": False,
+                "execution_time": 0.01,
+            }
+        ),
+        get_adbc_connection_info=AsyncMock(),
+    )
+    runtime, _, _ = _runtime(adbc=adbc)
+
+    with pytest.raises(QueryRuntimeFailure) as error:
+        await runtime.execute_adbc_query(sql="DROP TABLE customer")
+    assert error.value.reason_code == "QUERY_READ_ONLY_VIOLATION"
+    adbc.exec_adbc_query.assert_not_awaited()
+
+    result = await runtime.execute_adbc_query(
+        sql="SELECT id FROM customer",
+        max_rows=10,
+        timeout_ms=2000,
+        result_format="dict",
+    )
+
+    assert result["data"]["columns"] == [{"name": "id", "type": "BIGINT"}]
+    assert result["data"]["rows"] == [{"id": 1}]
+    adbc.exec_adbc_query.assert_awaited_once_with(
+        "SELECT id FROM customer",
+        max_rows=10,
+        timeout=2,
+        return_format="dict",
+    )
+
+
+@pytest.mark.asyncio
+async def test_adbc_rejects_invalid_runtime_options_before_provider() -> None:
+    adbc = SimpleNamespace(
+        exec_adbc_query=AsyncMock(),
+        get_adbc_connection_info=AsyncMock(),
+    )
+    runtime, _, _ = _runtime(adbc=adbc)
+
+    with pytest.raises(QueryRuntimeFailure, match="format"):
+        await runtime.execute_adbc_query(
+            sql="SELECT 1",
+            result_format="csv",
+        )
+    with pytest.raises(QueryRuntimeFailure, match="timeout_ms"):
+        await runtime.execute_adbc_query(
+            sql="SELECT 1",
+            timeout_ms=0,
+        )
+
+    adbc.exec_adbc_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_adbc_connection_info_never_returns_endpoint_or_identity() -> None:
+    adbc = SimpleNamespace(
+        exec_adbc_query=AsyncMock(),
+        get_adbc_connection_info=AsyncMock(
+            return_value={
+                "status": "ready",
+                "configuration": {
+                    "fe_host": "10.0.0.8",
+                    "fe_arrow_flight_port": "8070",
+                    "be_arrow_flight_port": "8060",
+                    "user": "root",
+                },
+                "port_status": {
+                    "success": True,
+                    "be_available_count": 1,
+                    "be_check_results": [{"host": "10.0.0.9", "port": 8060}],
+                },
+                "module_status": {
+                    "success": True,
+                    "adbc_manager_version": "1.8.0",
+                    "flight_sql_version": "1.8.0",
+                },
+            }
+        ),
+    )
+    runtime, _, _ = _runtime(adbc=adbc)
+
+    result = await runtime.get_adbc_connection_info()
+    serialized = repr(result)
+
+    assert result["data"]["status"] == "ready"
+    assert "10.0.0.8" not in serialized
+    assert "10.0.0.9" not in serialized
+    assert "root" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_diagnosis_is_deterministic_and_marks_missing_optional_evidence() -> None:
+    runtime, _, _ = _runtime()
+    runtime.explain_query = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "status": "success",
+            "data": {"plan_text": "CROSS JOIN", "facets": {}},
+            "warnings": [],
+            "metadata": {"source": "doris_explain"},
+            "evidence": [{"source": "doris_sql", "kind": "explain"}],
+        }
+    )
+    runtime.get_query_profile = AsyncMock(  # type: ignore[method-assign]
+        side_effect=QueryRuntimeFailure(
+            "Profile unavailable.",
+            reason_code="QUERY_PROFILE_NOT_FOUND",
+            status_code=404,
+        )
+    )
+    runtime._find_audit_record = AsyncMock(  # type: ignore[method-assign]
+        return_value=None
+    )
+
+    result = await runtime.diagnose_query_performance(
+        sql="SELECT * FROM a CROSS JOIN b",
+        include_cluster_context=True,
+    )
+
+    assert result["status"] == "partial"
+    assert result["metadata"]["rule_version"] == "query-diagnosis-v1"
+    assert result["data"]["findings"] == [
+        {
+            "code": "CROSS_JOIN_OBSERVED",
+            "severity": "high",
+            "evidence": "The Doris explain plan contains CROSS JOIN.",
+        }
+    ]
+    assert result["data"]["recommendations"][0]["finding_code"] == (
+        "CROSS_JOIN_OBSERVED"
+    )
+    assert result["data"]["cluster_context"]["reason_code"] == (
+        "CLUSTER_DOMAIN_NOT_YET_IMPLEMENTED"
+    )
+    assert (
+        result["data"]["steps"]["cluster_context"]
+        is not result["data"]["cluster_context"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_diagnosis_uses_profile_sql_when_audit_record_is_missing() -> None:
+    runtime, _, _ = _runtime()
+    runtime._find_audit_record = AsyncMock(  # type: ignore[method-assign]
+        return_value=None
+    )
+    runtime._fetch_query_sql = AsyncMock(  # type: ignore[method-assign]
+        return_value="SELECT 1"
+    )
+    runtime.explain_query = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "status": "success",
+            "data": {"plan_text": "SCAN", "facets": {}},
+            "warnings": [],
+            "metadata": {"source": "doris_explain"},
+            "evidence": [{"source": "doris_sql", "kind": "explain"}],
+        }
+    )
+    runtime.get_query_profile = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "status": "success",
+            "data": {"query_id": "query_1", "profile": "SCAN"},
+            "warnings": [],
+            "metadata": {"source": "doris_profile_api"},
+            "evidence": [{"source": "doris_fe_http", "kind": "query_profile"}],
+        }
+    )
+
+    result = await runtime.diagnose_query_performance(query_id="query_1")
+
+    assert result["status"] == "partial"
+    runtime._fetch_query_sql.assert_awaited_once_with("query_1")
+    runtime.explain_query.assert_awaited_once_with(
+        sql="SELECT 1",
+        catalog=None,
+        database=None,
+        level="verbose",
+    )
+
+
+@pytest.mark.asyncio
+async def test_diagnosis_reuses_audit_context_masks_output_and_propagates_partial() -> (
+    None
+):
+    audit_row = {
+        "query_id": "query_1",
+        "time": "2026-07-31 00:00:00",
+        "user": "analyst",
+        "catalog": "internal",
+        "db": "analytics",
+        "state": "EOF",
+        "query_time": 2500,
+        "stmt": "SELECT * FROM orders",
+    }
+    runtime, manager, _ = _runtime()
+    runtime._find_audit_record = AsyncMock(  # type: ignore[method-assign]
+        return_value=audit_row
+    )
+    runtime.explain_query = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "status": "partial",
+            "data": {"plan_text": "SCAN", "facets": {}},
+            "warnings": ["The EXPLAIN output was truncated."],
+            "metadata": {"source": "doris_explain"},
+            "evidence": [{"source": "doris_sql", "kind": "explain"}],
+        }
+    )
+    runtime.get_query_profile = AsyncMock(  # type: ignore[method-assign]
+        return_value={
+            "status": "partial",
+            "data": {"query_id": "query_1", "profile": "SCAN"},
+            "warnings": ["Profile text was truncated."],
+            "metadata": {"source": "doris_profile_api"},
+            "evidence": [{"source": "doris_fe_http", "kind": "query_profile"}],
+        }
+    )
+    manager.security_manager = SimpleNamespace(
+        apply_data_masking=AsyncMock(
+            return_value=[{**audit_row, "stmt": "SELECT [MASKED]"}]
+        )
+    )
+    context_token = set_current_auth_context(
+        AuthContext(auth_method="token", user_id="reader")
+    )
+    try:
+        result = await runtime.diagnose_query_performance(query_id="query_1")
+    finally:
+        reset_auth_context(context_token)
+
+    runtime.explain_query.assert_awaited_once_with(
+        sql="SELECT * FROM orders",
+        catalog="internal",
+        database="analytics",
+        level="verbose",
+    )
+    assert result["status"] == "partial"
+    assert result["warnings"] == [
+        "The EXPLAIN output was truncated.",
+        "Profile text was truncated.",
+    ]
+    assert result["data"]["steps"]["explain"]["status"] == "partial"
+    assert result["data"]["steps"]["profile"]["status"] == "partial"
+    assert result["data"]["audit_record"]["sql"] == "SELECT [MASKED]"
+    manager.security_manager.apply_data_masking.assert_awaited_once()

--- a/test/utils/test_result_limits.py
+++ b/test/utils/test_result_limits.py
@@ -170,19 +170,34 @@ async def test_exec_query_uses_configured_default_rows_when_argument_is_omitted(
     connection_manager = Mock()
     connection_manager.config = _config(default_rows=17)
     manager = DorisToolsManager(connection_manager)
-    manager.metadata_extractor.exec_query_for_mcp = AsyncMock()
-    manager.metadata_extractor.exec_query_for_mcp.return_value = {"success": True}
+    manager.query_runtime.execute_query = AsyncMock(
+        return_value={
+            "status": "success",
+            "data": {
+                "columns": [],
+                "rows": [],
+                "row_count": 0,
+                "truncated": False,
+            },
+            "warnings": [],
+            "metadata": {},
+        }
+    )
 
     result = await manager._exec_query_tool({"sql": "SELECT 1"})
 
-    assert result == {"success": True}
-    manager.metadata_extractor.exec_query_for_mcp.assert_called_once_with(
-        "SELECT 1",
-        None,
-        None,
-        17,
-        30,
-        max_bytes=None,
+    assert result["status"] == "success"
+    assert manager.query_runtime._resolve_limits(
+        max_rows=None,
+        timeout_ms=None,
+    ).max_rows == 17
+    manager.query_runtime.execute_query.assert_awaited_once_with(
+        sql="SELECT 1",
+        catalog=None,
+        database=None,
+        parameters=None,
+        max_rows=None,
+        timeout_ms=None,
     )
 
 


### PR DESCRIPTION
## Summary

- add the seven-child Query domain to hierarchical and flat exposure modes
- route MySQL and optional Arrow Flight SQL execution through one bounded, read-only runtime
- detect Query, Profile, Audit Log, and ADBC availability from the active Doris route
- add deterministic EXPLAIN, slow-query, and query-performance diagnosis with evidence and partial-state propagation
- enforce named parameter binding, session isolation, result limits, masking, timeout handling, and fail-closed optional providers

## Validation

- `uv run pytest -q -W error` — 1588 passed, 69 skipped
- total coverage 64.59%; protocol 90.34%, authentication 81.53%, core managers 85.47%
- `uv lock --check`
- `uv run ruff check .`
- `uv run mypy doris_mcp_server`
- `uv run bandit -q -c pyproject.toml -r doris_mcp_server doris_mcp_client generate_requirements.py`
- isolated Python 3.12 wheel build, install, CLI, import, and runtime-dependency smoke
- official MCP 2026-07-28 `server-stateless` conformance — 25/25 passed
- official MCP Python SDK against real Doris 4.0.5rc1
- MCP Inspector 2.0.0 against real Doris
- Codex Host progressive discovery and exact Query-child execution against real Doris

## Environment boundaries

- the active FE Profile HTTP route rejects the current SQL principal, so `get_query_profile` is exposed as unavailable with `PROFILE_API_PERMISSION_DENIED`
- Arrow Flight SQL ports are not configured in the acceptance environment, so both ADBC children are exposed as unavailable; ready-path behavior is covered by provider tests