### PR TITLE
feat: enforce Host exposure budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ under **Unreleased** until a new version is selected and published.
   OAuth scope issuance on explicit channel opt-in plus `semantic:read`.
 - Rejected 1.0 configuration attempts to enable the reserved administration
   domain or disable its mandatory confirmation invariant.
+- Enforced a 24 KiB hard budget for the stable eight-domain `tools/list`, with
+  cross-domain and separate-worker determinism gates for Hosts that do not
+  support dynamic tool re-registration.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -470,6 +470,24 @@ discovery grant are omitted, while authorized but unavailable children remain
 visible with `callable=false`. Doris RBAC remains the final data authorization
 backend for all Doris object access.
 
+#### Host stability and context budgets
+
+The default registration surface is stable for Hosts that never support
+dynamic tool re-registration. Cross-domain conversations reuse the same eight
+registered domain tools; capability changes update a domain's
+`manifest_version`, not the top-level names or schemas.
+
+The server fails closed if the canonical eight-domain `tools/list` exceeds
+24 KiB. Each progressively disclosed domain manifest remains limited to
+16 KiB and 12 children, with separate description and schema limits. Separate
+worker processes built from the same catalog and capability evidence produce
+the same registration contract and manifest versions.
+
+`MCP_TOOL_EXPOSURE_MODE=flat` remains a startup-time compatibility fallback
+that exposes the same 47 read-only children through collision-free formal
+names and the same handlers. It does not restore pre-1.0 names, and switching
+exposure modes requires the Host to reconnect.
+
 #### Administration domain reservation
 
 The `doris_admin` name and its future discovery, preview, execute,

--- a/doris_mcp_server/tools/domain_manifest.py
+++ b/doris_mcp_server/tools/domain_manifest.py
@@ -52,6 +52,7 @@ from .domain_models import (
 MAX_CHILD_DESCRIPTION_CHARACTERS = 800
 MAX_CHILD_SCHEMA_BYTES = 4 * 1024
 MAX_SCHEMA_ENUM_VALUES = 32
+MAX_TOP_LEVEL_TOOL_LIST_BYTES = 24 * 1024
 MANIFEST_FORMAT_VERSION = "1"
 
 DOMAIN_DISCOVERY_DESCRIPTION_SUFFIX = (
@@ -197,7 +198,7 @@ class DomainManifestError(ValueError):
 
 
 class DomainManifestBudgetError(DomainManifestError):
-    """Raised when a public domain manifest exceeds a hard context budget."""
+    """Raised when public tool exposure exceeds a hard context budget."""
 
 
 class DomainAvailabilityProvider(Protocol):
@@ -422,11 +423,25 @@ class DomainManifestService:
             _build_top_level_tool(domain)
             for domain in self._catalog.domains
         )
+        self._top_level_tool_list_bytes = _top_level_tool_list_size_bytes(
+            self._tools
+        )
+        if self._top_level_tool_list_bytes > MAX_TOP_LEVEL_TOOL_LIST_BYTES:
+            raise DomainManifestBudgetError(
+                "top-level tools/list is "
+                f"{self._top_level_tool_list_bytes} bytes; "
+                f"limit is {MAX_TOP_LEVEL_TOOL_LIST_BYTES} bytes"
+            )
         self.validate_default_manifest_budgets()
 
     @property
     def domain_names(self) -> frozenset[str]:
         return self._domain_names
+
+    @property
+    def top_level_tool_list_bytes(self) -> int:
+        """Return the deterministic serialized size of the stable tool list."""
+        return self._top_level_tool_list_bytes
 
     def handles(self, name: str) -> bool:
         """Return whether a name is one of the exact top-level domains."""
@@ -661,6 +676,26 @@ def _build_top_level_tool(domain: DomainDefinition) -> Tool:
     )
 
 
+def _top_level_tool_list_size_bytes(tools: Sequence[Tool]) -> int:
+    payload = {
+        "tools": [
+            tool.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_none=True,
+            )
+            for tool in tools
+        ]
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return len(canonical.encode("utf-8"))
+
+
 def _render_child(
     child: ChildToolDefinition,
     availability: Availability,
@@ -828,6 +863,7 @@ __all__ = [
     "MAX_CHILD_DESCRIPTION_CHARACTERS",
     "MAX_CHILD_SCHEMA_BYTES",
     "MAX_SCHEMA_ENUM_VALUES",
+    "MAX_TOP_LEVEL_TOOL_LIST_BYTES",
     "ChildDiscoveryPolicy",
     "DomainAvailabilityProvider",
     "DomainAvailabilityResolution",

--- a/test/tools/test_domain_manifest.py
+++ b/test/tools/test_domain_manifest.py
@@ -35,6 +35,7 @@ from doris_mcp_server.tools.domain_manifest import (
     MAX_CHILD_DESCRIPTION_CHARACTERS,
     MAX_CHILD_SCHEMA_BYTES,
     MAX_SCHEMA_ENUM_VALUES,
+    MAX_TOP_LEVEL_TOOL_LIST_BYTES,
     DomainManifestBudgetError,
     DomainManifestManagerMixin,
     DomainManifestService,
@@ -142,6 +143,7 @@ def test_top_level_catalog_is_exactly_eight_stable_read_only_domains() -> None:
     assert len({tool.name for tool in tools}) == 8
     assert len({str(tool.input_schema) for tool in tools}) == 1
     assert len({str(tool.output_schema) for tool in tools}) == 1
+    assert service.top_level_tool_list_bytes <= MAX_TOP_LEVEL_TOOL_LIST_BYTES
     ToolSchemaGuard().compile_catalog(tools)
 
     for tool in tools:
@@ -551,6 +553,21 @@ def test_startup_rejects_manifest_over_domain_budget() -> None:
     with pytest.raises(DomainManifestBudgetError, match="limit is 100 bytes"):
         DomainManifestService(
             catalog=_replace_domain(domain.name, constrained)
+        )
+
+
+def test_startup_rejects_top_level_tool_list_over_budget() -> None:
+    domain = DORIS_DOMAIN_CATALOG.resolve_domain("doris_catalog")
+    oversized = domain.model_copy(
+        update={"description": "x" * MAX_TOP_LEVEL_TOOL_LIST_BYTES}
+    )
+
+    with pytest.raises(
+        DomainManifestBudgetError,
+        match="top-level tools/list is",
+    ):
+        DomainManifestService(
+            catalog=_replace_domain(domain.name, oversized)
         )
 
 

--- a/test/tools/test_host_exposure_contract.py
+++ b/test/tools/test_host_exposure_contract.py
@@ -1,0 +1,136 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Process-independent contracts for stable progressive tool exposure."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from doris_mcp_server.tools.domain_manifest import (
+    MAX_TOP_LEVEL_TOOL_LIST_BYTES,
+    DomainManifestService,
+)
+from doris_mcp_server.tools.doris_feature_matrix import (
+    EXPECTED_DOMAIN_CHILDREN,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_WORKER_CONTRACT_SCRIPT = """
+import asyncio
+import json
+
+from doris_mcp_server.tools.domain_manifest import DomainManifestService
+
+
+async def main():
+    service = DomainManifestService()
+    manifests = {}
+    for name in sorted(service.domain_names):
+        result = await service.call(name, {}, None)
+        manifests[name] = result.manifest_version
+    payload = {
+        "manifest_versions": manifests,
+        "tool_list_bytes": service.top_level_tool_list_bytes,
+        "tools": [
+            tool.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_none=True,
+            )
+            for tool in service.list_tools()
+        ],
+    }
+    print(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    )
+
+
+asyncio.run(main())
+"""
+
+
+def _tool_wire(service: DomainManifestService) -> list[dict[str, Any]]:
+    return [
+        tool.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_none=True,
+        )
+        for tool in service.list_tools()
+    ]
+
+
+def _worker_contract(hash_seed: str) -> dict[str, Any]:
+    environment = {**os.environ, "PYTHONHASHSEED": hash_seed}
+    completed = subprocess.run(
+        [sys.executable, "-c", _WORKER_CONTRACT_SCRIPT],
+        cwd=REPO_ROOT,
+        env=environment,
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=30,
+    )
+    return json.loads(completed.stdout)
+
+
+@pytest.mark.asyncio
+async def test_host_registration_stays_stable_across_domain_switches() -> None:
+    service = DomainManifestService()
+    before = _tool_wire(service)
+
+    catalog = await service.call("doris_catalog", {}, None)
+    cluster_first = await service.call("doris_cluster", {}, None)
+    cluster_second = await service.call("doris_cluster", {}, None)
+    after = _tool_wire(service)
+
+    assert before == after
+    assert [tool["name"] for tool in before] == list(
+        EXPECTED_DOMAIN_CHILDREN
+    )
+    assert [child.name for child in catalog.children] == list(
+        EXPECTED_DOMAIN_CHILDREN["doris_catalog"]
+    )
+    assert [child.name for child in cluster_first.children] == list(
+        EXPECTED_DOMAIN_CHILDREN["doris_cluster"]
+    )
+    assert cluster_first.manifest_version == cluster_second.manifest_version
+    assert service.top_level_tool_list_bytes <= MAX_TOP_LEVEL_TOOL_LIST_BYTES
+
+
+def test_worker_processes_produce_identical_exposure_contracts() -> None:
+    first = _worker_contract("1")
+    second = _worker_contract("8675309")
+
+    assert first == second
+    assert first["tool_list_bytes"] <= MAX_TOP_LEVEL_TOOL_LIST_BYTES
+    assert len(first["tools"]) == 8
+    assert len(first["manifest_versions"]) == 8


### PR DESCRIPTION
## Summary

- fail closed when the stable eight-domain `tools/list` exceeds a 24 KiB context budget
- prove that cross-domain discovery keeps the Host registration contract byte-for-byte stable
- prove that separate worker processes produce identical tool contracts and manifest versions
- document Host reconnect behavior for the Flat compatibility mode
- update `CHANGELOG.md` under Unreleased

## Validation

- `pytest -W error -q`: 1733 passed, 81 skipped; 67.46% coverage
- focused Host exposure and manifest tests: 27 passed
- `uv lock --check`
- `uv run ruff check .`
- `uv run mypy doris_mcp_server`
- `uv run bandit -q -c pyproject.toml -r doris_mcp_server`
- `uv build`
- real Doris 4.0.5-rc01 acceptance over stdio/HTTP and hierarchical/flat exposure: all four cases passed
- hierarchical exposure: 8 stable domains; canonical `tools/list`: 21,878 bytes
- Flat compatibility exposure: 47 read-only tools
- administration tools/resources/prompts discovered: 0; write operations executed: 0
