### PR TITLE
feat: add Governance domain runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ under **Unreleased** until a new version is selected and published.
 - A read-only Search domain with four capability-gated children for
   target-index-validated text, vector, and hybrid retrieval, Doris-native
   tokenizer previews, search-index inspection, and evidence-based diagnosis.
+- A read-only Governance domain with eight capability-gated children for
+  column quality, table storage, lineage capability and tracing, access
+  patterns, audit events, user-defined functions, and authentication mappings.
+- An explicit queryable lineage-provider contract and canonical Doris lineage
+  event-store schema for companion-plugin deployments.
 - Real Doris process tests covering Streamable HTTP and stdio.
 
 ### Changed
@@ -93,6 +98,10 @@ under **Unreleased** until a new version is selected and published.
 - Separated production dependencies from test, lint, type-check, and build
   tooling across package metadata, generated requirements, Docker, and clean
   wheel verification.
+- Selected Governance lineage providers deterministically from observed Doris
+  versions and live plugin, store, and audit evidence: Doris 4.0.6 and later
+  can use native companion-plugin events, while audit inference remains the
+  primary path before 4.0.6 and an explicit degraded fallback afterward.
 
 ### Fixed
 
@@ -109,6 +118,12 @@ under **Unreleased** until a new version is selected and published.
   redaction.
 - Bound hybrid Search vector, text, and structured-filter parameters in exact
   SQL placeholder order.
+- Kept Governance sampling, audit windows, lineage traversals, identifiers,
+  and result collections bounded, and redacted raw SQL, client addresses,
+  authentication rules, secrets, and error messages from model-facing output.
+- Emitted lineage edges only from attributable native events or conservative
+  direct-column audit evidence, without placeholder sources or invented
+  numeric confidence scores.
 - Excluded explicitly dead Doris components from active version gating while
   preserving them in node inventory, and kept live runtime manifests within
   the 16 KiB domain budget.

--- a/doris_mcp_server/tools/capability_detector.py
+++ b/doris_mcp_server/tools/capability_detector.py
@@ -50,6 +50,18 @@ from .doris_version import (
     probe_doris_version,
 )
 
+_NATIVE_LINEAGE_MINIMUM = parse_doris_version_comment(
+    "Doris version doris-4.0.6"
+)
+_LINEAGE_STORE_REQUIRED_COLUMNS = frozenset(
+    {
+        "event_id",
+        "event_time",
+        "source_object",
+        "target_object",
+    }
+)
+
 
 class CapabilityProbeStatus(StrEnum):
     """Normalized result of one private runtime capability probe."""
@@ -288,6 +300,53 @@ _DOMAIN_PROBES: Mapping[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
             ("search_explain_readable",),
         ),
     ),
+    "doris_governance": (
+        (
+            (
+                "SELECT COLUMN_NAME, DATA_TYPE "
+                "FROM information_schema.columns LIMIT 1"
+            ),
+            ("column_statistics_and_safe_sampling_ready",),
+        ),
+        (
+            (
+                "SELECT TABLE_NAME, DATA_LENGTH "
+                "FROM information_schema.tables LIMIT 1"
+            ),
+            ("table_storage_metadata_readable",),
+        ),
+        (
+            (
+                "SELECT `time`, `query_id`, `stmt` "
+                "FROM internal.__internal_schema.audit_log LIMIT 1"
+            ),
+            (
+                "audit_log_readable",
+                "audit_history_readable",
+                "audit_lineage_provider_status_readable",
+                "enhanced_audit_fields_present",
+            ),
+        ),
+        (
+            "SHOW GLOBAL FULL FUNCTIONS",
+            (
+                "udf_metadata_readable",
+                "python_udf_metadata_readable",
+            ),
+        ),
+        (
+            "SHOW FRONTEND CONFIG LIKE 'ldap_authentication_enabled'",
+            ("ldap_mapping_status_readable",),
+        ),
+        (
+            "SELECT * FROM information_schema.role_mappings LIMIT 1",
+            ("oidc_and_role_mapping_status_readable",),
+        ),
+        (
+            "SHOW FRONTEND CONFIG LIKE 'activate_lineage_plugin'",
+            ("lineage_plugin_config_readable",),
+        ),
+    ),
 }
 
 
@@ -420,6 +479,17 @@ class DorisCapabilityDetector:
                     )
                     probes[match_probe.probe_id] = match_probe
                     probes.update(_combine_search_evidence_probes(probes))
+                elif domain_name == "doris_governance":
+                    plugin_probe = await self._probe_lineage_plugin_status(
+                        auth_context,
+                        base.version_vector,
+                    )
+                    probes[plugin_probe.probe_id] = plugin_probe
+                    store_probe = await self._probe_lineage_store(auth_context)
+                    probes[store_probe.probe_id] = store_probe
+                    probes.update(
+                        _combine_governance_evidence_probes(probes)
+                    )
                 completed_route = self.route_identity(auth_context)
                 if completed_route.fingerprint != base.route.fingerprint:
                     raise CapabilityRouteChangedError(
@@ -823,6 +893,185 @@ class DorisCapabilityDetector:
             status=status,
             reason_code=reason,
             evidence_sources=("doris_fe_http", "runtime_probe"),
+        )
+
+    async def _probe_lineage_plugin_status(
+        self,
+        auth_context: Any | None,
+        versions: DorisClusterVersionVector,
+    ) -> CapabilityProbeEvidence:
+        fe_versions = (versions.master_fe, *versions.follower_fes)
+        if not fe_versions or any(
+            not version.is_parsed for version in fe_versions
+        ):
+            return CapabilityProbeEvidence(
+                probe_id="all_fe_lineage_plugin_compatible",
+                status=CapabilityProbeStatus.UNKNOWN,
+                reason_code="LINEAGE_FE_VERSION_COVERAGE_INCOMPLETE",
+                evidence_sources=("show_frontends", "runtime_probe"),
+            )
+        if any(
+            not version.is_at_least(_NATIVE_LINEAGE_MINIMUM)
+            for version in fe_versions
+        ):
+            return CapabilityProbeEvidence(
+                probe_id="all_fe_lineage_plugin_compatible",
+                status=CapabilityProbeStatus.UNSUPPORTED,
+                reason_code="LINEAGE_SPI_VERSION_UNSUPPORTED",
+                evidence_sources=("show_frontends", "runtime_probe"),
+            )
+        session_id = (
+            "capability-governance:lineage-plugin:"
+            + (self.route_identity(auth_context).fingerprint[:12])
+        )
+        try:
+            async with (
+                self._connection_manager
+                .get_connection_context_for_auth_context(
+                    session_id,
+                    auth_context,
+                ) as connection
+            ):
+                rows, probe = await self._probe_rows(
+                    connection,
+                    "SHOW FRONTEND CONFIG LIKE 'activate_lineage_plugin'",
+                    "lineage_plugin_config_readable",
+                )
+        except Exception as exc:
+            status, reason = _classify_probe_error(exc)
+            return CapabilityProbeEvidence(
+                probe_id="all_fe_lineage_plugin_compatible",
+                status=status,
+                reason_code=reason,
+            )
+        if probe.status is not CapabilityProbeStatus.SUPPORTED:
+            return CapabilityProbeEvidence(
+                probe_id="all_fe_lineage_plugin_compatible",
+                status=probe.status,
+                reason_code=probe.reason_code,
+                evidence_sources=probe.evidence_sources,
+            )
+        active_names = tuple(
+            name.strip()
+            for row in rows
+            for name in str(_row_value(row, "Value") or "").split(",")
+            if name.strip()
+        )
+        if not active_names:
+            return CapabilityProbeEvidence(
+                probe_id="all_fe_lineage_plugin_compatible",
+                status=CapabilityProbeStatus.DEGRADED,
+                reason_code="LINEAGE_PLUGIN_NOT_EXPLICITLY_CONFIGURED",
+                evidence_sources=(
+                    "show_frontend_config",
+                    "runtime_probe",
+                ),
+            )
+        return CapabilityProbeEvidence(
+            probe_id="all_fe_lineage_plugin_compatible",
+            status=CapabilityProbeStatus.SUPPORTED,
+            reason_code="LINEAGE_SPI_AND_PLUGIN_CONFIG_OBSERVED",
+            evidence_sources=(
+                "show_frontends",
+                "show_frontend_config",
+                "runtime_probe",
+            ),
+        )
+
+    async def _probe_lineage_store(
+        self,
+        auth_context: Any | None,
+    ) -> CapabilityProbeEvidence:
+        configured_store = getattr(
+            getattr(
+                getattr(self._connection_manager, "config", None),
+                "governance",
+                None,
+            ),
+            "lineage_store_table",
+            None,
+        )
+        raw_table = (
+            configured_store.strip()
+            if isinstance(configured_store, str)
+            else ""
+        )
+        if not raw_table:
+            return CapabilityProbeEvidence(
+                probe_id="lineage_store_readable",
+                status=CapabilityProbeStatus.MISCONFIGURED,
+                reason_code="LINEAGE_STORE_NOT_CONFIGURED",
+                evidence_sources=("server_config",),
+            )
+        try:
+            parts = tuple(
+                validate_identifier(
+                    part.strip().strip("`"),
+                    "lineage store identifier",
+                )
+                for part in raw_table.split(".")
+            )
+            if len(parts) not in {2, 3}:
+                raise SQLSecurityError(
+                    "lineage store requires "
+                    "database.table or catalog.database.table"
+                )
+            table = ".".join(
+                quote_identifier(part, "lineage store identifier")
+                for part in parts
+            )
+        except SQLSecurityError:
+            return CapabilityProbeEvidence(
+                probe_id="lineage_store_readable",
+                status=CapabilityProbeStatus.MISCONFIGURED,
+                reason_code="LINEAGE_STORE_IDENTIFIER_INVALID",
+                evidence_sources=("server_config",),
+            )
+        session_id = (
+            "capability-governance:lineage-store:"
+            + (self.route_identity(auth_context).fingerprint[:12])
+        )
+        try:
+            async with (
+                self._connection_manager
+                .get_connection_context_for_auth_context(
+                    session_id,
+                    auth_context,
+                ) as connection
+            ):
+                # SQL sink audit: every configured lineage-store identifier was
+                # strictly validated and quoted above before _probe_rows sends
+                # this read-only DESC statement to connection.execute.
+                rows, probe = await self._probe_rows(
+                    connection,
+                    f"DESC {table}",  # nosec B608
+                    "lineage_store_readable",
+                )
+        except Exception as exc:
+            status, reason = _classify_probe_error(exc)
+            return CapabilityProbeEvidence(
+                probe_id="lineage_store_readable",
+                status=status,
+                reason_code=reason,
+            )
+        if probe.status is not CapabilityProbeStatus.SUPPORTED:
+            return probe
+        observed = {
+            str(_row_value(row, "Field") or "").casefold()
+            for row in rows
+        }
+        if not _LINEAGE_STORE_REQUIRED_COLUMNS <= observed:
+            return CapabilityProbeEvidence(
+                probe_id="lineage_store_readable",
+                status=CapabilityProbeStatus.MISCONFIGURED,
+                reason_code="LINEAGE_STORE_SCHEMA_INVALID",
+                evidence_sources=("lineage_store", "runtime_probe"),
+            )
+        return CapabilityProbeEvidence(
+            probe_id="lineage_store_readable",
+            status=CapabilityProbeStatus.SUPPORTED,
+            reason_code="LINEAGE_STORE_SCHEMA_READABLE",
+            evidence_sources=("lineage_store", "runtime_probe"),
         )
 
     async def _probe_adbc_services(
@@ -1592,6 +1841,68 @@ def _combine_search_evidence_probes(
         diagnosis.probe_id: diagnosis,
         plan.probe_id: plan,
     }
+
+
+def _combine_governance_evidence_probes(
+    probes: Mapping[str, CapabilityProbeEvidence],
+) -> dict[str, CapabilityProbeEvidence]:
+    storage = probes.get("table_storage_metadata_readable")
+    audit = probes.get("audit_log_readable")
+    udf = probes.get("udf_metadata_readable")
+    derived: dict[str, CapabilityProbeEvidence] = {}
+    if storage is not None:
+        for probe_id in (
+            "storage_v3_variant_properties_readable",
+            "storage_v3",
+            "variant_sparse",
+            "variant_doc",
+        ):
+            derived[probe_id] = CapabilityProbeEvidence(
+                probe_id=probe_id,
+                status=(
+                    CapabilityProbeStatus.DEGRADED
+                    if storage.status is CapabilityProbeStatus.SUPPORTED
+                    else storage.status
+                ),
+                reason_code=(
+                    "TARGET_STORAGE_FACETS_REQUIRE_CALL_TIME_VALIDATION"
+                    if storage.status is CapabilityProbeStatus.SUPPORTED
+                    else storage.reason_code
+                ),
+                evidence_sources=storage.evidence_sources,
+            )
+    if audit is not None:
+        for probe_id in (
+            "set_var_audit",
+            "enhanced_secret_masking",
+        ):
+            derived[probe_id] = CapabilityProbeEvidence(
+                probe_id=probe_id,
+                status=(
+                    CapabilityProbeStatus.DEGRADED
+                    if audit.status is CapabilityProbeStatus.SUPPORTED
+                    else audit.status
+                ),
+                reason_code=(
+                    "ENHANCED_AUDIT_FIELDS_REQUIRE_CALL_TIME_VALIDATION"
+                    if audit.status is CapabilityProbeStatus.SUPPORTED
+                    else audit.reason_code
+                ),
+                evidence_sources=audit.evidence_sources,
+            )
+    if udf is not None:
+        for probe_id in (
+            "python_udf",
+            "python_udaf",
+            "python_udtf",
+        ):
+            derived[probe_id] = CapabilityProbeEvidence(
+                probe_id=probe_id,
+                status=udf.status,
+                reason_code=udf.reason_code,
+                evidence_sources=udf.evidence_sources,
+            )
+    return derived
 
 
 def _combine_all_runtime_probes(

--- a/doris_mcp_server/tools/capability_registry.py
+++ b/doris_mcp_server/tools/capability_registry.py
@@ -114,6 +114,17 @@ class CapabilityProviderRegistry:
             configured = has_bound_consumer
             if provider_id == "adbc_provider":
                 configured = configured and configured_adbc
+            elif provider_id == "lineage_event_store":
+                configured_store = getattr(
+                    getattr(config, "governance", None),
+                    "lineage_store_table",
+                    None,
+                )
+                configured = (
+                    configured
+                    and isinstance(configured_store, str)
+                    and bool(configured_store.strip())
+                )
             providers[provider_id] = CapabilityProviderEvidence(
                 provider_id=provider_id,
                 status=(

--- a/doris_mcp_server/tools/domain_dispatcher.py
+++ b/doris_mcp_server/tools/domain_dispatcher.py
@@ -44,6 +44,7 @@ from ..schema_validation import (
 from ..state_handles import StateHandleCodec, StateHandleError
 from ..utils.catalog_metadata import CatalogMetadataFailure
 from ..utils.cluster_runtime import ClusterRuntimeFailure
+from ..utils.governance_runtime import GovernanceRuntimeFailure
 from ..utils.logger import get_audit_logger, get_logger
 from ..utils.pipeline_runtime import PipelineRuntimeFailure
 from ..utils.query_runtime import QueryRuntimeFailure
@@ -698,6 +699,30 @@ class DomainDispatcher:
                         "SEARCH_ANALYZER_NOT_FOUND",
                         "SEARCH_INDEX_NOT_FOUND",
                         "SEARCH_TABLE_NOT_FOUND",
+                    }
+                    else DomainErrorCode.CHILD_EXECUTION_FAILED
+                ),
+                str(exc),
+                child_tool=child.name,
+                manifest_version=manifest.manifest_version,
+                retryable=exc.retryable,
+                details={
+                    "rediscover": False,
+                    "reason_code": exc.reason_code,
+                    "status_code": exc.status_code,
+                },
+            )
+        except GovernanceRuntimeFailure as exc:
+            self._audit(feature_id, arguments, "error", started)
+            return self._error(
+                domain.name,
+                (
+                    DomainErrorCode.CHILD_ARGUMENTS_INVALID
+                    if exc.reason_code
+                    in {
+                        "GOVERNANCE_ARGUMENT_INVALID",
+                        "GOVERNANCE_COLUMN_NOT_FOUND",
+                        "GOVERNANCE_TABLE_NOT_FOUND",
                     }
                     else DomainErrorCode.CHILD_EXECUTION_FAILED
                 ),

--- a/doris_mcp_server/tools/governance_handlers.py
+++ b/doris_mcp_server/tools/governance_handlers.py
@@ -1,0 +1,143 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Formal Governance-domain handlers backed by one strict runtime."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, cast
+
+from ..utils.db import DorisConnectionManager
+from ..utils.governance_runtime import (
+    DorisGovernanceRuntime,
+    QueryableLineageProvider,
+)
+
+
+class _GovernanceHandlerOwner(Protocol):
+    """State supplied by ``DorisToolsManager`` to the mixin."""
+
+    governance_runtime: DorisGovernanceRuntime
+
+
+class GovernanceToolHandlersMixin:
+    """Route every Governance child through the evidence-bearing runtime."""
+
+    def _initialize_governance_handlers(
+        self: _GovernanceHandlerOwner,
+        connection_manager: DorisConnectionManager,
+        *,
+        lineage_provider: QueryableLineageProvider | None = None,
+    ) -> None:
+        self.governance_runtime = DorisGovernanceRuntime(
+            connection_manager,
+            lineage_provider=lineage_provider,
+        )
+
+    async def _formal_doris_governance_analyze_columns_tool(
+        self: _GovernanceHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.governance_runtime.analyze_columns(
+            database=cast(str, arguments.get("database")),
+            table=cast(str, arguments.get("table")),
+            columns=cast(list[str] | None, arguments.get("columns")),
+            sample_ratio=cast(float | None, arguments.get("sample_ratio")),
+        )
+
+    async def _formal_doris_governance_analyze_table_storage_tool(
+        self: _GovernanceHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.governance_runtime.analyze_table_storage(
+            database=cast(str, arguments.get("database")),
+            table=cast(str, arguments.get("table")),
+            include_partitions=bool(arguments.get("include_partitions", False)),
+            include_indexes=bool(arguments.get("include_indexes", False)),
+        )
+
+    async def _formal_doris_governance_get_lineage_capability_status_tool(
+        self: _GovernanceHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        del arguments
+        return await self.governance_runtime.get_lineage_capability_status()
+
+    async def _formal_doris_governance_trace_column_lineage_tool(
+        self: _GovernanceHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.governance_runtime.trace_column_lineage(
+            object_name=cast(str, arguments.get("object")),
+            column=cast(str | None, arguments.get("column")),
+            direction=cast(str | None, arguments.get("direction")),
+            depth=cast(int | None, arguments.get("depth")),
+            evidence_mode=cast(
+                str | None,
+                arguments.get("evidence_mode"),
+            ),
+        )
+
+    async def _formal_doris_governance_analyze_data_access_patterns_tool(
+        self: _GovernanceHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.governance_runtime.analyze_data_access_patterns(
+            database=cast(str | None, arguments.get("database")),
+            table=cast(str | None, arguments.get("table")),
+            window_days=cast(int | None, arguments.get("window_days")),
+            group_by=cast(str | None, arguments.get("group_by")),
+        )
+
+    async def _formal_doris_governance_get_recent_audit_logs_tool(
+        self: _GovernanceHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.governance_runtime.get_recent_audit_logs(
+            window_minutes=cast(
+                int | None,
+                arguments.get("window_minutes"),
+            ),
+            user=cast(str | None, arguments.get("user")),
+            operation=cast(str | None, arguments.get("operation")),
+            database=cast(str | None, arguments.get("database")),
+            table=cast(str | None, arguments.get("table")),
+            limit=cast(int | None, arguments.get("limit")),
+        )
+
+    async def _formal_doris_governance_list_udfs_tool(
+        self: _GovernanceHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.governance_runtime.list_udfs(
+            database=cast(str | None, arguments.get("database")),
+            language=cast(str | None, arguments.get("language")),
+            name_pattern=cast(str | None, arguments.get("name_pattern")),
+        )
+
+    async def _formal_doris_governance_get_auth_mapping_status_tool(
+        self: _GovernanceHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.governance_runtime.get_auth_mapping_status(
+            principal=cast(str | None, arguments.get("principal")),
+            provider=cast(str | None, arguments.get("provider")),
+            include_roles=bool(arguments.get("include_roles", False)),
+        )
+
+
+__all__ = ["GovernanceToolHandlersMixin"]

--- a/doris_mcp_server/tools/tools_manager.py
+++ b/doris_mcp_server/tools/tools_manager.py
@@ -63,6 +63,7 @@ from .domain_manifest import (
     DomainManifestService,
 )
 from .doris_feature_matrix import DORIS_FEATURE_MATRIX
+from .governance_handlers import GovernanceToolHandlersMixin
 from .pipeline_handlers import PipelineToolHandlersMixin
 from .query_handlers import QueryToolHandlersMixin
 from .search_handlers import SearchToolHandlersMixin
@@ -78,6 +79,7 @@ class DorisToolsManager(
     ClusterToolHandlersMixin,
     PipelineToolHandlersMixin,
     SearchToolHandlersMixin,
+    GovernanceToolHandlersMixin,
     DomainManifestManagerMixin,
 ):
     """Apache Doris Tools Manager"""
@@ -126,6 +128,7 @@ class DorisToolsManager(
             connection_manager,
             self.query_runtime,
         )
+        self._initialize_governance_handlers(connection_manager)
         self._capability_registry: CapabilityRegistry | None = None
         if domain_availability_provider is None:
             bound_handlers = BoundHandlerAvailabilityProvider(self)

--- a/doris_mcp_server/utils/config.py
+++ b/doris_mcp_server/utils/config.py
@@ -866,6 +866,17 @@ class CapabilityConfig:
 
 
 @dataclass
+class GovernanceConfig:
+    """Read-only Governance runtime limits and optional lineage store."""
+
+    max_sample_ratio: float = 0.25
+    max_audit_window_days: int = 30
+    max_lineage_edges: int = 500
+    lineage_store_table: str = ""
+    lineage_recent_event_minutes: int = 1440
+
+
+@dataclass
 class DorisConfig:
     """Doris MCP Server complete configuration"""
 
@@ -904,6 +915,7 @@ class DorisConfig:
     capability: CapabilityConfig = field(
         default_factory=CapabilityConfig
     )
+    governance: GovernanceConfig = field(default_factory=GovernanceConfig)
 
     # Custom configuration
     custom_config: dict[str, Any] = field(default_factory=dict)
@@ -1575,6 +1587,33 @@ class DorisConfig:
                 config.capability.stale_grace_seconds,
             )
             _mark_source(config, "capability_stale_grace_seconds", "env")
+        if "GOVERNANCE_MAX_SAMPLE_RATIO" in os.environ:
+            config.governance.max_sample_ratio = float(
+                os.getenv(
+                    "GOVERNANCE_MAX_SAMPLE_RATIO",
+                    str(config.governance.max_sample_ratio),
+                )
+            )
+        if "GOVERNANCE_MAX_AUDIT_WINDOW_DAYS" in os.environ:
+            config.governance.max_audit_window_days = _env_int(
+                "GOVERNANCE_MAX_AUDIT_WINDOW_DAYS",
+                config.governance.max_audit_window_days,
+            )
+        if "GOVERNANCE_MAX_LINEAGE_EDGES" in os.environ:
+            config.governance.max_lineage_edges = _env_int(
+                "GOVERNANCE_MAX_LINEAGE_EDGES",
+                config.governance.max_lineage_edges,
+            )
+        if "GOVERNANCE_LINEAGE_STORE_TABLE" in os.environ:
+            config.governance.lineage_store_table = os.getenv(
+                "GOVERNANCE_LINEAGE_STORE_TABLE",
+                "",
+            ).strip()
+        if "GOVERNANCE_LINEAGE_RECENT_EVENT_MINUTES" in os.environ:
+            config.governance.lineage_recent_event_minutes = _env_int(
+                "GOVERNANCE_LINEAGE_RECENT_EVENT_MINUTES",
+                config.governance.lineage_recent_event_minutes,
+            )
         if "MCP_STATE_HANDLE_SECRET" in os.environ:
             config.mcp_state_handle_secret = os.getenv(
                 "MCP_STATE_HANDLE_SECRET",
@@ -1687,6 +1726,12 @@ class DorisConfig:
                 if hasattr(config.capability, key):
                     setattr(config.capability, key, value)
 
+        if "governance" in config_data:
+            governance_config = config_data["governance"]
+            for key, value in governance_config.items():
+                if hasattr(config.governance, key):
+                    setattr(config.governance, key, value)
+
         # Custom configuration
         config.custom_config = config_data.get("custom", {})
 
@@ -1718,6 +1763,17 @@ class DorisConfig:
                 ),
                 "stale_grace_seconds": (
                     self.capability.stale_grace_seconds
+                ),
+            },
+            "governance": {
+                "max_sample_ratio": self.governance.max_sample_ratio,
+                "max_audit_window_days": (
+                    self.governance.max_audit_window_days
+                ),
+                "max_lineage_edges": self.governance.max_lineage_edges,
+                "lineage_store_table": self.governance.lineage_store_table,
+                "lineage_recent_event_minutes": (
+                    self.governance.lineage_recent_event_minutes
                 ),
             },
             "database": {
@@ -1960,6 +2016,23 @@ class DorisConfig:
         if not 0 <= self.capability.stale_grace_seconds <= 86400:
             errors.append(
                 "Capability stale grace must be in the range 0-86400 seconds"
+            )
+        if not 0 < self.governance.max_sample_ratio <= 1:
+            errors.append(
+                "Governance maximum sample ratio must be in the range (0, 1]"
+            )
+        if not 1 <= self.governance.max_audit_window_days <= 365:
+            errors.append(
+                "Governance audit window must be in the range 1-365 days"
+            )
+        if not 1 <= self.governance.max_lineage_edges <= 5000:
+            errors.append(
+                "Governance lineage edge limit must be in the range 1-5000"
+            )
+        if not 1 <= self.governance.lineage_recent_event_minutes <= 525600:
+            errors.append(
+                "Governance recent lineage event window must be in the range "
+                "1-525600 minutes"
             )
 
         raw_tool_providers: Any = self.mcp_tool_providers

--- a/doris_mcp_server/utils/governance_runtime.py
+++ b/doris_mcp_server/utils/governance_runtime.py
@@ -1,0 +1,2730 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Strict, evidence-bearing runtime for the read-only Governance domain."""
+
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import json
+import re
+import uuid
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Protocol
+from urllib.parse import urlsplit
+
+import sqlparse
+
+from ..tools.doris_version import DorisVersion, parse_doris_version_comment
+from .db import DorisConnectionManager
+from .redaction import redact_sensitive_data
+from .security import get_current_auth_context
+from .sql_security_utils import (
+    SQLSecurityError,
+    build_table_reference,
+    quote_identifier,
+    validate_identifier,
+)
+
+_MAX_BYTES = 2 * 1024 * 1024
+_MAX_COLUMNS = 32
+_MAX_AUDIT_ROWS = 1_000
+_MAX_AUDIT_RESULTS = 200
+_MAX_UDFS = 500
+_MAX_PARTITIONS = 1_000
+_MAX_INDEXES = 512
+_MAX_LINEAGE_DEPTH = 5
+_NATIVE_LINEAGE_MINIMUM = parse_doris_version_comment("Doris version doris-4.0.6")
+_AUDIT_TABLE = "internal.__internal_schema.audit_log"
+_SIMPLE_IDENTIFIER = r"(?:`[^`]+`|[A-Za-z_][A-Za-z0-9_$]*)"
+_QUALIFIED_IDENTIFIER = (
+    rf"{_SIMPLE_IDENTIFIER}"
+    rf"(?:\s*\.\s*{_SIMPLE_IDENTIFIER}){{0,2}}"
+)
+_WRITE_TARGET = re.compile(
+    rf"\b(?:INSERT\s+INTO|INSERT\s+OVERWRITE\s+TABLE|CREATE\s+TABLE)"
+    rf"\s+({_QUALIFIED_IDENTIFIER})",
+    re.IGNORECASE,
+)
+_SOURCE_REFERENCE = re.compile(
+    rf"\b(?:FROM|JOIN)\s+({_QUALIFIED_IDENTIFIER})",
+    re.IGNORECASE,
+)
+_SIMPLE_INSERT_SELECT = re.compile(
+    rf"""
+    \bINSERT\s+(?:INTO|OVERWRITE\s+TABLE)\s+
+    (?P<target>{_QUALIFIED_IDENTIFIER})
+    \s*\((?P<target_columns>[^()]+)\)\s*
+    SELECT\s+(?P<select_list>.+?)\s+
+    FROM\s+(?P<source>{_QUALIFIED_IDENTIFIER})
+    (?P<tail>.*)
+    """,
+    re.IGNORECASE | re.DOTALL | re.VERBOSE,
+)
+_SAFE_CREATE_PROPERTY_KEYS = frozenset(
+    {
+        "compression",
+        "enable_light_schema_change",
+        "enable_unique_key_merge_on_write",
+        "replication_allocation",
+        "replication_num",
+        "storage_format",
+        "variant_enable_typed_paths_to_sparse",
+        "variant_flatten_nested",
+        "variant_max_sparse_column_statistics_size",
+        "variant_sparse_hash_shard_count",
+    }
+)
+_COMPLEX_TYPE_MARKERS = (
+    "ARRAY",
+    "MAP",
+    "STRUCT",
+    "JSON",
+    "VARIANT",
+    "HLL",
+    "BITMAP",
+    "QUANTILE_STATE",
+    "AGG_STATE",
+)
+_AUDIT_FIELD_ORDER = (
+    "query_id",
+    "stmt_id",
+    "time",
+    "user",
+    "catalog",
+    "db",
+    "state",
+    "error_code",
+    "query_time",
+    "scan_bytes",
+    "scan_rows",
+    "return_rows",
+    "stmt_type",
+    "is_query",
+    "queried_tables_and_views",
+    "chosen_m_views",
+    "stmt",
+)
+_LINEAGE_STORE_REQUIRED_COLUMNS = frozenset(
+    {
+        "event_id",
+        "event_time",
+        "source_object",
+        "target_object",
+    }
+)
+_LINEAGE_STORE_OPTIONAL_COLUMNS = (
+    "query_id",
+    "source_column",
+    "target_column",
+    "dependency_type",
+    "statement_type",
+)
+
+
+class GovernanceRuntimeFailure(RuntimeError):
+    """Sanitized Governance-domain failure with a stable reason code."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        status_code: int,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+        self.status_code = status_code
+        self.retryable = retryable
+
+
+@dataclass(frozen=True, slots=True)
+class LineageProviderStatus:
+    """Queryable lineage-provider health without implementation secrets."""
+
+    provider_id: str
+    status: str
+    queryable: bool
+    observed_columns: tuple[str, ...] = ()
+    row_count: int | None = None
+    latest_event_time: Any | None = None
+    recent_event_observed: bool = False
+    limitations: tuple[str, ...] = ()
+
+
+class QueryableLineageProvider(Protocol):
+    """Provider boundary for Doris native or external lineage stores."""
+
+    async def status(self) -> LineageProviderStatus:
+        """Return current queryability and freshness evidence."""
+
+    async def trace(
+        self,
+        *,
+        object_name: str,
+        column: str | None,
+        direction: str,
+        depth: int,
+        max_edges: int,
+    ) -> dict[str, Any]:
+        """Return bounded lineage edges preserving native evidence IDs."""
+
+
+class DorisLineageStoreProvider:
+    """Read the canonical MCP lineage-event table populated by a plugin sink."""
+
+    def __init__(
+        self,
+        connection_manager: DorisConnectionManager,
+        *,
+        table: str,
+        recent_event_minutes: int,
+    ) -> None:
+        self._connection_manager = connection_manager
+        self._table_parts = _qualified_parts(
+            table,
+            field="lineage store table",
+            minimum_parts=2,
+        )
+        self._table = _table_reference(self._table_parts)
+        self._recent_event_minutes = recent_event_minutes
+        self._session_prefix = f"lineage_store_{uuid.uuid4().hex[:8]}"
+
+    async def status(self) -> LineageProviderStatus:
+        try:
+            # SQL sink audit: the constructor strictly validates and quotes the
+            # configured table before _execute sends this read-only statement.
+            rows = await self._execute(
+                f"DESC {self._table}",  # nosec B608
+                max_rows=128,
+            )
+        except GovernanceRuntimeFailure as exc:
+            return LineageProviderStatus(
+                provider_id="doris_native_event_store",
+                status="unavailable",
+                queryable=False,
+                limitations=(
+                    f"The configured lineage store is unreadable ({exc.reason_code}).",
+                ),
+            )
+
+        columns = tuple(
+            dict.fromkeys(
+                str(_value(row, "field", "column_name", "name")).casefold()
+                for row in rows
+                if _value(row, "field", "column_name", "name") is not None
+            )
+        )
+        missing = sorted(_LINEAGE_STORE_REQUIRED_COLUMNS - set(columns))
+        if missing:
+            return LineageProviderStatus(
+                provider_id="doris_native_event_store",
+                status="misconfigured",
+                queryable=False,
+                observed_columns=columns,
+                limitations=(
+                    "The lineage store is missing required canonical columns: "
+                    + ", ".join(missing),
+                ),
+            )
+
+        summary_sql = (
+            "SELECT COUNT(*) AS row_count, "
+            "MAX(`event_time`) AS latest_event_time, "
+            "SUM(CASE WHEN `event_time` >= "
+            "DATE_SUB(NOW(), INTERVAL %s MINUTE) THEN 1 ELSE 0 END) "
+            # SQL sink audit: the table is validated and quoted at construction;
+            # _execute binds the only value parameter before reaching the sink.
+            f"AS recent_event_count FROM {self._table}"  # nosec B608
+        )
+        try:
+            summary = await self._execute(
+                summary_sql,
+                params=(self._recent_event_minutes,),
+                max_rows=1,
+            )
+        except GovernanceRuntimeFailure as exc:
+            return LineageProviderStatus(
+                provider_id="doris_native_event_store",
+                status="degraded",
+                queryable=True,
+                observed_columns=columns,
+                limitations=(
+                    f"Lineage freshness evidence is unavailable ({exc.reason_code}).",
+                ),
+            )
+        row = summary[0] if summary else {}
+        row_count = _optional_int(_value(row, "row_count"))
+        recent_count = _optional_int(_value(row, "recent_event_count")) or 0
+        latest = _json_value(_value(row, "latest_event_time"))
+        limitations: tuple[str, ...] = ()
+        status = "available"
+        if not row_count or recent_count <= 0:
+            status = "degraded"
+            limitations = (
+                "The store is queryable but no recent lineage event was observed.",
+            )
+        return LineageProviderStatus(
+            provider_id="doris_native_event_store",
+            status=status,
+            queryable=True,
+            observed_columns=columns,
+            row_count=row_count,
+            latest_event_time=latest,
+            recent_event_observed=recent_count > 0,
+            limitations=limitations,
+        )
+
+    async def trace(
+        self,
+        *,
+        object_name: str,
+        column: str | None,
+        direction: str,
+        depth: int,
+        max_edges: int,
+    ) -> dict[str, Any]:
+        provider_status = await self.status()
+        if not provider_status.queryable:
+            raise GovernanceRuntimeFailure(
+                "The configured lineage event store is unavailable.",
+                reason_code="GOVERNANCE_LINEAGE_STORE_UNAVAILABLE",
+                status_code=503,
+                retryable=True,
+            )
+        selected = (
+            "event_id",
+            "event_time",
+            "source_object",
+            "target_object",
+            *tuple(
+                name
+                for name in _LINEAGE_STORE_OPTIONAL_COLUMNS
+                if name in provider_status.observed_columns
+            ),
+        )
+        select_list = ", ".join(quote_identifier(name) for name in selected)
+        frontier = {object_name}
+        visited = {object_name}
+        edges: list[dict[str, Any]] = []
+        edge_keys: set[tuple[Any, ...]] = set()
+        source_rows = 0
+
+        for level in range(1, depth + 1):
+            if not frontier or len(edges) >= max_edges:
+                break
+            placeholders = ", ".join("%s" for _ in frontier)
+            predicates: list[str] = []
+            params: list[Any] = []
+            ordered_frontier = sorted(frontier)
+            if direction in {"upstream", "both"}:
+                predicates.append(f"`target_object` IN ({placeholders})")
+                params.extend(ordered_frontier)
+            if direction in {"downstream", "both"}:
+                predicates.append(f"`source_object` IN ({placeholders})")
+                params.extend(ordered_frontier)
+            if column is not None:
+                column_predicates: list[str] = []
+                if "source_column" in selected:
+                    column_predicates.append("`source_column` = %s")
+                    params.append(column)
+                if "target_column" in selected:
+                    column_predicates.append("`target_column` = %s")
+                    params.append(column)
+                if not column_predicates:
+                    return {
+                        "edges": [],
+                        "truncated": False,
+                        "rows_observed": 0,
+                        "provider_status": provider_status,
+                        "limitations": [
+                            "The lineage store has no column-level fields."
+                        ],
+                    }
+                predicates = [
+                    f"({' OR '.join(predicates)}) "
+                    f"AND ({' OR '.join(column_predicates)})"
+                ]
+
+            remaining = max_edges - len(edges)
+            # SQL sink audit: table and selected fields are canonical quoted
+            # identifiers, predicates use placeholders, and _execute receives
+            # a bounded server-generated integer limit.
+            sql = (
+                f"SELECT {select_list} FROM {self._table} "  # nosec B608
+                f"WHERE {' OR '.join(predicates)} "
+                "ORDER BY `event_time` DESC LIMIT "
+                f"{remaining}"
+            )
+            rows = await self._execute(
+                sql,
+                params=tuple(params),
+                max_rows=remaining,
+            )
+            source_rows += len(rows)
+            next_frontier: set[str] = set()
+            for row in rows:
+                edge = _native_lineage_edge(row, level=level)
+                if edge is None:
+                    continue
+                key = (
+                    edge["source_object"],
+                    edge.get("source_column"),
+                    edge["target_object"],
+                    edge.get("target_column"),
+                    edge["source_event_id"],
+                )
+                if key in edge_keys:
+                    continue
+                edge_keys.add(key)
+                edges.append(edge)
+                if direction in {"upstream", "both"} and (
+                    edge["target_object"] in frontier
+                ):
+                    next_frontier.add(edge["source_object"])
+                if direction in {"downstream", "both"} and (
+                    edge["source_object"] in frontier
+                ):
+                    next_frontier.add(edge["target_object"])
+                if len(edges) >= max_edges:
+                    break
+            frontier = next_frontier - visited
+            visited.update(frontier)
+
+        return {
+            "edges": edges,
+            "truncated": len(edges) >= max_edges,
+            "rows_observed": source_rows,
+            "provider_status": provider_status,
+            "limitations": list(provider_status.limitations),
+        }
+
+    async def _execute(
+        self,
+        sql: str,
+        *,
+        params: Mapping[str, Any] | tuple[Any, ...] | None = None,
+        max_rows: int,
+    ) -> list[dict[str, Any]]:
+        auth_context = get_current_auth_context()
+        session_id = f"{self._session_prefix}:{uuid.uuid4().hex[:8]}"
+        try:
+            async with self._connection_manager.get_connection_context_for_auth_context(
+                session_id,
+                auth_context,
+            ) as connection:
+                result = await connection.execute(
+                    sql,
+                    params=params,
+                    auth_context=auth_context,
+                    mask_result=False,
+                    max_rows=max_rows,
+                    max_bytes=_MAX_BYTES,
+                )
+        except Exception as exc:
+            raise _classify_failure(exc) from exc
+        return [dict(row) for row in (result.data or ()) if isinstance(row, Mapping)][
+            :max_rows
+        ]
+
+
+class DorisGovernanceRuntime:
+    """Read bounded governance evidence without creating metadata or edges."""
+
+    def __init__(
+        self,
+        connection_manager: DorisConnectionManager,
+        *,
+        lineage_provider: QueryableLineageProvider | None = None,
+    ) -> None:
+        self._connection_manager = connection_manager
+        self._session_prefix = f"formal_governance_{uuid.uuid4().hex[:8]}"
+        config = getattr(connection_manager, "config", None)
+        governance = getattr(config, "governance", None)
+        sample_ratio = getattr(governance, "max_sample_ratio", None)
+        self._max_sample_ratio = (
+            float(sample_ratio)
+            if isinstance(sample_ratio, int | float)
+            and not isinstance(sample_ratio, bool)
+            else 0.25
+        )
+        audit_window_days = getattr(governance, "max_audit_window_days", None)
+        self._max_audit_window_days = (
+            audit_window_days
+            if isinstance(audit_window_days, int)
+            and not isinstance(audit_window_days, bool)
+            else 30
+        )
+        max_lineage_edges = getattr(governance, "max_lineage_edges", None)
+        self._max_lineage_edges = (
+            max_lineage_edges
+            if isinstance(max_lineage_edges, int)
+            and not isinstance(max_lineage_edges, bool)
+            else 500
+        )
+        configured_store = getattr(governance, "lineage_store_table", None)
+        lineage_store_table = (
+            configured_store.strip() if isinstance(configured_store, str) else ""
+        )
+        configured_recent_minutes = getattr(
+            governance,
+            "lineage_recent_event_minutes",
+            None,
+        )
+        recent_event_minutes = (
+            configured_recent_minutes
+            if isinstance(configured_recent_minutes, int)
+            and not isinstance(configured_recent_minutes, bool)
+            else 1440
+        )
+        self._lineage_provider = lineage_provider
+        if self._lineage_provider is None and lineage_store_table:
+            self._lineage_provider = DorisLineageStoreProvider(
+                connection_manager,
+                table=lineage_store_table,
+                recent_event_minutes=recent_event_minutes,
+            )
+
+    async def analyze_columns(
+        self,
+        *,
+        database: str,
+        table: str,
+        columns: Sequence[str] | None,
+        sample_ratio: float | None,
+    ) -> dict[str, Any]:
+        database_name = _identifier(database, "database name")
+        table_name = _identifier(table, "table name")
+        table_ref = build_table_reference(
+            table_name,
+            database_name,
+            "internal",
+        )
+        column_rows = await self._execute(
+            (
+                "SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, "
+                "COLUMN_COMMENT, ORDINAL_POSITION "
+                "FROM information_schema.columns "
+                "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
+                "ORDER BY ORDINAL_POSITION LIMIT 512"
+            ),
+            params=(database_name, table_name),
+            max_rows=512,
+        )
+        available = {
+            str(_value(row, "column_name")): row
+            for row in column_rows
+            if _value(row, "column_name") is not None
+        }
+        if not available:
+            raise GovernanceRuntimeFailure(
+                "The requested Doris table is unavailable.",
+                reason_code="GOVERNANCE_TABLE_NOT_FOUND",
+                status_code=404,
+            )
+
+        warnings: list[str] = []
+        if columns:
+            selected = tuple(
+                dict.fromkeys(_identifier(item, "column name") for item in columns)
+            )
+            missing = [name for name in selected if name not in available]
+            if missing:
+                raise GovernanceRuntimeFailure(
+                    "One or more requested columns are unavailable.",
+                    reason_code="GOVERNANCE_COLUMN_NOT_FOUND",
+                    status_code=404,
+                )
+        else:
+            selected = tuple(available)
+        if len(selected) > _MAX_COLUMNS:
+            selected = selected[:_MAX_COLUMNS]
+            warnings.append(
+                f"Column analysis was limited to the first {_MAX_COLUMNS} columns."
+            )
+
+        stats_rows: list[dict[str, Any]] = []
+        stats_failure: GovernanceRuntimeFailure | None = None
+        try:
+            # SQL sink audit: table_ref contains only strictly validated and
+            # quoted identifiers before _execute sends this read-only command.
+            stats_rows = await self._execute(
+                f"SHOW COLUMN STATS {table_ref}",  # nosec B608
+                max_rows=512,
+            )
+        except GovernanceRuntimeFailure as exc:
+            stats_failure = exc
+            warnings.append(
+                f"Recorded Doris column statistics are unavailable ({exc.reason_code})."
+            )
+        stats = {
+            str(_value(row, "column_name")): row
+            for row in stats_rows
+            if _value(row, "column_name") is not None
+        }
+
+        applied_ratio = _sample_ratio(
+            sample_ratio,
+            maximum=self._max_sample_ratio,
+        )
+        if sample_ratio is not None and applied_ratio < float(sample_ratio):
+            warnings.append(
+                "Requested sample ratio exceeded the configured Governance "
+                f"ceiling and was reduced to {applied_ratio:g}."
+            )
+        sample: Mapping[str, Any] = {}
+        sample_columns = tuple(
+            name
+            for name in selected
+            if not _is_complex_type(str(_value(available[name], "data_type") or ""))
+        )
+        sample_failure: GovernanceRuntimeFailure | None = None
+        if applied_ratio > 0 and sample_columns:
+            percentage = max(1, min(100, round(applied_ratio * 100)))
+            projections = ["COUNT(*) AS `sample_rows`"]
+            for index, name in enumerate(sample_columns):
+                column_ref = quote_identifier(name, "column name")
+                projections.extend(
+                    (
+                        f"COUNT({column_ref}) AS `c{index}_non_null`",
+                        f"NDV({column_ref}) AS `c{index}_ndv`",
+                    )
+                )
+            # SQL sink audit: table and column identifiers are validated and
+            # quoted; the sample percentage is a bounded server-generated int
+            # before _execute receives the read-only statement.
+            sample_sql = (
+                f"SELECT {', '.join(projections)} FROM {table_ref} "  # nosec B608
+                f"TABLESAMPLE {percentage} PERCENT REPEATABLE 1"
+            )
+            try:
+                sample_rows = await self._execute(
+                    sample_sql,
+                    max_rows=1,
+                )
+                sample = sample_rows[0] if sample_rows else {}
+            except GovernanceRuntimeFailure as exc:
+                sample_failure = exc
+                warnings.append(
+                    f"Bounded live sampling is unavailable ({exc.reason_code})."
+                )
+        elif applied_ratio > 0:
+            warnings.append(
+                "Live sampling was skipped because all selected columns use "
+                "complex or aggregate-state types."
+            )
+
+        sample_row_count = _optional_int(_value(sample, "sample_rows"))
+        items: list[dict[str, Any]] = []
+        for name in selected:
+            metadata = available[name]
+            statistic = stats.get(name, {})
+            count = _optional_float(_value(statistic, "count"))
+            null_count = _optional_float(_value(statistic, "num_null", "null_count"))
+            sample_index = (
+                sample_columns.index(name) if name in sample_columns else None
+            )
+            sampled_non_null = (
+                _optional_int(_value(sample, f"c{sample_index}_non_null"))
+                if sample_index is not None
+                else None
+            )
+            sampled_ndv = (
+                _optional_int(_value(sample, f"c{sample_index}_ndv"))
+                if sample_index is not None
+                else None
+            )
+            risks: list[str] = []
+            data_type = str(_value(metadata, "data_type") or "")
+            nullable = str(_value(metadata, "is_nullable") or "").upper() == "YES"
+            if nullable:
+                risks.append("nullable")
+            if _is_complex_type(data_type):
+                risks.append("complex_type_statistics_limited")
+            if not statistic:
+                risks.append("recorded_statistics_missing")
+            item = {
+                "name": name,
+                "data_type": data_type,
+                "nullable": nullable,
+                "ordinal_position": _optional_int(_value(metadata, "ordinal_position")),
+                "statistics": {
+                    "row_count": count,
+                    "distinct_count": _optional_float(_value(statistic, "ndv")),
+                    "null_count": null_count,
+                    "null_ratio": (
+                        round(null_count / count, 6)
+                        if count and null_count is not None
+                        else None
+                    ),
+                    "data_size_bytes": _optional_float(_value(statistic, "data_size")),
+                    "collection_method": _value(statistic, "method"),
+                    "updated_at": _json_value(
+                        _value(statistic, "updated_time", "update_time")
+                    ),
+                    "min_observed": _value(statistic, "min") is not None,
+                    "max_observed": _value(statistic, "max") is not None,
+                },
+                "sample": {
+                    "sample_rows": sample_row_count,
+                    "non_null_count": sampled_non_null,
+                    "distinct_count": sampled_ndv,
+                    "null_ratio": (
+                        round(
+                            (sample_row_count - sampled_non_null) / sample_row_count,
+                            6,
+                        )
+                        if sample_row_count and sampled_non_null is not None
+                        else None
+                    ),
+                },
+                "risks": risks,
+            }
+            items.append(item)
+
+        evidence = [
+            {
+                "source": "information_schema.columns",
+                "success": True,
+                "rows_observed": len(column_rows),
+            },
+            {
+                "source": "SHOW COLUMN STATS",
+                "success": stats_failure is None,
+                "rows_observed": len(stats_rows),
+                "reason_code": (
+                    None if stats_failure is None else stats_failure.reason_code
+                ),
+            },
+        ]
+        if applied_ratio > 0:
+            evidence.append(
+                {
+                    "source": "TABLESAMPLE",
+                    "success": sample_failure is None and bool(sample_columns),
+                    "sample_ratio": applied_ratio,
+                    "sample_rows": sample_row_count,
+                    "reason_code": (
+                        None if sample_failure is None else sample_failure.reason_code
+                    ),
+                }
+            )
+        return _result(
+            {
+                "database": database_name,
+                "table": table_name,
+                "columns": items,
+                "sample_ratio_requested": sample_ratio,
+                "sample_ratio_applied": applied_ratio,
+                "truncated": len(available) > len(selected),
+            },
+            source="doris_column_metadata_and_statistics",
+            warnings=warnings,
+            evidence=evidence,
+            metadata={"invented_statistics": False},
+        )
+
+    async def analyze_table_storage(
+        self,
+        *,
+        database: str,
+        table: str,
+        include_partitions: bool,
+        include_indexes: bool,
+    ) -> dict[str, Any]:
+        database_name = _identifier(database, "database name")
+        table_name = _identifier(table, "table name")
+        table_ref = build_table_reference(
+            table_name,
+            database_name,
+            "internal",
+        )
+        table_rows = await self._execute(
+            (
+                "SELECT TABLE_CATALOG, TABLE_SCHEMA, TABLE_NAME, TABLE_TYPE, "
+                "ENGINE, TABLE_ROWS, AVG_ROW_LENGTH, DATA_LENGTH, INDEX_LENGTH, "
+                "DATA_FREE, CREATE_TIME, UPDATE_TIME "
+                "FROM information_schema.tables "
+                "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s LIMIT 2"
+            ),
+            params=(database_name, table_name),
+            max_rows=2,
+        )
+        if not table_rows:
+            raise GovernanceRuntimeFailure(
+                "The requested Doris table is unavailable.",
+                reason_code="GOVERNANCE_TABLE_NOT_FOUND",
+                status_code=404,
+            )
+        table_row = table_rows[0]
+        warnings: list[str] = []
+        evidence: list[dict[str, Any]] = [
+            {
+                "source": "information_schema.tables",
+                "success": True,
+                "rows_observed": len(table_rows),
+            }
+        ]
+
+        # SQL sink audit: table_ref contains only strictly validated and quoted
+        # identifiers before _optional_execute sends this read-only command.
+        table_stats, stats_failure = await self._optional_execute(
+            f"SHOW TABLE STATS {table_ref}",  # nosec B608
+            max_rows=2,
+        )
+        _append_optional_evidence(
+            evidence,
+            warnings,
+            source="SHOW TABLE STATS",
+            rows=table_stats,
+            failure=stats_failure,
+        )
+        # SQL sink audit: table_ref contains only strictly validated and quoted
+        # identifiers before _optional_execute sends this read-only command.
+        create_rows, create_failure = await self._optional_execute(
+            f"SHOW CREATE TABLE {table_ref}",  # nosec B608
+            max_rows=1,
+        )
+        _append_optional_evidence(
+            evidence,
+            warnings,
+            source="SHOW CREATE TABLE",
+            rows=create_rows,
+            failure=create_failure,
+        )
+        create_sql = (
+            str(_value(create_rows[0], "create table", "create_table") or "")
+            if create_rows
+            else ""
+        )
+
+        partition_items: list[dict[str, Any]] = []
+        partitions_truncated = False
+        if include_partitions:
+            # SQL sink audit: table_ref is validated and quoted, and the limit
+            # is a module constant before _optional_execute reaches the sink.
+            partition_rows, partition_failure = await self._optional_execute(
+                f"SHOW PARTITIONS FROM {table_ref} LIMIT {_MAX_PARTITIONS}",  # nosec B608
+                max_rows=_MAX_PARTITIONS,
+            )
+            _append_optional_evidence(
+                evidence,
+                warnings,
+                source="SHOW PARTITIONS",
+                rows=partition_rows,
+                failure=partition_failure,
+            )
+            partition_items = [_storage_partition(row) for row in partition_rows]
+            partitions_truncated = len(partition_rows) >= _MAX_PARTITIONS
+
+        index_items: list[dict[str, Any]] = []
+        indexes_truncated = False
+        if include_indexes:
+            # SQL sink audit: table_ref contains only strictly validated and
+            # quoted identifiers before _optional_execute reaches the sink.
+            index_rows, index_failure = await self._optional_execute(
+                f"SHOW INDEX FROM {table_ref}",  # nosec B608
+                max_rows=_MAX_INDEXES,
+            )
+            _append_optional_evidence(
+                evidence,
+                warnings,
+                source="SHOW INDEX",
+                rows=index_rows,
+                failure=index_failure,
+            )
+            index_items = [_storage_index(row) for row in index_rows]
+            indexes_truncated = len(index_rows) >= _MAX_INDEXES
+
+        stats_row = table_stats[0] if table_stats else {}
+        properties = _safe_create_properties(create_sql)
+        data = {
+            "database": database_name,
+            "table": table_name,
+            "table_type": _value(table_row, "table_type"),
+            "engine": _value(table_row, "engine"),
+            "estimated_rows": _optional_int(_value(table_row, "table_rows")),
+            "average_row_length": _optional_int(_value(table_row, "avg_row_length")),
+            "data_length_bytes": _optional_int(_value(table_row, "data_length")),
+            "index_length_bytes": _optional_int(_value(table_row, "index_length")),
+            "data_free_bytes": _optional_int(_value(table_row, "data_free")),
+            "created_at": _json_value(_value(table_row, "create_time")),
+            "updated_at": _json_value(_value(table_row, "update_time")),
+            "statistics": {
+                "row_count": _optional_int(_value(stats_row, "row_count")),
+                "updated_rows": _optional_int(_value(stats_row, "updated_rows")),
+                "query_times": _optional_int(_value(stats_row, "query_times")),
+                "last_analyze_time": _json_value(
+                    _value(stats_row, "last_analyze_time")
+                ),
+                "auto_analyze_enabled": _value(
+                    stats_row,
+                    "enable_auto_analyze",
+                ),
+            },
+            "properties": properties,
+            "features": {
+                "storage_format": properties.get("storage_format"),
+                "compression": properties.get("compression"),
+                "merge_on_write": properties.get("enable_unique_key_merge_on_write"),
+                "variant": {
+                    key: value
+                    for key, value in properties.items()
+                    if key.startswith("variant_")
+                },
+            },
+            "partitions": partition_items if include_partitions else None,
+            "indexes": index_items if include_indexes else None,
+            "truncated": partitions_truncated or indexes_truncated,
+        }
+        return _result(
+            data,
+            source="doris_storage_metadata",
+            warnings=warnings,
+            evidence=evidence,
+            metadata={
+                "raw_create_table_exposed": False,
+                "include_partitions": include_partitions,
+                "include_indexes": include_indexes,
+            },
+        )
+
+    async def get_lineage_capability_status(self) -> dict[str, Any]:
+        versions, version_evidence, version_warnings = await self._lineage_versions()
+        parsed_versions = tuple(version for version in versions if version.is_parsed)
+        all_frontends_eligible = (
+            bool(versions)
+            and len(parsed_versions) == len(versions)
+            and all(
+                version.is_at_least(_NATIVE_LINEAGE_MINIMUM)
+                for version in parsed_versions
+            )
+        )
+        any_frontend_eligible = any(
+            version.is_at_least(_NATIVE_LINEAGE_MINIMUM) for version in parsed_versions
+        )
+
+        (
+            plugin_config,
+            plugin_evidence,
+            plugin_warnings,
+        ) = await self._lineage_plugin_config()
+        audit_status, audit_evidence = await self._audit_status()
+        provider_status = await self._lineage_provider_status()
+
+        active_plugins = _csv_values(plugin_config.get("activate_lineage_plugin"))
+        recent_native_event = provider_status.recent_event_observed
+        native_ready = (
+            all_frontends_eligible
+            and provider_status.queryable
+            and bool(active_plugins)
+            and recent_native_event
+        )
+        native_degraded = (
+            all_frontends_eligible
+            and provider_status.queryable
+            and bool(active_plugins)
+        )
+        if native_ready:
+            active_path = "doris_native_event_store"
+            capability_status = "available"
+        elif native_degraded:
+            active_path = "doris_native_event_store"
+            capability_status = "degraded"
+        elif audit_status["readable"]:
+            active_path = "audit_sql_inference"
+            capability_status = "degraded" if any_frontend_eligible else "available"
+        else:
+            active_path = "unavailable"
+            capability_status = "unavailable"
+
+        limitations = [
+            "Native lineage delivery is asynchronous and best effort.",
+            "Doris does not persist lineage events or expose a lineage query API.",
+            "Native events cover successful INSERT SELECT, INSERT OVERWRITE "
+            "SELECT, and CTAS statements only.",
+            "SELECT, UPDATE, DELETE, load jobs, VALUES-only inserts, and writes "
+            "to __internal_schema are not covered by native events.",
+        ]
+        limitations.extend(version_warnings)
+        limitations.extend(plugin_warnings)
+        limitations.extend(provider_status.limitations)
+        if active_path == "audit_sql_inference":
+            limitations.append(
+                "The active path infers bounded lineage from audit SQL and is "
+                "not native column-lineage evidence."
+            )
+
+        evidence = [
+            *version_evidence,
+            *plugin_evidence,
+            audit_evidence,
+            {
+                "source": provider_status.provider_id,
+                "success": provider_status.queryable,
+                "status": provider_status.status,
+                "row_count": provider_status.row_count,
+                "latest_event_time": _json_value(provider_status.latest_event_time),
+                "recent_event_observed": recent_native_event,
+            },
+        ]
+        return _result(
+            {
+                "status": capability_status,
+                "active_path": active_path,
+                "native_spi": {
+                    "minimum_version": "4.0.6",
+                    "all_frontends_eligible": all_frontends_eligible,
+                    "mixed_or_unparsed_frontends": (
+                        len(parsed_versions) != len(versions)
+                        or len({version.core for version in parsed_versions}) > 1
+                    ),
+                    "detected_versions": [
+                        version.normalized or "unknown" for version in versions
+                    ],
+                },
+                "plugin": {
+                    "configured_names": active_plugins,
+                    "configuration_observed": bool(plugin_config),
+                    "loaded_verified": recent_native_event,
+                    "queue_size": _optional_int(
+                        plugin_config.get("lineage_event_queue_size")
+                    ),
+                    "configuration_scope": "connected_frontend",
+                },
+                "queryable_store": {
+                    "provider_id": provider_status.provider_id,
+                    "status": provider_status.status,
+                    "queryable": provider_status.queryable,
+                    "row_count": provider_status.row_count,
+                    "latest_event_time": _json_value(provider_status.latest_event_time),
+                    "recent_event_observed": recent_native_event,
+                },
+                "audit_fallback": audit_status,
+                "coverage": {
+                    "native_supported_statements": [
+                        "INSERT INTO ... SELECT",
+                        "INSERT OVERWRITE TABLE ... SELECT",
+                        "CREATE TABLE AS SELECT",
+                    ],
+                    "native_excluded_statements": [
+                        "SELECT",
+                        "UPDATE",
+                        "DELETE",
+                        "load jobs",
+                        "VALUES-only INSERT",
+                        "writes to __internal_schema",
+                    ],
+                    "delivery_guarantee": "asynchronous_best_effort",
+                },
+                "limitations": list(dict.fromkeys(limitations)),
+            },
+            source="doris_lineage_capability_evidence",
+            warnings=limitations if capability_status != "available" else (),
+            evidence=evidence,
+            metadata={"invented_lineage_capability": False},
+        )
+
+    async def trace_column_lineage(
+        self,
+        *,
+        object_name: str,
+        column: str | None,
+        direction: str | None,
+        depth: int | None,
+        evidence_mode: str | None,
+    ) -> dict[str, Any]:
+        object_parts = _qualified_parts(
+            object_name,
+            field="lineage object",
+            minimum_parts=2,
+        )
+        canonical_object = _canonical_object(object_parts)
+        column_name = _identifier(column, "column name") if column is not None else None
+        selected_direction = direction or "both"
+        if selected_direction not in {"upstream", "downstream", "both"}:
+            raise _argument_failure("Unsupported lineage direction.")
+        selected_depth = _bounded_int(
+            depth,
+            default=3,
+            minimum=1,
+            maximum=_MAX_LINEAGE_DEPTH,
+            field="lineage depth",
+        )
+        selected_mode = evidence_mode or "auto"
+        if selected_mode not in {"auto", "native", "audit"}:
+            raise _argument_failure("Unsupported lineage evidence mode.")
+
+        status_result = await self.get_lineage_capability_status()
+        capability = status_result["data"]
+        active_path = str(capability["active_path"])
+        if selected_mode == "native":
+            if active_path != "doris_native_event_store":
+                raise GovernanceRuntimeFailure(
+                    "Native lineage evidence is unavailable.",
+                    reason_code="GOVERNANCE_NATIVE_LINEAGE_UNAVAILABLE",
+                    status_code=409,
+                )
+            path = "doris_native_event_store"
+        elif selected_mode == "audit":
+            if not capability["audit_fallback"]["readable"]:
+                raise GovernanceRuntimeFailure(
+                    "Audit lineage evidence is unavailable.",
+                    reason_code="GOVERNANCE_AUDIT_LINEAGE_UNAVAILABLE",
+                    status_code=503,
+                    retryable=True,
+                )
+            path = "audit_sql_inference"
+        else:
+            path = active_path
+
+        if path == "doris_native_event_store":
+            provider = self._lineage_provider
+            if provider is None:
+                raise GovernanceRuntimeFailure(
+                    "Native lineage provider is not configured.",
+                    reason_code="GOVERNANCE_LINEAGE_PROVIDER_NOT_CONFIGURED",
+                    status_code=503,
+                )
+            traced = await provider.trace(
+                object_name=canonical_object,
+                column=column_name,
+                direction=selected_direction,
+                depth=selected_depth,
+                max_edges=self._max_lineage_edges,
+            )
+            edges = traced["edges"]
+            warnings = list(traced.get("limitations", ()))
+            evidence = [
+                {
+                    "source": "doris_native_event_store",
+                    "success": True,
+                    "rows_observed": traced.get("rows_observed", 0),
+                    "edges_returned": len(edges),
+                }
+            ]
+            truncated = bool(traced.get("truncated"))
+        elif path == "audit_sql_inference":
+            traced = await self._trace_audit_lineage(
+                object_name=canonical_object,
+                column=column_name,
+                direction=selected_direction,
+                depth=selected_depth,
+            )
+            edges = traced["edges"]
+            warnings = list(traced["limitations"])
+            evidence = [
+                {
+                    "source": "internal.__internal_schema.audit_log",
+                    "success": True,
+                    "rows_observed": traced["rows_observed"],
+                    "edges_returned": len(edges),
+                    "evidence_quality": "inferred",
+                }
+            ]
+            truncated = bool(traced["truncated"])
+        else:
+            raise GovernanceRuntimeFailure(
+                "No queryable lineage evidence source is available.",
+                reason_code="GOVERNANCE_LINEAGE_EVIDENCE_UNAVAILABLE",
+                status_code=503,
+                retryable=True,
+            )
+
+        if not edges:
+            warnings.append(
+                "No qualifying lineage edge was observed; no placeholder edge "
+                "was generated."
+            )
+        return _result(
+            {
+                "object": canonical_object,
+                "column": column_name,
+                "direction": selected_direction,
+                "depth": selected_depth,
+                "evidence_mode": selected_mode,
+                "active_path": path,
+                "edges": edges,
+                "edge_count": len(edges),
+                "truncated": truncated,
+                "determinate": bool(edges),
+                "coverage": capability["coverage"],
+            },
+            source=path,
+            warnings=warnings,
+            evidence=evidence,
+            metadata={
+                "invented_edges": False,
+                "numeric_confidence_emitted": False,
+            },
+        )
+
+    async def analyze_data_access_patterns(
+        self,
+        *,
+        database: str | None,
+        table: str | None,
+        window_days: int | None,
+        group_by: str | None,
+    ) -> dict[str, Any]:
+        database_name = (
+            _identifier(database, "database name") if database is not None else None
+        )
+        table_name = _identifier(table, "table name") if table is not None else None
+        days = _bounded_int(
+            window_days,
+            default=7,
+            minimum=1,
+            maximum=self._max_audit_window_days,
+            field="audit window",
+        )
+        grouping = group_by or "object"
+        if grouping not in {"user", "object", "hour", "operation"}:
+            raise _argument_failure("Unsupported access grouping.")
+        rows, audit_metadata = await self._read_audit_rows(
+            window_minutes=days * 1440,
+            database=database_name,
+            user=None,
+            row_limit=_MAX_AUDIT_ROWS,
+        )
+
+        aggregates: dict[str, dict[str, Any]] = defaultdict(
+            lambda: {
+                "event_count": 0,
+                "error_count": 0,
+                "query_time_ms": 0,
+                "scan_bytes": 0,
+                "scan_rows": 0,
+                "return_rows": 0,
+            }
+        )
+        matched_rows = 0
+        for row in rows:
+            referenced = _audit_referenced_objects(row)
+            if table_name is not None and not any(
+                _object_matches_table(item, database_name, table_name)
+                for item in referenced
+            ):
+                continue
+            operation = _audit_operation(row)
+            groups: Sequence[str]
+            if grouping == "user":
+                groups = (_principal_label(_value(row, "user")),)
+            elif grouping == "hour":
+                groups = (_hour_bucket(_value(row, "time")),)
+            elif grouping == "operation":
+                groups = (operation,)
+            else:
+                groups = tuple(referenced) or (_database_object_label(row),)
+            matched_rows += 1
+            for key in dict.fromkeys(groups):
+                aggregate = aggregates[key]
+                aggregate["event_count"] += 1
+                if not _audit_success(row):
+                    aggregate["error_count"] += 1
+                aggregate["query_time_ms"] += (
+                    _optional_int(_value(row, "query_time")) or 0
+                )
+                aggregate["scan_bytes"] += _optional_int(_value(row, "scan_bytes")) or 0
+                aggregate["scan_rows"] += _optional_int(_value(row, "scan_rows")) or 0
+                aggregate["return_rows"] += (
+                    _optional_int(_value(row, "return_rows")) or 0
+                )
+
+        items = []
+        for key, aggregate in sorted(
+            aggregates.items(),
+            key=lambda item: (-item[1]["event_count"], item[0]),
+        ):
+            event_count = aggregate["event_count"]
+            items.append(
+                {
+                    "group": key,
+                    **aggregate,
+                    "error_rate": round(
+                        aggregate["error_count"] / event_count,
+                        6,
+                    ),
+                    "average_query_time_ms": round(
+                        aggregate["query_time_ms"] / event_count,
+                        3,
+                    ),
+                }
+            )
+        truncated = len(rows) >= _MAX_AUDIT_ROWS
+        warnings = []
+        if truncated:
+            warnings.append("Access analysis reached the bounded audit-row limit.")
+        return _result(
+            {
+                "group_by": grouping,
+                "window_days": days,
+                "database": database_name,
+                "table": table_name,
+                "items": items,
+                "matched_event_count": matched_rows,
+                "source_event_count": len(rows),
+                "truncated": truncated,
+            },
+            source="doris_audit_access_history",
+            warnings=warnings,
+            evidence=[
+                {
+                    "source": _AUDIT_TABLE,
+                    "success": True,
+                    "rows_observed": len(rows),
+                    "fields": audit_metadata["fields"],
+                }
+            ],
+            metadata={
+                "principal_representation": "stable_pseudonym",
+                "raw_sql_exposed": False,
+            },
+        )
+
+    async def get_recent_audit_logs(
+        self,
+        *,
+        window_minutes: int | None,
+        user: str | None,
+        operation: str | None,
+        database: str | None,
+        table: str | None,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        maximum_minutes = self._max_audit_window_days * 1440
+        minutes = _bounded_int(
+            window_minutes,
+            default=1440,
+            minimum=1,
+            maximum=maximum_minutes,
+            field="audit window",
+        )
+        result_limit = _bounded_int(
+            limit,
+            default=100,
+            minimum=1,
+            maximum=_MAX_AUDIT_RESULTS,
+            field="audit result limit",
+        )
+        database_name = (
+            _identifier(database, "database name") if database is not None else None
+        )
+        table_name = _identifier(table, "table name") if table is not None else None
+        principal = (
+            _bounded_text(user, "audit user", maximum=128) if user is not None else None
+        )
+        requested_operation = (
+            _bounded_text(operation, "audit operation", maximum=64).upper()
+            if operation is not None
+            else None
+        )
+        fetch_limit = min(
+            _MAX_AUDIT_ROWS,
+            max(result_limit * 4, result_limit),
+        )
+        rows, metadata = await self._read_audit_rows(
+            window_minutes=minutes,
+            database=database_name,
+            user=principal,
+            row_limit=fetch_limit,
+        )
+        items: list[dict[str, Any]] = []
+        for row in rows:
+            observed_operation = _audit_operation(row)
+            if (
+                requested_operation is not None
+                and observed_operation != requested_operation
+            ):
+                continue
+            referenced = _audit_referenced_objects(row)
+            if table_name is not None and not any(
+                _object_matches_table(item, database_name, table_name)
+                for item in referenced
+            ):
+                continue
+            items.append(
+                {
+                    "event_id": _value(row, "query_id", "stmt_id"),
+                    "observed_at": _json_value(_value(row, "time")),
+                    "principal": _principal_label(_value(row, "user")),
+                    "operation": observed_operation,
+                    "catalog": _value(row, "catalog"),
+                    "database": _value(row, "db"),
+                    "state": _value(row, "state"),
+                    "error_code": _optional_int(_value(row, "error_code")),
+                    "query_time_ms": _optional_int(_value(row, "query_time")),
+                    "scan_bytes": _optional_int(_value(row, "scan_bytes")),
+                    "scan_rows": _optional_int(_value(row, "scan_rows")),
+                    "return_rows": _optional_int(_value(row, "return_rows")),
+                    "referenced_objects": referenced[:32],
+                }
+            )
+            if len(items) >= result_limit:
+                break
+        truncated = len(items) >= result_limit and len(rows) > len(items)
+        return _collection(
+            items,
+            source="doris_audit_log",
+            truncated=truncated,
+            metadata={
+                "window_minutes": minutes,
+                "source_rows_observed": len(rows),
+                "fields": metadata["fields"],
+                "principal_representation": "stable_pseudonym",
+                "raw_sql_exposed": False,
+                "client_address_exposed": False,
+                "error_message_exposed": False,
+            },
+        )
+
+    async def list_udfs(
+        self,
+        *,
+        database: str | None,
+        language: str | None,
+        name_pattern: str | None,
+    ) -> dict[str, Any]:
+        database_name = (
+            _identifier(database, "database name")
+            if database is not None
+            else await self._current_database()
+        )
+        language_filter = (
+            _bounded_text(language, "UDF language", maximum=32).casefold()
+            if language is not None
+            else None
+        )
+        pattern = (
+            _bounded_text(name_pattern, "UDF name pattern", maximum=128)
+            if name_pattern is not None
+            else None
+        )
+        if database_name is not None:
+            quoted_database = quote_identifier(
+                database_name,
+                "database name",
+            )
+            # SQL sink audit: quoted_database is a strictly validated identifier
+            # before _execute sends this read-only SHOW command.
+            statement = f"SHOW FULL FUNCTIONS IN {quoted_database}"  # nosec B608
+            scope = database_name
+        else:
+            statement = "SHOW GLOBAL FULL FUNCTIONS"
+            scope = "global"
+        rows = await self._execute(statement, max_rows=_MAX_UDFS)
+        items: list[dict[str, Any]] = []
+        for row in rows:
+            udf = _udf_item(row, scope=scope)
+            if udf is None:
+                continue
+            if language_filter is not None and (
+                str(udf["language"]).casefold() != language_filter
+            ):
+                continue
+            if pattern is not None and not _matches_name_pattern(
+                str(udf["name"]),
+                pattern,
+            ):
+                continue
+            items.append(udf)
+        return _collection(
+            items,
+            source="SHOW FULL FUNCTIONS",
+            truncated=len(rows) >= _MAX_UDFS,
+            metadata={
+                "scope": scope,
+                "code_loaded": False,
+                "code_executed": False,
+                "raw_object_location_exposed": False,
+            },
+        )
+
+    async def get_auth_mapping_status(
+        self,
+        *,
+        principal: str | None,
+        provider: str | None,
+        include_roles: bool,
+    ) -> dict[str, Any]:
+        selected_provider = provider
+        if selected_provider is not None and selected_provider not in {
+            "ldap",
+            "oidc",
+        }:
+            raise _argument_failure("Unsupported authentication provider.")
+        principal_filter = (
+            _bounded_text(
+                principal,
+                "principal",
+                maximum=128,
+            )
+            if principal is not None
+            else None
+        )
+        provider_names = (
+            (selected_provider,) if selected_provider is not None else ("ldap", "oidc")
+        )
+        providers: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        evidence: list[dict[str, Any]] = []
+
+        if "ldap" in provider_names:
+            ldap_config, ldap_evidence, ldap_warnings = await self._ldap_status()
+            providers.append(ldap_config)
+            evidence.extend(ldap_evidence)
+            warnings.extend(ldap_warnings)
+
+        if "oidc" in provider_names:
+            role_rows, role_failure = await self._optional_execute(
+                "SELECT * FROM information_schema.role_mappings LIMIT 500",
+                max_rows=500,
+            )
+            evidence.append(
+                {
+                    "source": "information_schema.role_mappings",
+                    "success": role_failure is None,
+                    "rows_observed": len(role_rows),
+                    "reason_code": (
+                        None if role_failure is None else role_failure.reason_code
+                    ),
+                }
+            )
+            if role_failure is not None:
+                warnings.append(
+                    "OIDC role-mapping metadata is unavailable "
+                    f"({role_failure.reason_code})."
+                )
+            mappings = []
+            for row in role_rows:
+                mapping = _safe_role_mapping(row)
+                raw_principal = _role_mapping_principal(row)
+                if (
+                    principal_filter is not None
+                    and raw_principal is not None
+                    and raw_principal != principal_filter
+                ):
+                    continue
+                if principal_filter is not None and raw_principal is None:
+                    continue
+                mappings.append(mapping)
+            providers.append(
+                {
+                    "provider": "oidc",
+                    "status": (
+                        "configured"
+                        if role_rows
+                        else ("not_configured" if role_failure is None else "unknown")
+                    ),
+                    "mapping_count": len(mappings),
+                    "mappings": mappings,
+                    "minimum_role_mapping_version": "4.1.2",
+                }
+            )
+
+        roles: list[dict[str, Any]] | None = None
+        if include_roles:
+            role_rows, role_failure = await self._optional_execute(
+                "SHOW ROLES",
+                max_rows=500,
+            )
+            evidence.append(
+                {
+                    "source": "SHOW ROLES",
+                    "success": role_failure is None,
+                    "rows_observed": len(role_rows),
+                    "reason_code": (
+                        None if role_failure is None else role_failure.reason_code
+                    ),
+                }
+            )
+            if role_failure is not None:
+                warnings.append(
+                    f"Authorized role metadata is unavailable ({role_failure.reason_code})."
+                )
+            roles = [
+                {
+                    "name": _value(row, "name", "role"),
+                    "assigned_principal_count": _listed_value_count(
+                        _value(row, "users")
+                    ),
+                }
+                for row in role_rows
+                if _value(row, "name", "role") is not None
+            ]
+
+        return _result(
+            {
+                "providers": providers,
+                "principal_filter": (
+                    _principal_label(principal_filter)
+                    if principal_filter is not None
+                    else None
+                ),
+                "roles": roles,
+                "secrets_exposed": False,
+                "mapping_rules_exposed": False,
+            },
+            source="doris_authentication_mapping_metadata",
+            warnings=warnings,
+            evidence=evidence,
+            metadata={
+                "principal_representation": "stable_pseudonym",
+                "raw_configuration_exposed": False,
+            },
+        )
+
+    async def _trace_audit_lineage(
+        self,
+        *,
+        object_name: str,
+        column: str | None,
+        direction: str,
+        depth: int,
+    ) -> dict[str, Any]:
+        rows, _ = await self._read_audit_rows(
+            window_minutes=self._max_audit_window_days * 1440,
+            database=None,
+            user=None,
+            row_limit=_MAX_AUDIT_ROWS,
+        )
+        inferred: list[dict[str, Any]] = []
+        for row in rows:
+            inferred.extend(_audit_lineage_edges(row, column=column))
+        edges, truncated = _traverse_edges(
+            inferred,
+            object_name=object_name,
+            direction=direction,
+            depth=depth,
+            max_edges=self._max_lineage_edges,
+        )
+        limitations = [
+            "Audit SQL inference is bounded and may omit statements outside "
+            "the configured history window.",
+            "Audit-derived edges are inferred and are never labeled as native.",
+        ]
+        if column is not None:
+            limitations.append(
+                "Column edges are emitted only for simple direct INSERT SELECT "
+                "mappings with explicit target columns."
+            )
+        return {
+            "edges": edges,
+            "truncated": truncated or len(rows) >= _MAX_AUDIT_ROWS,
+            "rows_observed": len(rows),
+            "limitations": limitations,
+        }
+
+    async def _lineage_provider_status(self) -> LineageProviderStatus:
+        if self._lineage_provider is None:
+            return LineageProviderStatus(
+                provider_id="doris_native_event_store",
+                status="not_configured",
+                queryable=False,
+                limitations=(
+                    "No queryable lineage event-store provider is configured.",
+                ),
+            )
+        return await self._lineage_provider.status()
+
+    async def _lineage_versions(
+        self,
+    ) -> tuple[
+        list[DorisVersion],
+        list[dict[str, Any]],
+        list[str],
+    ]:
+        versions: list[DorisVersion] = []
+        evidence: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        version_rows, version_failure = await self._optional_execute(
+            "SELECT @@version_comment;",
+            max_rows=1,
+        )
+        if version_failure is None and version_rows:
+            raw = _value(version_rows[0], "@@version_comment", "version_comment")
+            if isinstance(raw, str):
+                versions.append(parse_doris_version_comment(raw))
+        evidence.append(
+            {
+                "source": "SELECT @@version_comment",
+                "success": version_failure is None and bool(versions),
+                "rows_observed": len(version_rows),
+                "reason_code": (
+                    None if version_failure is None else version_failure.reason_code
+                ),
+            }
+        )
+
+        frontend_rows, frontend_failure = await self._optional_execute(
+            "SHOW FRONTENDS",
+            max_rows=128,
+        )
+        frontend_versions = []
+        for row in frontend_rows:
+            raw = _value(
+                row,
+                "version",
+                "version_comment",
+                "fe_version",
+            )
+            if isinstance(raw, str):
+                frontend_versions.append(parse_doris_version_comment(raw))
+        if frontend_versions:
+            versions = frontend_versions
+        evidence.append(
+            {
+                "source": "SHOW FRONTENDS",
+                "success": frontend_failure is None,
+                "rows_observed": len(frontend_rows),
+                "versions_observed": len(frontend_versions),
+                "reason_code": (
+                    None if frontend_failure is None else frontend_failure.reason_code
+                ),
+            }
+        )
+        if frontend_failure is not None:
+            warnings.append(
+                "Cluster-wide FE version coverage is unavailable "
+                f"({frontend_failure.reason_code})."
+            )
+        if not versions:
+            warnings.append("No parseable Doris FE version was observed.")
+        return versions, evidence, warnings
+
+    async def _lineage_plugin_config(
+        self,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+        values: dict[str, Any] = {}
+        evidence: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        for key in (
+            "activate_lineage_plugin",
+            "lineage_event_queue_size",
+        ):
+            # SQL sink audit: key comes exclusively from the fixed tuple above
+            # before _optional_execute sends this read-only SHOW command.
+            rows, failure = await self._optional_execute(
+                f"SHOW FRONTEND CONFIG LIKE '{key}'",  # nosec B608
+                max_rows=4,
+            )
+            if rows:
+                values[key] = _value(rows[0], "value")
+            evidence.append(
+                {
+                    "source": f"SHOW FRONTEND CONFIG:{key}",
+                    "success": failure is None,
+                    "rows_observed": len(rows),
+                    "reason_code": (None if failure is None else failure.reason_code),
+                }
+            )
+            if failure is not None:
+                warnings.append(
+                    f"Frontend lineage configuration {key} is unavailable "
+                    f"({failure.reason_code})."
+                )
+        return values, evidence, warnings
+
+    async def _audit_status(
+        self,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        # SQL sink audit: _AUDIT_TABLE is a module-owned constant and the
+        # statement has no user values before _optional_execute reaches the sink.
+        rows, failure = await self._optional_execute(
+            (
+                "SELECT `time`, `query_id` "
+                f"FROM {_AUDIT_TABLE} ORDER BY `time` DESC LIMIT 1"  # nosec B608
+            ),
+            max_rows=1,
+        )
+        return (
+            {
+                "readable": failure is None,
+                "status": ("available" if failure is None else "unavailable"),
+                "recent_event_observed": bool(rows),
+                "evidence_quality": "inferred",
+            },
+            {
+                "source": _AUDIT_TABLE,
+                "success": failure is None,
+                "rows_observed": len(rows),
+                "reason_code": (None if failure is None else failure.reason_code),
+            },
+        )
+
+    async def _read_audit_rows(
+        self,
+        *,
+        window_minutes: int,
+        database: str | None,
+        user: str | None,
+        row_limit: int,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        schema_rows = await self._execute(
+            f"DESC {_AUDIT_TABLE}",
+            max_rows=256,
+        )
+        available = {
+            str(_value(row, "field", "column_name", "name")).casefold()
+            for row in schema_rows
+            if _value(row, "field", "column_name", "name") is not None
+        }
+        selected = tuple(field for field in _AUDIT_FIELD_ORDER if field in available)
+        if "time" not in selected:
+            raise GovernanceRuntimeFailure(
+                "Doris audit metadata does not expose an event time.",
+                reason_code="GOVERNANCE_AUDIT_SCHEMA_UNSUPPORTED",
+                status_code=503,
+            )
+        select_list = ", ".join(quote_identifier(field) for field in selected)
+        predicates = ["`time` >= DATE_SUB(NOW(), INTERVAL %s MINUTE)"]
+        params: list[Any] = [window_minutes]
+        if database is not None and "db" in selected:
+            predicates.append("`db` = %s")
+            params.append(database)
+        if user is not None and "user" in selected:
+            predicates.append("`user` = %s")
+            params.append(user)
+        bounded_limit = min(max(1, row_limit), _MAX_AUDIT_ROWS)
+        # SQL sink audit: selected fields and predicates come from fixed
+        # allowlists, values remain bound, and _execute receives a bounded limit.
+        sql = (
+            f"SELECT {select_list} FROM {_AUDIT_TABLE} "  # nosec B608
+            f"WHERE {' AND '.join(predicates)} "
+            f"ORDER BY `time` DESC LIMIT {bounded_limit}"
+        )
+        rows = await self._execute(
+            sql,
+            params=tuple(params),
+            max_rows=bounded_limit,
+        )
+        return rows, {"fields": list(selected)}
+
+    async def _ldap_status(
+        self,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]], list[str]]:
+        observed: dict[str, Any] = {}
+        evidence: list[dict[str, Any]] = []
+        warnings: list[str] = []
+        for key in (
+            "authentication_type",
+            "ldap_authentication_enabled",
+            "ldap_use_ssl",
+            "ldap_default_roles",
+        ):
+            # SQL sink audit: key comes exclusively from the fixed tuple above
+            # before _optional_execute sends this read-only SHOW command.
+            rows, failure = await self._optional_execute(
+                f"SHOW FRONTEND CONFIG LIKE '{key}'",  # nosec B608
+                max_rows=4,
+            )
+            if rows:
+                observed[key] = _value(rows[0], "value")
+            evidence.append(
+                {
+                    "source": f"SHOW FRONTEND CONFIG:{key}",
+                    "success": failure is None,
+                    "rows_observed": len(rows),
+                    "reason_code": (None if failure is None else failure.reason_code),
+                }
+            )
+            if failure is not None:
+                warnings.append(
+                    f"LDAP configuration {key} is unavailable ({failure.reason_code})."
+                )
+        authentication_type = str(observed.get("authentication_type", "")).casefold()
+        enabled_value = str(observed.get("ldap_authentication_enabled", "")).casefold()
+        configured = authentication_type == "ldap" or enabled_value in {
+            "true",
+            "1",
+            "yes",
+            "on",
+        }
+        return (
+            {
+                "provider": "ldap",
+                "status": "configured" if configured else "not_configured",
+                "tls_enabled": str(observed.get("ldap_use_ssl", "")).casefold()
+                in {"true", "1", "yes", "on"},
+                "default_roles": _csv_values(observed.get("ldap_default_roles")),
+                "group_mapping_mode": "ldap_group_name_to_doris_role_name",
+                "configuration_scope": "connected_frontend",
+            },
+            evidence,
+            warnings,
+        )
+
+    async def _current_database(self) -> str | None:
+        rows = await self._execute(
+            "SELECT DATABASE() AS database_name",
+            max_rows=1,
+        )
+        value = _value(rows[0], "database_name") if rows else None
+        if value is None:
+            return None
+        return _identifier(str(value), "database name")
+
+    async def _optional_execute(
+        self,
+        sql: str,
+        *,
+        params: Mapping[str, Any] | tuple[Any, ...] | None = None,
+        max_rows: int,
+    ) -> tuple[list[dict[str, Any]], GovernanceRuntimeFailure | None]:
+        try:
+            return await self._execute(
+                sql,
+                params=params,
+                max_rows=max_rows,
+            ), None
+        except GovernanceRuntimeFailure as exc:
+            return [], exc
+
+    async def _execute(
+        self,
+        sql: str,
+        *,
+        params: Mapping[str, Any] | tuple[Any, ...] | None = None,
+        max_rows: int,
+    ) -> list[dict[str, Any]]:
+        auth_context = get_current_auth_context()
+        session_id = f"{self._session_prefix}:{uuid.uuid4().hex[:8]}"
+        try:
+            async with self._connection_manager.get_connection_context_for_auth_context(
+                session_id,
+                auth_context,
+            ) as connection:
+                result = await connection.execute(
+                    sql,
+                    params=params,
+                    auth_context=auth_context,
+                    mask_result=False,
+                    max_rows=max_rows,
+                    max_bytes=_MAX_BYTES,
+                )
+        except Exception as exc:
+            raise _classify_failure(exc) from exc
+        return [dict(row) for row in (result.data or ()) if isinstance(row, Mapping)][
+            :max_rows
+        ]
+
+
+def _result(
+    data: Mapping[str, Any],
+    *,
+    source: str,
+    warnings: Sequence[str] = (),
+    evidence: Sequence[Mapping[str, Any]],
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    unique_warnings = list(dict.fromkeys(str(item) for item in warnings))
+    return {
+        "status": "partial" if unique_warnings else "success",
+        "data": redact_sensitive_data(dict(data)),
+        "warnings": unique_warnings,
+        "metadata": {
+            "source": source,
+            **dict(metadata or {}),
+        },
+        "evidence": [redact_sensitive_data(dict(item)) for item in evidence],
+    }
+
+
+def _collection(
+    items: Sequence[Mapping[str, Any]],
+    *,
+    source: str,
+    warnings: Sequence[str] = (),
+    truncated: bool,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    unique_warnings = list(dict.fromkeys(str(item) for item in warnings))
+    return {
+        "status": "partial" if unique_warnings else "success",
+        "data": {
+            "items": [redact_sensitive_data(dict(item)) for item in items],
+            "next_cursor": None,
+            "truncated": truncated,
+        },
+        "warnings": unique_warnings,
+        "metadata": {
+            "source": source,
+            **dict(metadata or {}),
+        },
+    }
+
+
+def _identifier(value: Any, field: str) -> str:
+    try:
+        return validate_identifier(value, field)
+    except (SQLSecurityError, TypeError) as exc:
+        raise _argument_failure(f"Invalid {field}.") from exc
+
+
+def _qualified_parts(
+    value: Any,
+    *,
+    field: str,
+    minimum_parts: int,
+) -> tuple[str, ...]:
+    if not isinstance(value, str):
+        raise _argument_failure(f"Invalid {field}.")
+    raw_parts = [part.strip().strip("`") for part in value.split(".")]
+    if not minimum_parts <= len(raw_parts) <= 3:
+        raise _argument_failure(
+            f"{field.capitalize()} must contain two or three identifiers."
+        )
+    return tuple(_identifier(part, field) for part in raw_parts)
+
+
+def _table_reference(parts: Sequence[str]) -> str:
+    if len(parts) == 2:
+        return build_table_reference(parts[1], parts[0])
+    return build_table_reference(parts[2], parts[1], parts[0])
+
+
+def _canonical_object(parts: Sequence[str]) -> str:
+    if len(parts) == 2:
+        return f"internal.{parts[0]}.{parts[1]}"
+    return ".".join(parts)
+
+
+def _bounded_text(value: Any, field: str, *, maximum: int) -> str:
+    if not isinstance(value, str):
+        raise _argument_failure(f"{field.capitalize()} must be a string.")
+    normalized = value.strip()
+    if not normalized or len(normalized) > maximum:
+        raise _argument_failure(
+            f"{field.capitalize()} must contain 1-{maximum} characters."
+        )
+    if any(character in normalized for character in ("\x00", "\r", "\n")):
+        raise _argument_failure(f"{field.capitalize()} contains control characters.")
+    return normalized
+
+
+def _bounded_int(
+    value: Any,
+    *,
+    default: int,
+    minimum: int,
+    maximum: int,
+    field: str,
+) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise _argument_failure(f"{field.capitalize()} must be an integer.")
+    if not minimum <= value <= maximum:
+        raise _argument_failure(
+            f"{field.capitalize()} must be between {minimum} and {maximum}."
+        )
+    return int(value)
+
+
+def _sample_ratio(value: Any, *, maximum: float) -> float:
+    if value is None:
+        return 0.0
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise _argument_failure("Sample ratio must be numeric.")
+    normalized = float(value)
+    if not 0 <= normalized <= 1:
+        raise _argument_failure("Sample ratio must be between 0 and 1.")
+    return min(normalized, maximum)
+
+
+def _argument_failure(message: str) -> GovernanceRuntimeFailure:
+    return GovernanceRuntimeFailure(
+        message,
+        reason_code="GOVERNANCE_ARGUMENT_INVALID",
+        status_code=400,
+    )
+
+
+def _classify_failure(error: Exception) -> GovernanceRuntimeFailure:
+    if isinstance(error, GovernanceRuntimeFailure):
+        return error
+    if isinstance(error, SQLSecurityError):
+        return _argument_failure("Governance arguments are invalid.")
+    error_code = next(
+        (item for item in getattr(error, "args", ()) if isinstance(item, int)),
+        None,
+    )
+    if error_code in {1044, 1045, 1142, 1227}:
+        return GovernanceRuntimeFailure(
+            "Doris denied access to the requested governance evidence.",
+            reason_code="GOVERNANCE_PERMISSION_DENIED",
+            status_code=403,
+        )
+    if error_code in {1049, 1054, 1064, 1109, 1146, 1305}:
+        return GovernanceRuntimeFailure(
+            "The requested Doris governance evidence is unsupported.",
+            reason_code="GOVERNANCE_EVIDENCE_UNSUPPORTED",
+            status_code=503,
+        )
+    if isinstance(error, ConnectionError | TimeoutError):
+        return GovernanceRuntimeFailure(
+            "Doris governance evidence is temporarily unavailable.",
+            reason_code="GOVERNANCE_CONNECTION_FAILED",
+            status_code=503,
+            retryable=True,
+        )
+    return GovernanceRuntimeFailure(
+        "Doris governance evidence execution failed.",
+        reason_code="GOVERNANCE_EXECUTION_FAILED",
+        status_code=502,
+    )
+
+
+def _value(row: Mapping[str, Any], *names: str) -> Any:
+    normalized = {
+        str(key).strip().casefold().replace(" ", "_"): value
+        for key, value in row.items()
+    }
+    for name in names:
+        key = name.strip().casefold().replace(" ", "_")
+        if key in normalized:
+            return normalized[key]
+    return None
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _is_complex_type(data_type: str) -> bool:
+    upper = data_type.upper()
+    return any(marker in upper for marker in _COMPLEX_TYPE_MARKERS)
+
+
+def _safe_create_properties(create_sql: str) -> dict[str, str]:
+    properties: dict[str, str] = {}
+    for key, value in re.findall(
+        r'["\']([A-Za-z_][A-Za-z0-9_]*)["\']\s*=\s*["\']([^"\']*)["\']',
+        create_sql,
+    ):
+        normalized = key.casefold()
+        if normalized in _SAFE_CREATE_PROPERTY_KEYS:
+            properties[normalized] = value
+    return properties
+
+
+def _storage_partition(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "name": _value(row, "partitionname", "partition_name"),
+        "id": _value(row, "partitionid", "partition_id"),
+        "state": _value(row, "state"),
+        "visible_version": _value(row, "visibleversion", "visible_version"),
+        "visible_version_time": _json_value(
+            _value(row, "visibleversiontime", "visible_version_time")
+        ),
+        "distribution_key": _value(
+            row,
+            "distributionkey",
+            "distribution_key",
+        ),
+        "buckets": _optional_int(_value(row, "buckets")),
+        "replication_allocation": _value(
+            row,
+            "replicationallocation",
+            "replication_allocation",
+        ),
+        "data_size": _value(row, "datasize", "data_size"),
+        "row_count": _optional_int(_value(row, "rowcount", "row_count")),
+    }
+
+
+def _storage_index(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "name": _value(row, "key_name", "index_name", "name"),
+        "column": _value(row, "column_name", "columns"),
+        "type": _value(row, "index_type", "type"),
+        "visible": _value(row, "visible"),
+    }
+
+
+def _append_optional_evidence(
+    evidence: list[dict[str, Any]],
+    warnings: list[str],
+    *,
+    source: str,
+    rows: Sequence[Mapping[str, Any]],
+    failure: GovernanceRuntimeFailure | None,
+) -> None:
+    evidence.append(
+        {
+            "source": source,
+            "success": failure is None,
+            "rows_observed": len(rows),
+            "reason_code": None if failure is None else failure.reason_code,
+        }
+    )
+    if failure is not None:
+        warnings.append(
+            f"Optional {source} evidence is unavailable ({failure.reason_code})."
+        )
+
+
+def _csv_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    return [item.strip() for item in str(value).split(",") if item.strip()][:64]
+
+
+def _native_lineage_edge(
+    row: Mapping[str, Any],
+    *,
+    level: int,
+) -> dict[str, Any] | None:
+    source = _value(row, "source_object")
+    target = _value(row, "target_object")
+    event_id = _value(row, "event_id")
+    if not all(isinstance(item, str) and item for item in (source, target)):
+        return None
+    return {
+        "source_object": source,
+        "source_column": _value(row, "source_column"),
+        "target_object": target,
+        "target_column": _value(row, "target_column"),
+        "dependency_type": (_value(row, "dependency_type") or "unspecified"),
+        "statement_type": _value(row, "statement_type"),
+        "depth": level,
+        "evidence_type": "native_event",
+        "source_event_id": event_id,
+        "query_id": _value(row, "query_id"),
+        "observed_at": _json_value(_value(row, "event_time")),
+        "coverage": {
+            "level": (
+                "column"
+                if _value(row, "source_column", "target_column") is not None
+                else "table"
+            ),
+            "delivery": "asynchronous_best_effort",
+        },
+        "limitations": [
+            "Native events cover only supported successful DML statements."
+        ],
+    }
+
+
+def _audit_lineage_edges(
+    row: Mapping[str, Any],
+    *,
+    column: str | None,
+) -> list[dict[str, Any]]:
+    if not _audit_success(row):
+        return []
+    statement = _value(row, "stmt")
+    if not isinstance(statement, str) or not statement.strip():
+        return []
+    normalized_sql = sqlparse.format(
+        statement,
+        strip_comments=True,
+        keyword_case="upper",
+    ).strip()
+    target_match = _WRITE_TARGET.search(normalized_sql)
+    if target_match is None:
+        return []
+    default_catalog = str(_value(row, "catalog") or "internal")
+    default_database = _value(row, "db")
+    target = _normalize_sql_object(
+        target_match.group(1),
+        default_catalog=default_catalog,
+        default_database=(
+            str(default_database) if default_database is not None else None
+        ),
+    )
+    if target is None:
+        return []
+    event_id = _value(row, "query_id", "stmt_id")
+    observed_at = _json_value(_value(row, "time"))
+    statement_type = _audit_operation(row)
+
+    if column is not None:
+        direct = _simple_direct_column_edges(
+            normalized_sql,
+            target=target,
+            column=column,
+            default_catalog=default_catalog,
+            default_database=(
+                str(default_database) if default_database is not None else None
+            ),
+            event_id=event_id,
+            observed_at=observed_at,
+            statement_type=statement_type,
+        )
+        return direct
+
+    sources = _audit_referenced_objects(row)
+    if not sources:
+        sources = tuple(
+            item
+            for match in _SOURCE_REFERENCE.finditer(normalized_sql)
+            if (
+                item := _normalize_sql_object(
+                    match.group(1),
+                    default_catalog=default_catalog,
+                    default_database=(
+                        str(default_database) if default_database is not None else None
+                    ),
+                )
+            )
+        )
+    edges = []
+    for source in dict.fromkeys(sources):
+        if source == target:
+            continue
+        edges.append(
+            {
+                "source_object": source,
+                "source_column": None,
+                "target_object": target,
+                "target_column": None,
+                "dependency_type": "table_dependency",
+                "statement_type": statement_type,
+                "depth": 1,
+                "evidence_type": "audit_sql_inference",
+                "source_event_id": event_id,
+                "query_id": _value(row, "query_id"),
+                "observed_at": observed_at,
+                "coverage": {
+                    "level": "table",
+                    "derivation": (
+                        "recorded_queried_tables"
+                        if _value(row, "queried_tables_and_views") is not None
+                        else "bounded_sql_parse"
+                    ),
+                },
+                "limitations": ["This edge is inferred from bounded audit evidence."],
+            }
+        )
+    return edges
+
+
+def _simple_direct_column_edges(
+    statement: str,
+    *,
+    target: str,
+    column: str,
+    default_catalog: str,
+    default_database: str | None,
+    event_id: Any,
+    observed_at: Any,
+    statement_type: str,
+) -> list[dict[str, Any]]:
+    match = _SIMPLE_INSERT_SELECT.search(statement)
+    if match is None:
+        return []
+    tail = match.group("tail")
+    if re.search(r"\b(?:JOIN|UNION|GROUP\s+BY|WINDOW)\b", tail, re.IGNORECASE):
+        return []
+    parsed_target = _normalize_sql_object(
+        match.group("target"),
+        default_catalog=default_catalog,
+        default_database=default_database,
+    )
+    if parsed_target != target:
+        return []
+    source = _normalize_sql_object(
+        match.group("source"),
+        default_catalog=default_catalog,
+        default_database=default_database,
+    )
+    if source is None:
+        return []
+    target_columns = [
+        _strip_identifier(item) for item in match.group("target_columns").split(",")
+    ]
+    select_expressions = [
+        item.strip() for item in match.group("select_list").split(",")
+    ]
+    if len(target_columns) != len(select_expressions):
+        return []
+    edges = []
+    for target_column, expression in zip(
+        target_columns,
+        select_expressions,
+        strict=True,
+    ):
+        if target_column != column:
+            continue
+        direct_match = re.fullmatch(
+            rf"\s*(?:{_SIMPLE_IDENTIFIER}\s*\.\s*)?"
+            rf"(?P<column>{_SIMPLE_IDENTIFIER})"
+            rf"(?:\s+AS\s+{_SIMPLE_IDENTIFIER})?\s*",
+            expression,
+            re.IGNORECASE,
+        )
+        if direct_match is None:
+            continue
+        source_column = _strip_identifier(direct_match.group("column"))
+        edges.append(
+            {
+                "source_object": source,
+                "source_column": source_column,
+                "target_object": target,
+                "target_column": target_column,
+                "dependency_type": "direct",
+                "statement_type": statement_type,
+                "depth": 1,
+                "evidence_type": "audit_sql_inference",
+                "source_event_id": event_id,
+                "query_id": event_id,
+                "observed_at": observed_at,
+                "coverage": {
+                    "level": "column_direct",
+                    "derivation": "simple_explicit_insert_projection",
+                },
+                "limitations": [
+                    "This direct mapping is inferred from a simple audited "
+                    "INSERT SELECT projection."
+                ],
+            }
+        )
+    return edges
+
+
+def _traverse_edges(
+    edges: Sequence[Mapping[str, Any]],
+    *,
+    object_name: str,
+    direction: str,
+    depth: int,
+    max_edges: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    frontier = {object_name}
+    visited = {object_name}
+    selected: list[dict[str, Any]] = []
+    selected_keys: set[tuple[Any, ...]] = set()
+    for level in range(1, depth + 1):
+        next_frontier: set[str] = set()
+        for raw in edges:
+            source = raw.get("source_object")
+            target = raw.get("target_object")
+            include = False
+            if direction in {"upstream", "both"} and target in frontier:
+                include = True
+                if isinstance(source, str):
+                    next_frontier.add(source)
+            if direction in {"downstream", "both"} and source in frontier:
+                include = True
+                if isinstance(target, str):
+                    next_frontier.add(target)
+            if not include:
+                continue
+            key = (
+                source,
+                raw.get("source_column"),
+                target,
+                raw.get("target_column"),
+                raw.get("source_event_id"),
+            )
+            if key in selected_keys:
+                continue
+            selected_keys.add(key)
+            item = dict(raw)
+            item["depth"] = level
+            selected.append(item)
+            if len(selected) >= max_edges:
+                return selected, True
+        frontier = next_frontier - visited
+        visited.update(frontier)
+        if not frontier:
+            break
+    return selected, False
+
+
+def _audit_success(row: Mapping[str, Any]) -> bool:
+    state = str(_value(row, "state") or "").strip().casefold()
+    error_code = _optional_int(_value(row, "error_code"))
+    return state in {"", "ok", "success", "finished"} and (
+        error_code is None or error_code == 0
+    )
+
+
+def _audit_operation(row: Mapping[str, Any]) -> str:
+    statement_type = _value(row, "stmt_type")
+    if isinstance(statement_type, str) and statement_type.strip():
+        return statement_type.strip().upper()
+    statement = _value(row, "stmt")
+    if not isinstance(statement, str):
+        return "UNKNOWN"
+    formatted = str(sqlparse.format(statement, strip_comments=True)).strip()
+    if not formatted:
+        return "UNKNOWN"
+    upper = formatted.upper()
+    if upper.startswith("INSERT OVERWRITE"):
+        return "INSERT_OVERWRITE"
+    if upper.startswith("CREATE TABLE") and re.search(
+        r"\bAS\s+SELECT\b",
+        upper,
+    ):
+        return "CTAS"
+    return formatted.split(None, 1)[0].upper()
+
+
+def _audit_referenced_objects(row: Mapping[str, Any]) -> tuple[str, ...]:
+    raw = _value(row, "queried_tables_and_views")
+    values: Sequence[Any] = ()
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = [item.strip() for item in raw.split(",") if item.strip()]
+        if isinstance(parsed, list):
+            values = parsed
+    elif isinstance(raw, Sequence) and not isinstance(raw, bytes):
+        values = raw
+    normalized = []
+    default_catalog = str(_value(row, "catalog") or "internal")
+    database = _value(row, "db")
+    for item in values:
+        if not isinstance(item, str):
+            continue
+        object_name = _normalize_sql_object(
+            item,
+            default_catalog=default_catalog,
+            default_database=(str(database) if database is not None else None),
+        )
+        if object_name is not None:
+            normalized.append(object_name)
+    if normalized:
+        return tuple(dict.fromkeys(normalized))
+
+    statement = _value(row, "stmt")
+    if not isinstance(statement, str):
+        return ()
+    clean = sqlparse.format(statement, strip_comments=True)
+    for match in _SOURCE_REFERENCE.finditer(clean):
+        object_name = _normalize_sql_object(
+            match.group(1),
+            default_catalog=default_catalog,
+            default_database=(str(database) if database is not None else None),
+        )
+        if object_name is not None:
+            normalized.append(object_name)
+    return tuple(dict.fromkeys(normalized))
+
+
+def _normalize_sql_object(
+    value: str,
+    *,
+    default_catalog: str,
+    default_database: str | None,
+) -> str | None:
+    cleaned = re.sub(r"\s+", "", value)
+    parts = [_strip_identifier(part) for part in cleaned.split(".")]
+    try:
+        validated = tuple(validate_identifier(part, "lineage object") for part in parts)
+    except SQLSecurityError:
+        return None
+    if len(validated) == 3:
+        return ".".join(validated)
+    if len(validated) == 2:
+        return f"{default_catalog}.{validated[0]}.{validated[1]}"
+    if len(validated) == 1 and default_database:
+        return f"{default_catalog}.{default_database}.{validated[0]}"
+    return None
+
+
+def _strip_identifier(value: str) -> str:
+    return value.strip().strip("`")
+
+
+def _principal_label(value: Any) -> str:
+    normalized = str(value or "unknown")
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:12]
+    return f"principal:{digest}"
+
+
+def _hour_bucket(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.replace(minute=0, second=0, microsecond=0).isoformat()
+    text = str(value or "")
+    return text[:13] + ":00:00" if len(text) >= 13 else "unknown"
+
+
+def _database_object_label(row: Mapping[str, Any]) -> str:
+    catalog = str(_value(row, "catalog") or "internal")
+    database = str(_value(row, "db") or "unknown")
+    return f"{catalog}.{database}.*"
+
+
+def _object_matches_table(
+    object_name: str,
+    database: str | None,
+    table: str,
+) -> bool:
+    parts = object_name.split(".")
+    if not parts or parts[-1].casefold() != table.casefold():
+        return False
+    return (
+        database is None
+        or len(parts) < 2
+        or parts[-2].casefold() == database.casefold()
+    )
+
+
+def _safe_url_type(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    parsed = urlsplit(value)
+    suffix = parsed.path.rsplit(".", 1)[-1].casefold()
+    return suffix if suffix in {"jar", "so", "py", "zip"} else None
+
+
+def _parse_properties(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return {str(key).casefold(): item for key, item in value.items()}
+    if not isinstance(value, str) or not value.strip():
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        parsed = None
+    if isinstance(parsed, Mapping):
+        return {str(key).casefold(): item for key, item in parsed.items()}
+    return {
+        key.casefold(): item
+        for key, item in re.findall(
+            r'["\']?([A-Za-z_][A-Za-z0-9_]*)["\']?\s*'
+            r'[:=]\s*["\']?([^,"\'}]+)',
+            value,
+        )
+    }
+
+
+def _udf_item(
+    row: Mapping[str, Any],
+    *,
+    scope: str,
+) -> dict[str, Any] | None:
+    signature = _value(row, "signature", "function_name", "name")
+    if not isinstance(signature, str) or not signature.strip():
+        return None
+    properties = _parse_properties(_value(row, "properties"))
+    declared_type = str(
+        properties.get("type") or _value(row, "function_type") or ""
+    ).upper()
+    object_type = _safe_url_type(
+        properties.get("object_file") or properties.get("file")
+    )
+    if "PYTHON" in declared_type or object_type == "py":
+        language = "python"
+    elif "JAVA" in declared_type or object_type == "jar":
+        language = "java"
+    elif object_type == "so":
+        language = "native"
+    elif str(_value(row, "function_type") or "").casefold() == "alias":
+        language = "sql_alias"
+    else:
+        language = "unknown"
+    name = signature.split("(", 1)[0].strip()
+    return {
+        "name": name,
+        "signature": signature,
+        "scope": scope,
+        "language": language,
+        "function_type": _value(row, "function_type"),
+        "return_type": _value(row, "return_type"),
+        "intermediate_type": _value(row, "intermediate_type"),
+        "runtime_version": properties.get("runtime_version"),
+        "volatility": properties.get("volatility"),
+        "always_nullable": properties.get("always_nullable"),
+        "status": "registered",
+    }
+
+
+def _matches_name_pattern(name: str, pattern: str) -> bool:
+    shell_pattern = pattern.replace("%", "*").replace("_", "?")
+    return fnmatch.fnmatchcase(name.casefold(), shell_pattern.casefold())
+
+
+def _safe_role_mapping(row: Mapping[str, Any]) -> dict[str, Any]:
+    principal = _role_mapping_principal(row)
+    roles = _csv_values(
+        _value(
+            row,
+            "roles",
+            "role_names",
+            "target_roles",
+            "role",
+        )
+    )
+    return {
+        "name": _value(
+            row,
+            "name",
+            "mapping_name",
+            "rule_name",
+            "id",
+        ),
+        "principal": (_principal_label(principal) if principal is not None else None),
+        "roles": roles,
+        "enabled": _value(row, "enabled", "is_enabled", "active"),
+        "status": _value(row, "status", "state") or "configured",
+        "rule_redacted": True,
+    }
+
+
+def _role_mapping_principal(row: Mapping[str, Any]) -> str | None:
+    value = _value(
+        row,
+        "principal",
+        "subject",
+        "user",
+        "username",
+        "claim_value",
+    )
+    return str(value) if value is not None else None
+
+
+def _listed_value_count(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+        return len(value)
+    text = str(value).strip()
+    if not text:
+        return 0
+    return len([item for item in text.split(",") if item.strip()])

--- a/test/integration/test_real_doris_transports.py
+++ b/test/integration/test_real_doris_transports.py
@@ -97,6 +97,16 @@ SEARCH_CHILD_NAMES = (
     "inspect_search_indexes",
     "diagnose_search_query",
 )
+GOVERNANCE_CHILD_NAMES = (
+    "analyze_columns",
+    "analyze_table_storage",
+    "get_lineage_capability_status",
+    "trace_column_lineage",
+    "analyze_data_access_patterns",
+    "get_recent_audit_logs",
+    "list_udfs",
+    "get_auth_mapping_status",
+)
 
 
 @dataclass(frozen=True)
@@ -1547,6 +1557,158 @@ async def test_real_doris_hierarchical_search_domain_is_read_only_and_live(
         cursor.execute(
             f"SELECT COUNT(*) FROM {doris_search_sandbox.qualified_table}"
         )
+        row_count_after = int(cursor.fetchone()[0])
+    assert row_count_after == row_count_before
+
+
+@pytest.mark.parametrize("transport", ["http", "stdio"])
+async def test_real_doris_hierarchical_governance_domain_is_read_only_and_live(
+    transport: str,
+    doris_sandbox: DorisSandbox,
+) -> None:
+    environment = _server_environment(
+        doris_sandbox.settings,
+        user=doris_sandbox.settings.user,
+        password=doris_sandbox.settings.password,
+    )
+    environment["MCP_TOOL_EXPOSURE_MODE"] = "hierarchical"
+    with doris_sandbox.admin_connection.cursor() as cursor:
+        cursor.execute(
+            f"INSERT INTO {doris_sandbox.qualified_table} VALUES (1, %s)",
+            (doris_sandbox.marker,),
+        )
+        cursor.execute(f"SELECT COUNT(*) FROM {doris_sandbox.qualified_table}")
+        row_count_before = int(cursor.fetchone()[0])
+
+    async with _transport_client(
+        transport,
+        environment,
+        read_timeout_seconds=60,
+    ) as client:
+        governance_result = await client.call_tool("doris_governance", {})
+        assert governance_result.is_error is False
+        assert isinstance(governance_result.structured_content, dict)
+        manifest = governance_result.structured_content
+        assert manifest["mode"] == "manifest"
+        assert manifest["domain"] == "doris_governance"
+        children = {child["name"]: child for child in manifest["children"]}
+        assert tuple(children) == GOVERNANCE_CHILD_NAMES
+        assert all(child["availability"]["callable"] for child in children.values())
+        manifest_version = manifest["manifest_version"]
+
+        columns = await _call_domain_child(
+            client,
+            domain="doris_governance",
+            child_tool="analyze_columns",
+            arguments={
+                "database": doris_sandbox.settings.database,
+                "table": doris_sandbox.table,
+                "columns": ["id", "marker"],
+                "sample_ratio": 0.1,
+            },
+            manifest_version=manifest_version,
+        )
+        assert [item["name"] for item in columns["data"]["columns"]] == [
+            "id",
+            "marker",
+        ]
+        assert columns["metadata"]["invented_statistics"] is False
+
+        storage = await _call_domain_child(
+            client,
+            domain="doris_governance",
+            child_tool="analyze_table_storage",
+            arguments={
+                "database": doris_sandbox.settings.database,
+                "table": doris_sandbox.table,
+                "include_partitions": True,
+                "include_indexes": True,
+            },
+            manifest_version=manifest_version,
+        )
+        assert storage["data"]["table"] == doris_sandbox.table
+        assert storage["metadata"]["raw_create_table_exposed"] is False
+
+        lineage_status = await _call_domain_child(
+            client,
+            domain="doris_governance",
+            child_tool="get_lineage_capability_status",
+            arguments={},
+            manifest_version=manifest_version,
+        )
+        assert lineage_status["data"]["active_path"] in {
+            "audit_sql_inference",
+            "doris_native_event_store",
+        }
+        assert lineage_status["metadata"]["invented_lineage_capability"] is False
+
+        lineage = await _call_domain_child(
+            client,
+            domain="doris_governance",
+            child_tool="trace_column_lineage",
+            arguments={
+                "object": (
+                    f"{doris_sandbox.settings.database}.{doris_sandbox.table}"
+                ),
+                "direction": "both",
+                "depth": 2,
+                "evidence_mode": "audit",
+            },
+            manifest_version=manifest_version,
+        )
+        assert lineage["metadata"]["invented_edges"] is False
+        assert "unknown_source" not in str(lineage)
+
+        access = await _call_domain_child(
+            client,
+            domain="doris_governance",
+            child_tool="analyze_data_access_patterns",
+            arguments={
+                "database": doris_sandbox.settings.database,
+                "table": doris_sandbox.table,
+                "window_days": 1,
+                "group_by": "operation",
+            },
+            manifest_version=manifest_version,
+        )
+        assert access["metadata"]["raw_sql_exposed"] is False
+
+        audit = await _call_domain_child(
+            client,
+            domain="doris_governance",
+            child_tool="get_recent_audit_logs",
+            arguments={
+                "window_minutes": 60,
+                "database": doris_sandbox.settings.database,
+                "limit": 20,
+            },
+            manifest_version=manifest_version,
+        )
+        assert audit["metadata"]["raw_sql_exposed"] is False
+        assert audit["metadata"]["client_address_exposed"] is False
+
+        udfs = await _call_domain_child(
+            client,
+            domain="doris_governance",
+            child_tool="list_udfs",
+            arguments={"database": doris_sandbox.settings.database},
+            manifest_version=manifest_version,
+        )
+        assert isinstance(udfs["data"]["items"], list)
+        assert udfs["metadata"]["code_executed"] is False
+
+        auth = await _call_domain_child(
+            client,
+            domain="doris_governance",
+            child_tool="get_auth_mapping_status",
+            arguments={"provider": "ldap", "include_roles": False},
+            manifest_version=manifest_version,
+        )
+        assert auth["data"]["secrets_exposed"] is False
+        assert auth["data"]["mapping_rules_exposed"] is False
+
+    with doris_sandbox.admin_connection.cursor() as cursor:
+        cursor.execute(f"SELECT COUNT(*) FROM {doris_sandbox.qualified_table}")
         row_count_after = int(cursor.fetchone()[0])
     assert row_count_after == row_count_before
 

--- a/test/protocol/test_multiworker_config.py
+++ b/test/protocol/test_multiworker_config.py
@@ -152,6 +152,70 @@ def test_capability_cache_controls_are_explicit_and_validated(
     assert "Capability stale grace must be in the range 0-86400 seconds" in errors
 
 
+def test_governance_runtime_controls_load_serialize_and_validate(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("GOVERNANCE_MAX_SAMPLE_RATIO", "0.15")
+    monkeypatch.setenv("GOVERNANCE_MAX_AUDIT_WINDOW_DAYS", "45")
+    monkeypatch.setenv("GOVERNANCE_MAX_LINEAGE_EDGES", "750")
+    monkeypatch.setenv(
+        "GOVERNANCE_LINEAGE_STORE_TABLE",
+        "governance.lineage_events",
+    )
+    monkeypatch.setenv("GOVERNANCE_LINEAGE_RECENT_EVENT_MINUTES", "180")
+
+    configured = DorisConfig.from_env()
+
+    assert configured.to_dict()["governance"] == {
+        "max_sample_ratio": 0.15,
+        "max_audit_window_days": 45,
+        "max_lineage_edges": 750,
+        "lineage_store_table": "governance.lineage_events",
+        "lineage_recent_event_minutes": 180,
+    }
+    assert configured.validate() == []
+
+    config_path = tmp_path / "doris-mcp.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "governance": {
+                    "max_sample_ratio": 0.2,
+                    "max_audit_window_days": 60,
+                    "max_lineage_edges": 900,
+                    "lineage_store_table": "metadata.lineage_events",
+                    "lineage_recent_event_minutes": 240,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    from_file = DorisConfig.from_file(str(config_path))
+    assert from_file.governance.max_sample_ratio == 0.2
+    assert from_file.governance.max_audit_window_days == 60
+    assert from_file.governance.max_lineage_edges == 900
+    assert from_file.governance.lineage_store_table == "metadata.lineage_events"
+    assert from_file.governance.lineage_recent_event_minutes == 240
+
+    from_file.governance.max_sample_ratio = 0
+    from_file.governance.max_audit_window_days = 366
+    from_file.governance.max_lineage_edges = 5001
+    from_file.governance.lineage_recent_event_minutes = 0
+    errors = from_file.validate()
+    assert (
+        "Governance maximum sample ratio must be in the range (0, 1]"
+        in errors
+    )
+    assert "Governance audit window must be in the range 1-365 days" in errors
+    assert "Governance lineage edge limit must be in the range 1-5000" in errors
+    assert (
+        "Governance recent lineage event window must be in the range "
+        "1-525600 minutes"
+        in errors
+    )
+
+
 def test_state_handle_secret_and_ttl_are_configurable_without_serializing_secret(
     monkeypatch,
 ):

--- a/test/tools/test_capability_detector.py
+++ b/test/tools/test_capability_detector.py
@@ -744,6 +744,111 @@ async def test_detector_uses_fallback_for_unknown_master_and_retains_follower() 
 
 
 @pytest.mark.asyncio
+async def test_governance_probes_keep_pre_406_audit_lineage_available() -> None:
+    connection = _ProbeConnection()
+    connection.row_overrides[
+        "SELECT TABLE_NAME, DATA_LENGTH "
+        "FROM information_schema.tables LIMIT 1"
+    ] = [{"TABLE_NAME": "orders", "DATA_LENGTH": 1024}]
+    connection.row_overrides[
+        "SELECT `time`, `query_id`, `stmt` "
+        "FROM internal.__internal_schema.audit_log LIMIT 1"
+    ] = [{"time": "2026-07-31", "query_id": "query-1", "stmt": "SELECT 1"}]
+    manager = _ProbeConnectionManager(connection)
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.governance",
+    )
+
+    governance = await detector.detect_domain(base, "doris_governance", None)
+
+    assert (
+        governance.probe("audit_lineage_provider_status_readable").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert (
+        governance.probe("all_fe_lineage_plugin_compatible").status
+        is CapabilityProbeStatus.UNSUPPORTED
+    )
+    assert (
+        governance.probe("lineage_store_readable").status
+        is CapabilityProbeStatus.MISCONFIGURED
+    )
+    assert (
+        governance.probe("storage_v3").status
+        is CapabilityProbeStatus.DEGRADED
+    )
+
+
+@pytest.mark.asyncio
+async def test_governance_probes_require_406_plugin_and_canonical_store_schema() -> None:
+    connection = _ProbeConnection()
+    version = "doris-4.0.6-43f06a5e26"
+    connection.row_overrides["SELECT @@version_comment;"] = [
+        {"@@version_comment": f"Doris version {version} (Cloud Mode)"}
+    ]
+    connection.row_overrides["SHOW FRONTENDS"] = [
+        {
+            "Name": "fe-1",
+            "Role": "FOLLOWER",
+            "IsMaster": "true",
+            "Version": version,
+        },
+        {
+            "Name": "fe-2",
+            "Role": "FOLLOWER",
+            "IsMaster": "false",
+            "Version": version,
+        },
+    ]
+    connection.row_overrides["SHOW BACKENDS"] = [
+        {"BackendId": "1", "Version": version}
+    ]
+    connection.row_overrides[
+        "SHOW FRONTEND CONFIG LIKE 'activate_lineage_plugin'"
+    ] = [{"Value": "mcp_lineage_sink"}]
+    connection.row_overrides[
+        "DESC `governance`.`lineage_events`"
+    ] = [
+        {"Field": name}
+        for name in (
+            "event_id",
+            "event_time",
+            "source_object",
+            "target_object",
+        )
+    ]
+    manager = _ProbeConnectionManager(connection)
+    manager.config.governance = SimpleNamespace(
+        lineage_store_table="governance.lineage_events"
+    )
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.governance",
+    )
+
+    governance = await detector.detect_domain(base, "doris_governance", None)
+
+    assert (
+        governance.probe("all_fe_lineage_plugin_compatible").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert (
+        governance.probe("lineage_store_readable").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    assert (
+        governance.probe("all_fe_lineage_plugin_compatible").reason_code
+        == "LINEAGE_SPI_AND_PLUGIN_CONFIG_OBSERVED"
+    )
+    assert "DESC `governance`.`lineage_events`" in connection.statements
+
+
+@pytest.mark.asyncio
 async def test_detector_rejects_route_change_before_domain_probe() -> None:
     connection = _ProbeConnection()
     manager = _ProbeConnectionManager(connection)

--- a/test/tools/test_capability_registry.py
+++ b/test/tools/test_capability_registry.py
@@ -361,6 +361,43 @@ def test_adbc_provider_requires_configuration_and_bound_consumer(
     )
 
 
+@pytest.mark.parametrize(
+    ("store_table", "bound", "expected_status"),
+    [
+        ("", True, CapabilityProbeStatus.MISCONFIGURED),
+        ("governance.lineage_events", False, CapabilityProbeStatus.MISCONFIGURED),
+        ("governance.lineage_events", True, CapabilityProbeStatus.SUPPORTED),
+    ],
+)
+def test_lineage_store_provider_requires_configuration_and_bound_consumer(
+    store_table: str,
+    bound: bool,
+    expected_status: CapabilityProbeStatus,
+) -> None:
+    handlers = (
+        _BoundHandlers("doris_governance.trace_column_lineage")
+        if bound
+        else _BoundHandlers()
+    )
+    registry = CapabilityProviderRegistry.from_runtime(
+        matrix=DORIS_FEATURE_MATRIX,
+        bound_handlers=handlers,  # type: ignore[arg-type]
+        config=SimpleNamespace(
+            adbc=SimpleNamespace(enabled=False),
+            governance=SimpleNamespace(lineage_store_table=store_table),
+        ),
+    )
+
+    provider = registry.snapshot().providers["lineage_event_store"]
+
+    assert provider.status is expected_status
+    assert provider.reason_code == (
+        "PROVIDER_CONFIGURED"
+        if expected_status is CapabilityProbeStatus.SUPPORTED
+        else "PROVIDER_NOT_CONFIGURED"
+    )
+
+
 def test_builtin_query_evidence_providers_are_ready_when_bound() -> None:
     handlers = _BoundHandlers(
         "doris_query.diagnose_query_performance",

--- a/test/tools/test_domain_dispatcher.py
+++ b/test/tools/test_domain_dispatcher.py
@@ -52,6 +52,7 @@ from doris_mcp_server.tools.domain_models import (
 )
 from doris_mcp_server.tools.tools_manager import DorisToolsManager
 from doris_mcp_server.utils.config import DorisConfig
+from doris_mcp_server.utils.governance_runtime import GovernanceRuntimeFailure
 from doris_mcp_server.utils.query_runtime import QueryRuntimeFailure
 from doris_mcp_server.utils.security import AuthContext
 
@@ -148,6 +149,47 @@ def test_cluster_domain_binds_all_eleven_children() -> None:
         bound.is_bound(cluster.name, child.name)
         for child in cluster.children
     )
+
+
+def test_governance_domain_binds_all_eight_children() -> None:
+    manager = _manager()
+    bound = BoundHandlerAvailabilityProvider(manager)
+    governance = DORIS_DOMAIN_CATALOG.resolve_domain("doris_governance")
+
+    assert len(governance.children) == 8
+    assert all(
+        bound.is_bound(governance.name, child.name)
+        for child in governance.children
+    )
+
+
+@pytest.mark.asyncio
+async def test_governance_failures_keep_stable_reason_codes() -> None:
+    manager = _manager("doris_governance.analyze_columns")
+    manager.governance_runtime.analyze_columns = AsyncMock(
+        side_effect=GovernanceRuntimeFailure(
+            "The requested Doris table is unavailable.",
+            reason_code="GOVERNANCE_TABLE_NOT_FOUND",
+            status_code=404,
+        )
+    )
+
+    result = await manager.domain_dispatcher.call_domain(
+        "doris_governance",
+        {
+            "child_tool": "analyze_columns",
+            "arguments": {
+                "database": "analytics",
+                "table": "missing",
+            },
+        },
+        None,
+    )
+
+    assert result.mode == "error"
+    assert result.error.code is DomainErrorCode.CHILD_ARGUMENTS_INVALID
+    assert result.error.details["reason_code"] == "GOVERNANCE_TABLE_NOT_FOUND"
+    assert result.error.details["status_code"] == 404
 
 
 @pytest.mark.asyncio

--- a/test/tools/test_governance_handlers.py
+++ b/test/tools/test_governance_handlers.py
@@ -1,0 +1,194 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Exact argument-routing contracts for the formal Governance handlers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from doris_mcp_server.tools.governance_handlers import (
+    GovernanceToolHandlersMixin,
+)
+
+
+class _Harness(GovernanceToolHandlersMixin):
+    def __init__(self) -> None:
+        self.governance_runtime = SimpleNamespace(
+            analyze_columns=AsyncMock(return_value={"status": "success"}),
+            analyze_table_storage=AsyncMock(return_value={"status": "success"}),
+            get_lineage_capability_status=AsyncMock(
+                return_value={"status": "success"}
+            ),
+            trace_column_lineage=AsyncMock(return_value={"status": "success"}),
+            analyze_data_access_patterns=AsyncMock(
+                return_value={"status": "success"}
+            ),
+            get_recent_audit_logs=AsyncMock(return_value={"status": "success"}),
+            list_udfs=AsyncMock(return_value={"status": "success"}),
+            get_auth_mapping_status=AsyncMock(
+                return_value={"status": "success"}
+            ),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_name", "runtime_name", "arguments", "expected"),
+    [
+        (
+            "_formal_doris_governance_analyze_columns_tool",
+            "analyze_columns",
+            {
+                "database": "analytics",
+                "table": "orders",
+                "columns": ["id"],
+                "sample_ratio": 0.1,
+            },
+            {
+                "database": "analytics",
+                "table": "orders",
+                "columns": ["id"],
+                "sample_ratio": 0.1,
+            },
+        ),
+        (
+            "_formal_doris_governance_analyze_table_storage_tool",
+            "analyze_table_storage",
+            {
+                "database": "analytics",
+                "table": "orders",
+                "include_partitions": True,
+                "include_indexes": True,
+            },
+            {
+                "database": "analytics",
+                "table": "orders",
+                "include_partitions": True,
+                "include_indexes": True,
+            },
+        ),
+        (
+            "_formal_doris_governance_get_lineage_capability_status_tool",
+            "get_lineage_capability_status",
+            {},
+            {},
+        ),
+        (
+            "_formal_doris_governance_trace_column_lineage_tool",
+            "trace_column_lineage",
+            {
+                "object": "analytics.orders",
+                "column": "id",
+                "direction": "upstream",
+                "depth": 2,
+                "evidence_mode": "native",
+            },
+            {
+                "object_name": "analytics.orders",
+                "column": "id",
+                "direction": "upstream",
+                "depth": 2,
+                "evidence_mode": "native",
+            },
+        ),
+        (
+            "_formal_doris_governance_analyze_data_access_patterns_tool",
+            "analyze_data_access_patterns",
+            {
+                "database": "analytics",
+                "table": "orders",
+                "window_days": 7,
+                "group_by": "operation",
+            },
+            {
+                "database": "analytics",
+                "table": "orders",
+                "window_days": 7,
+                "group_by": "operation",
+            },
+        ),
+        (
+            "_formal_doris_governance_get_recent_audit_logs_tool",
+            "get_recent_audit_logs",
+            {
+                "window_minutes": 60,
+                "user": "alice",
+                "operation": "SELECT",
+                "database": "analytics",
+                "table": "orders",
+                "limit": 20,
+            },
+            {
+                "window_minutes": 60,
+                "user": "alice",
+                "operation": "SELECT",
+                "database": "analytics",
+                "table": "orders",
+                "limit": 20,
+            },
+        ),
+        (
+            "_formal_doris_governance_list_udfs_tool",
+            "list_udfs",
+            {
+                "database": "analytics",
+                "language": "java",
+                "name_pattern": "normalize%",
+            },
+            {
+                "database": "analytics",
+                "language": "java",
+                "name_pattern": "normalize%",
+            },
+        ),
+        (
+            "_formal_doris_governance_get_auth_mapping_status_tool",
+            "get_auth_mapping_status",
+            {
+                "principal": "alice",
+                "provider": "oidc",
+                "include_roles": True,
+            },
+            {
+                "principal": "alice",
+                "provider": "oidc",
+                "include_roles": True,
+            },
+        ),
+    ],
+)
+async def test_governance_handlers_forward_exact_arguments(
+    handler_name: str,
+    runtime_name: str,
+    arguments: dict[str, Any],
+    expected: dict[str, Any],
+) -> None:
+    harness = _Harness()
+
+    result = await getattr(harness, handler_name)(arguments)
+
+    assert result == {"status": "success"}
+    runtime_method = getattr(harness.governance_runtime, runtime_name)
+    if expected:
+        runtime_method.assert_awaited_once_with(**expected)
+    else:
+        runtime_method.assert_awaited_once_with()

--- a/test/utils/test_governance_runtime.py
+++ b/test/utils/test_governance_runtime.py
@@ -1,0 +1,786 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Production evidence contracts for the formal Governance runtime."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from doris_mcp_server.utils.governance_runtime import (
+    DorisGovernanceRuntime,
+    DorisLineageStoreProvider,
+    GovernanceRuntimeFailure,
+    LineageProviderStatus,
+)
+
+_Params = Mapping[str, Any] | tuple[Any, ...] | None
+_Responder = Callable[[str, _Params], list[dict[str, Any]]]
+
+
+class _ConnectionManager:
+    def __init__(
+        self,
+        responder: _Responder,
+        *,
+        governance: Any | None = None,
+    ) -> None:
+        self._responder = responder
+        self.calls: list[str] = []
+        self.params: list[_Params] = []
+        self.context_count = 0
+        self.config = SimpleNamespace(
+            governance=governance
+            or SimpleNamespace(
+                max_sample_ratio=0.25,
+                max_audit_window_days=30,
+                max_lineage_edges=500,
+                lineage_store_table="",
+                lineage_recent_event_minutes=1440,
+            )
+        )
+
+    @asynccontextmanager
+    async def get_connection_context_for_auth_context(
+        self,
+        _session_id: str,
+        _auth_context: Any,
+    ) -> AsyncIterator[Any]:
+        self.context_count += 1
+        manager = self
+
+        class _Connection:
+            async def execute(
+                self,
+                sql: str,
+                params: _Params = None,
+                **_kwargs: Any,
+            ) -> SimpleNamespace:
+                manager.calls.append(sql)
+                manager.params.append(params)
+                return SimpleNamespace(data=manager._responder(sql, params))
+
+        yield _Connection()
+
+
+def _runtime(
+    responder: _Responder,
+    *,
+    governance: Any | None = None,
+    lineage_provider: Any | None = None,
+) -> tuple[DorisGovernanceRuntime, _ConnectionManager]:
+    manager = _ConnectionManager(responder, governance=governance)
+    runtime = DorisGovernanceRuntime(
+        manager,  # type: ignore[arg-type]
+        lineage_provider=lineage_provider,
+    )
+    return runtime, manager
+
+
+def _lineage_responder(
+    sql: str,
+    _params: _Params,
+    *,
+    version: str,
+    plugin: str = "",
+    audit_available: bool = True,
+) -> list[dict[str, Any]]:
+    if sql == "SELECT @@version_comment;":
+        return [{"version_comment": version}]
+    if sql == "SHOW FRONTENDS":
+        return [{"Version": version}]
+    if sql == "SHOW FRONTEND CONFIG LIKE 'activate_lineage_plugin'":
+        return [{"Value": plugin}] if plugin else []
+    if sql == "SHOW FRONTEND CONFIG LIKE 'lineage_event_queue_size'":
+        return [{"Value": "1000"}] if plugin else []
+    if sql.startswith("SELECT `time`, `query_id` FROM"):
+        if not audit_available:
+            raise RuntimeError(1146, "audit metadata unavailable")
+        return [{"time": "2026-07-31 10:00:00", "query_id": "audit-1"}]
+    return []
+
+
+@pytest.mark.asyncio
+async def test_column_analysis_uses_recorded_stats_and_clamps_live_sampling() -> None:
+    def responder(sql: str, _params: _Params) -> list[dict[str, Any]]:
+        if "FROM information_schema.columns" in sql:
+            return [
+                {
+                    "COLUMN_NAME": "id",
+                    "DATA_TYPE": "BIGINT",
+                    "IS_NULLABLE": "NO",
+                    "ORDINAL_POSITION": 1,
+                },
+                {
+                    "COLUMN_NAME": "email",
+                    "DATA_TYPE": "VARCHAR",
+                    "IS_NULLABLE": "YES",
+                    "ORDINAL_POSITION": 2,
+                },
+            ]
+        if sql.startswith("SHOW COLUMN STATS"):
+            return [
+                {
+                    "column_name": "id",
+                    "count": 100,
+                    "ndv": 100,
+                    "num_null": 0,
+                    "data_size": 800,
+                },
+                {
+                    "column_name": "email",
+                    "count": 100,
+                    "ndv": 80,
+                    "num_null": 10,
+                    "data_size": 1200,
+                },
+            ]
+        if "TABLESAMPLE 25 PERCENT REPEATABLE 1" in sql:
+            return [
+                {
+                    "sample_rows": 25,
+                    "c0_non_null": 25,
+                    "c0_ndv": 25,
+                    "c1_non_null": 20,
+                    "c1_ndv": 18,
+                }
+            ]
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    runtime, manager = _runtime(responder)
+    result = await runtime.analyze_columns(
+        database="analytics",
+        table="customers",
+        columns=None,
+        sample_ratio=0.9,
+    )
+
+    assert result["status"] == "partial"
+    assert result["data"]["sample_ratio_requested"] == 0.9
+    assert result["data"]["sample_ratio_applied"] == 0.25
+    assert result["data"]["columns"][1]["statistics"]["null_ratio"] == 0.1
+    assert result["data"]["columns"][1]["sample"]["null_ratio"] == 0.2
+    assert any("configured Governance ceiling" in item for item in result["warnings"])
+    assert manager.params[0] == ("analytics", "customers")
+    assert any("TABLESAMPLE 25 PERCENT" in sql for sql in manager.calls)
+
+
+@pytest.mark.asyncio
+async def test_column_analysis_rejects_identifier_injection_before_sql() -> None:
+    runtime, manager = _runtime(lambda _sql, _params: [])
+
+    with pytest.raises(GovernanceRuntimeFailure) as failure:
+        await runtime.analyze_columns(
+            database="analytics",
+            table="orders; DROP TABLE users",
+            columns=None,
+            sample_ratio=None,
+        )
+
+    assert failure.value.reason_code == "GOVERNANCE_ARGUMENT_INVALID"
+    assert manager.calls == []
+
+
+@pytest.mark.asyncio
+async def test_storage_analysis_keeps_optional_failures_and_raw_ddl_private() -> None:
+    def responder(sql: str, _params: _Params) -> list[dict[str, Any]]:
+        if "FROM information_schema.tables" in sql:
+            return [
+                {
+                    "TABLE_TYPE": "BASE TABLE",
+                    "ENGINE": "OLAP",
+                    "TABLE_ROWS": 120,
+                    "DATA_LENGTH": 4096,
+                }
+            ]
+        if sql.startswith("SHOW TABLE STATS"):
+            raise RuntimeError(1105, "table stats disabled")
+        if sql.startswith("SHOW CREATE TABLE"):
+            return [
+                {
+                    "Create Table": (
+                        "CREATE TABLE orders (id BIGINT) PROPERTIES ("
+                        '"compression"="zstd",'
+                        '"password"="do-not-return",'
+                        '"enable_unique_key_merge_on_write"="true")'
+                    )
+                }
+            ]
+        if sql.startswith("SHOW PARTITIONS"):
+            return [
+                {
+                    "PartitionName": "p202607",
+                    "State": "NORMAL",
+                    "VisibleVersion": 7,
+                    "ReplicationNum": 3,
+                }
+            ]
+        if sql.startswith("SHOW INDEX"):
+            return [
+                {
+                    "Key_name": "idx_message",
+                    "Column_name": "message",
+                    "Index_type": "INVERTED",
+                }
+            ]
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    runtime, _ = _runtime(responder)
+    result = await runtime.analyze_table_storage(
+        database="analytics",
+        table="orders",
+        include_partitions=True,
+        include_indexes=True,
+    )
+
+    assert result["status"] == "partial"
+    assert result["data"]["properties"]["compression"] == "zstd"
+    assert result["data"]["features"]["merge_on_write"] == "true"
+    assert result["data"]["partitions"][0]["name"] == "p202607"
+    assert result["data"]["indexes"][0]["type"] == "INVERTED"
+    serialized = str(result)
+    assert "do-not-return" not in serialized
+    assert "CREATE TABLE orders" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_lineage_before_406_uses_audit_as_primary_path() -> None:
+    runtime, _ = _runtime(
+        lambda sql, params: _lineage_responder(
+            sql,
+            params,
+            version="Doris version doris-4.0.5-rc01",
+        )
+    )
+
+    result = await runtime.get_lineage_capability_status()
+
+    assert result["data"]["status"] == "available"
+    assert result["data"]["active_path"] == "audit_sql_inference"
+    assert result["data"]["native_spi"]["all_frontends_eligible"] is False
+
+
+@pytest.mark.asyncio
+async def test_lineage_406_without_plugin_uses_explicit_degraded_audit_fallback() -> (
+    None
+):
+    runtime, _ = _runtime(
+        lambda sql, params: _lineage_responder(
+            sql,
+            params,
+            version="Doris version doris-4.0.6-43f06a5e26 (Cloud Mode)",
+        )
+    )
+
+    result = await runtime.get_lineage_capability_status()
+
+    assert result["status"] == "partial"
+    assert result["data"]["status"] == "degraded"
+    assert result["data"]["active_path"] == "audit_sql_inference"
+    assert result["data"]["native_spi"]["all_frontends_eligible"] is True
+
+
+@pytest.mark.asyncio
+async def test_explicit_native_lineage_fails_when_native_path_is_unavailable() -> None:
+    runtime, _ = _runtime(
+        lambda sql, params: _lineage_responder(
+            sql,
+            params,
+            version="Doris version doris-4.0.6-43f06a5e26",
+        )
+    )
+
+    with pytest.raises(GovernanceRuntimeFailure) as failure:
+        await runtime.trace_column_lineage(
+            object_name="analytics.orders",
+            column=None,
+            direction="upstream",
+            depth=1,
+            evidence_mode="native",
+        )
+
+    assert failure.value.reason_code == "GOVERNANCE_NATIVE_LINEAGE_UNAVAILABLE"
+
+
+class _NativeProvider:
+    def __init__(self) -> None:
+        self.trace_calls: list[dict[str, Any]] = []
+
+    async def status(self) -> LineageProviderStatus:
+        return LineageProviderStatus(
+            provider_id="doris_native_event_store",
+            status="available",
+            queryable=True,
+            row_count=12,
+            latest_event_time="2026-07-31 10:00:00",
+            recent_event_observed=True,
+        )
+
+    async def trace(self, **kwargs: Any) -> dict[str, Any]:
+        self.trace_calls.append(kwargs)
+        return {
+            "edges": [
+                {
+                    "source_object": "internal.analytics.raw_orders",
+                    "source_column": "id",
+                    "target_object": "internal.analytics.orders",
+                    "target_column": "id",
+                    "evidence_type": "native_event",
+                    "source_event_id": "native-1",
+                    "limitations": [],
+                }
+            ],
+            "rows_observed": 1,
+            "truncated": False,
+            "limitations": [],
+        }
+
+
+@pytest.mark.asyncio
+async def test_native_lineage_provider_is_selected_deterministically() -> None:
+    provider = _NativeProvider()
+    runtime, _ = _runtime(
+        lambda sql, params: _lineage_responder(
+            sql,
+            params,
+            version="Doris version doris-4.1.2-43f06a5e26 (Cloud Mode)",
+            plugin="mcp_lineage_sink",
+        ),
+        lineage_provider=provider,
+    )
+
+    result = await runtime.trace_column_lineage(
+        object_name="analytics.orders",
+        column="id",
+        direction="upstream",
+        depth=2,
+        evidence_mode="auto",
+    )
+
+    assert result["data"]["active_path"] == "doris_native_event_store"
+    assert result["data"]["edges"][0]["source_event_id"] == "native-1"
+    assert provider.trace_calls == [
+        {
+            "object_name": "internal.analytics.orders",
+            "column": "id",
+            "direction": "upstream",
+            "depth": 2,
+            "max_edges": 500,
+        }
+    ]
+    assert result["metadata"]["numeric_confidence_emitted"] is False
+    assert "confidence" not in result["data"]["edges"][0]
+
+
+def _audit_schema() -> list[dict[str, Any]]:
+    return [
+        {"Field": field}
+        for field in (
+            "query_id",
+            "time",
+            "user",
+            "catalog",
+            "db",
+            "state",
+            "error_code",
+            "query_time",
+            "scan_bytes",
+            "scan_rows",
+            "return_rows",
+            "stmt_type",
+            "queried_tables_and_views",
+            "stmt",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_audit_lineage_emits_only_simple_direct_column_evidence() -> None:
+    statement = (
+        "INSERT INTO analytics.orders (id, amount) "
+        "SELECT id, amount FROM analytics.raw_orders"
+    )
+
+    def responder(sql: str, params: _Params) -> list[dict[str, Any]]:
+        base = _lineage_responder(
+            sql,
+            params,
+            version="Doris version doris-4.0.5",
+        )
+        if base:
+            return base
+        if sql == "DESC internal.__internal_schema.audit_log":
+            return _audit_schema()
+        if "WHERE `time` >= DATE_SUB" in sql:
+            return [
+                {
+                    "query_id": "audit-insert-1",
+                    "time": "2026-07-31 09:00:00",
+                    "user": "alice",
+                    "catalog": "internal",
+                    "db": "analytics",
+                    "state": "OK",
+                    "error_code": 0,
+                    "stmt_type": "INSERT",
+                    "stmt": statement,
+                },
+                {
+                    "query_id": "audit-select-1",
+                    "time": "2026-07-31 08:00:00",
+                    "state": "OK",
+                    "stmt_type": "SELECT",
+                    "stmt": "SELECT id FROM analytics.raw_orders",
+                },
+            ]
+        return []
+
+    runtime, _ = _runtime(responder)
+    result = await runtime.trace_column_lineage(
+        object_name="analytics.orders",
+        column="amount",
+        direction="upstream",
+        depth=3,
+        evidence_mode="audit",
+    )
+
+    assert result["data"]["edge_count"] == 1
+    edge = result["data"]["edges"][0]
+    assert edge["source_object"] == "internal.analytics.raw_orders"
+    assert edge["source_column"] == "amount"
+    assert edge["target_object"] == "internal.analytics.orders"
+    assert edge["target_column"] == "amount"
+    assert edge["evidence_type"] == "audit_sql_inference"
+    assert result["metadata"]["numeric_confidence_emitted"] is False
+    assert "confidence" not in edge
+
+
+@pytest.mark.asyncio
+async def test_audit_lineage_returns_no_placeholder_when_evidence_has_no_edge() -> None:
+    def responder(sql: str, params: _Params) -> list[dict[str, Any]]:
+        base = _lineage_responder(
+            sql,
+            params,
+            version="Doris version doris-4.0.5",
+        )
+        if base:
+            return base
+        if sql == "DESC internal.__internal_schema.audit_log":
+            return _audit_schema()
+        if "WHERE `time` >= DATE_SUB" in sql:
+            return [
+                {
+                    "query_id": "audit-select-1",
+                    "time": "2026-07-31 08:00:00",
+                    "state": "OK",
+                    "stmt_type": "SELECT",
+                    "stmt": "SELECT id FROM analytics.raw_orders",
+                }
+            ]
+        return []
+
+    runtime, _ = _runtime(responder)
+    result = await runtime.trace_column_lineage(
+        object_name="analytics.orders",
+        column=None,
+        direction="both",
+        depth=3,
+        evidence_mode="auto",
+    )
+
+    assert result["data"]["edges"] == []
+    assert result["data"]["determinate"] is False
+    assert "unknown_source" not in str(result)
+    assert any("no placeholder edge" in item for item in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_recent_audit_logs_are_bounded_and_redacted() -> None:
+    def responder(sql: str, _params: _Params) -> list[dict[str, Any]]:
+        if sql == "DESC internal.__internal_schema.audit_log":
+            return _audit_schema()
+        if "WHERE `time` >= DATE_SUB" in sql:
+            return [
+                {
+                    "query_id": "query-1",
+                    "time": "2026-07-31 08:00:00",
+                    "user": "alice@example.com",
+                    "catalog": "internal",
+                    "db": "analytics",
+                    "state": "FAILED",
+                    "error_code": 1105,
+                    "stmt_type": "SELECT",
+                    "stmt": "SELECT * FROM secret_table WHERE password='secret'",
+                    "queried_tables_and_views": '["analytics.orders"]',
+                    "client_ip": "10.0.0.8",
+                    "error_message": "password=secret",
+                }
+            ]
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    runtime, manager = _runtime(responder)
+    result = await runtime.get_recent_audit_logs(
+        window_minutes=60,
+        user=None,
+        operation=None,
+        database=None,
+        table=None,
+        limit=10,
+    )
+
+    item = result["data"]["items"][0]
+    assert item["principal"].startswith("principal:")
+    assert item["referenced_objects"] == ("internal.analytics.orders",)
+    serialized = str(result)
+    assert "alice@example.com" not in serialized
+    assert "password='secret'" not in serialized
+    assert "10.0.0.8" not in serialized
+    assert manager.params[-1] == (60,)
+
+
+@pytest.mark.asyncio
+async def test_access_patterns_pseudonymize_principals() -> None:
+    def responder(sql: str, _params: _Params) -> list[dict[str, Any]]:
+        if sql == "DESC internal.__internal_schema.audit_log":
+            return _audit_schema()
+        if "WHERE `time` >= DATE_SUB" in sql:
+            return [
+                {
+                    "query_id": "query-1",
+                    "time": "2026-07-31 08:00:00",
+                    "user": "alice",
+                    "state": "OK",
+                    "error_code": 0,
+                    "query_time": 12,
+                    "scan_bytes": 100,
+                    "scan_rows": 10,
+                    "return_rows": 2,
+                    "stmt_type": "SELECT",
+                    "queried_tables_and_views": '["analytics.orders"]',
+                }
+            ]
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    runtime, _ = _runtime(responder)
+    result = await runtime.analyze_data_access_patterns(
+        database=None,
+        table=None,
+        window_days=1,
+        group_by="user",
+    )
+
+    assert result["data"]["items"][0]["group"].startswith("principal:")
+    assert "alice" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_udf_listing_does_not_expose_object_location() -> None:
+    def responder(sql: str, _params: _Params) -> list[dict[str, Any]]:
+        if sql == "SHOW FULL FUNCTIONS IN `analytics`":
+            return [
+                {
+                    "Signature": "normalize_email(VARCHAR)",
+                    "Function Type": "SCALAR",
+                    "Return Type": "VARCHAR",
+                    "Properties": (
+                        '{"type":"JAVA_UDF","object_file":'
+                        '"s3://private-bucket/udf.jar?token=secret",'
+                        '"runtime_version":"17"}'
+                    ),
+                }
+            ]
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    runtime, _ = _runtime(responder)
+    result = await runtime.list_udfs(
+        database="analytics",
+        language="java",
+        name_pattern="normalize%",
+    )
+
+    assert result["data"]["items"][0]["language"] == "java"
+    assert result["data"]["items"][0]["runtime_version"] == "17"
+    serialized = str(result)
+    assert "private-bucket" not in serialized
+    assert "token=secret" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_auth_mapping_status_redacts_rules_secrets_and_principals() -> None:
+    def responder(sql: str, _params: _Params) -> list[dict[str, Any]]:
+        if sql == "SELECT * FROM information_schema.role_mappings LIMIT 500":
+            return [
+                {
+                    "mapping_name": "engineering",
+                    "claim_value": "alice@example.com",
+                    "roles": "analyst,reader",
+                    "enabled": True,
+                    "rule": "groups contains secret-admin",
+                    "client_secret": "do-not-return",
+                }
+            ]
+        if sql == "SHOW ROLES":
+            return [{"Role": "analyst", "Users": "alice,bob"}]
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    runtime, _ = _runtime(responder)
+    result = await runtime.get_auth_mapping_status(
+        principal=None,
+        provider="oidc",
+        include_roles=True,
+    )
+
+    mapping = result["data"]["providers"][0]["mappings"][0]
+    assert mapping["principal"].startswith("principal:")
+    assert mapping["roles"] == ["analyst", "reader"]
+    assert mapping["rule_redacted"] is True
+    serialized = str(result)
+    assert "alice@example.com" not in serialized
+    assert "secret-admin" not in serialized
+    assert "do-not-return" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_ldap_mapping_status_exposes_only_safe_configuration_facets() -> None:
+    values = {
+        "authentication_type": "ldap",
+        "ldap_authentication_enabled": "true",
+        "ldap_use_ssl": "true",
+        "ldap_default_roles": "reader,analyst",
+    }
+
+    def responder(sql: str, _params: _Params) -> list[dict[str, Any]]:
+        for name, value in values.items():
+            if sql == f"SHOW FRONTEND CONFIG LIKE '{name}'":
+                return [
+                    {
+                        "Value": value,
+                        "Password": "ldap-bind-secret",
+                        "Host": "ldap.private.example",
+                    }
+                ]
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    runtime, _ = _runtime(responder)
+    result = await runtime.get_auth_mapping_status(
+        principal=None,
+        provider="ldap",
+        include_roles=False,
+    )
+
+    provider = result["data"]["providers"][0]
+    assert provider["status"] == "configured"
+    assert provider["tls_enabled"] is True
+    assert provider["default_roles"] == ["reader", "analyst"]
+    serialized = str(result)
+    assert "ldap-bind-secret" not in serialized
+    assert "ldap.private.example" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_lineage_store_validates_schema_and_preserves_parameter_order() -> None:
+    observed_params: list[_Params] = []
+
+    def responder(sql: str, params: _Params) -> list[dict[str, Any]]:
+        observed_params.append(params)
+        if sql == "DESC `governance`.`lineage_events`":
+            return [
+                {"Field": name}
+                for name in (
+                    "event_id",
+                    "event_time",
+                    "source_object",
+                    "target_object",
+                    "source_column",
+                    "target_column",
+                    "query_id",
+                )
+            ]
+        if sql.startswith("SELECT COUNT(*) AS row_count"):
+            return [
+                {
+                    "row_count": 1,
+                    "latest_event_time": "2026-07-31 08:00:00",
+                    "recent_event_count": 1,
+                }
+            ]
+        if sql.startswith("SELECT `event_id`"):
+            return [
+                {
+                    "event_id": "event-1",
+                    "event_time": "2026-07-31 08:00:00",
+                    "source_object": "internal.analytics.raw_orders",
+                    "target_object": "internal.analytics.orders",
+                    "source_column": "id",
+                    "target_column": "id",
+                    "query_id": "query-1",
+                }
+            ]
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    manager = _ConnectionManager(responder)
+    provider = DorisLineageStoreProvider(
+        manager,  # type: ignore[arg-type]
+        table="governance.lineage_events",
+        recent_event_minutes=120,
+    )
+    result = await provider.trace(
+        object_name="internal.analytics.orders",
+        column="id",
+        direction="both",
+        depth=1,
+        max_edges=10,
+    )
+
+    assert result["edges"][0]["evidence_type"] == "native_event"
+    assert observed_params[1] == (120,)
+    assert observed_params[2] == (
+        "internal.analytics.orders",
+        "internal.analytics.orders",
+        "id",
+        "id",
+    )
+
+
+@pytest.mark.asyncio
+async def test_lineage_store_rejects_noncanonical_schema() -> None:
+    manager = _ConnectionManager(
+        lambda sql, _params: (
+            [
+                {"Field": "event_id"},
+                {"Field": "event_time"},
+                {"Field": "target_object"},
+            ]
+            if sql == "DESC `governance`.`lineage_events`"
+            else []
+        )
+    )
+    provider = DorisLineageStoreProvider(
+        manager,  # type: ignore[arg-type]
+        table="governance.lineage_events",
+        recent_event_minutes=120,
+    )
+
+    status = await provider.status()
+
+    assert status.status == "misconfigured"
+    assert status.queryable is False
+    assert "source_object" in status.limitations[0]


### PR DESCRIPTION
## Summary

- implement all eight read-only `doris_governance` children through the shared domain manifest, dispatcher, handlers, and a bounded Governance runtime
- add route-aware capability probes for column statistics, table storage, audit metadata, UDFs, authentication mappings, and native lineage prerequisites
- select lineage providers deterministically from Doris version, companion-plugin configuration, canonical queryable-store schema, and audit availability
- add Governance configuration limits, stable error mapping, redaction, focused unit coverage, real transport coverage, and the corresponding `CHANGELOG.md` entries

## Lineage behavior

- Doris versions before 4.0.6 use conservative audit SQL inference as the primary available provider
- Doris 4.0.6 and later prefer attributable native events only when the companion plugin and canonical queryable store are both observable
- missing plugin/store evidence falls back explicitly to degraded audit inference
- the runtime never emits placeholder sources, invented edges, or numeric confidence scores

## Safety and compatibility

- all identifiers are validated and quoted before reaching SQL sinks
- values remain driver-bound where Doris syntax permits binding
- sampling, audit windows, traversal depth, lineage edges, and result collections are hard-bounded
- raw SQL, client addresses, authentication rules, secrets, and internal errors are redacted from model-facing output
- both Streamable HTTP and stdio expose the same eight-child Governance manifest and dispatch behavior

## Validation

- `uv lock --check`
- `uv run ruff check .`
- `uv run mypy doris_mcp_server`
- configured Bandit source gate and SQL sink audit: 21 passed
- `uv run pytest -q -W error`: 1657 passed, 77 skipped; total coverage 65.69%
- domain coverage: protocol 90.34%, authentication 81.53%, core managers 85.32%
- Governance runtime coverage 80%; Governance handlers coverage 100%
- `uv build` plus clean Python 3.12 wheel installation and CLI/runtime dependency smoke
- real Doris Streamable HTTP and stdio exercise of the manifest and all eight Governance children: 2 passed, 18 deselected; target row count unchanged and the ephemeral test account removed
