### PR TITLE
feat: add Doris patch certification matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,10 @@ under **Unreleased** until a new version is selected and published.
 - Enforced a 24 KiB hard budget for the stable eight-domain `tools/list`, with
   cross-domain and separate-worker determinism gates for Hosts that do not
   support dynamic tool re-registration.
+- Added an evidence-backed Doris patch certification matrix keyed by normalized
+  three-part versions, with complete Host-quadrant proof requirements and
+  fail-closed runtime disclosure for unknown or mixed component versions;
+  Doris `4.0.5` is the first certified target.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -488,6 +488,26 @@ that exposes the same 47 read-only children through collision-free formal
 names and the same handlers. It does not restore pre-1.0 names, and switching
 exposure modes requires the Host to reconnect.
 
+#### Doris patch certification
+
+Runtime certification is keyed by the normalized three-part Doris version
+(`major.minor.patch`). Prerelease labels, commit hashes, and deployment hints
+remain visible as evidence but do not create separate certification buckets.
+
+The 1.0 target set is `3.0.3`, `3.1.4`, `4.0.5`, `4.0.6`, `4.0.7`, `4.1.0`,
+`4.1.1`, `4.1.2`, and `4.1.3`. A target is reported as certified only after
+committed evidence proves the same core version across the observed FE and BE
+components, the exact eight-domain/47-child contract, a real read-only query,
+and all stdio/Streamable HTTP × hierarchical/Flat quadrants with zero write
+operations. Missing components, unparseable versions, and mixed core versions
+fail closed.
+
+`doris_cluster.get_runtime_capabilities` returns the observed component
+versions together with `patch_certification`, including the target set,
+certified set, current status, reason code, evidence IDs, and limitations.
+The current evidence-backed certified set is `4.0.5`; the other targets remain
+explicitly `target_uncertified` until the same gate is completed for them.
+
 #### Administration domain reservation
 
 The `doris_admin` name and its future discovery, preview, execute,

--- a/doris_mcp_server/tools/cluster_handlers.py
+++ b/doris_mcp_server/tools/cluster_handlers.py
@@ -25,6 +25,7 @@ from ..utils.db import DorisConnectionManager
 from ..utils.monitoring_tools import DorisMonitoringTools
 from ..utils.security import get_current_auth_context
 from .capability_registry import CapabilityRegistry
+from .doris_feature_matrix import DORIS_PATCH_CERTIFICATION_MATRIX
 
 
 class _ClusterHandlerOwner(Protocol):
@@ -153,6 +154,11 @@ class ClusterToolHandlersMixin:
         data: dict[str, Any] = {
             "detail": detail,
             "versions": versions,
+            "patch_certification": (
+                DORIS_PATCH_CERTIFICATION_MATRIX.evaluate(
+                    snapshot.version_vector
+                ).model_dump(mode="json")
+            ),
             "deployment_mode": snapshot.deployment_mode,
             "mixed_versions": snapshot.mixed_versions,
             "stale": snapshot.stale,

--- a/doris_mcp_server/tools/doris_feature_matrix.py
+++ b/doris_mcp_server/tools/doris_feature_matrix.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from enum import StrEnum
 from types import MappingProxyType
-from typing import Annotated, Self
+from typing import Annotated, Literal, Self
 
 from pydantic import Field, StringConstraints, model_validator
 
@@ -54,9 +54,6 @@ CERTIFICATION_TARGET_VERSIONS = (
     "4.1.2",
     "4.1.3",
 )
-
-# Certification is evidence-driven. V1-02 defines targets but certifies no patch.
-CERTIFIED_DORIS_VERSIONS: tuple[str, ...] = ()
 
 SourceIdentifier = Annotated[
     str,
@@ -251,7 +248,7 @@ class ChildFeatureDefinition(ContractModel):
 
 
 class VersionCertificationStatus(StrEnum):
-    """Certification relationship for one exact observed Doris patch."""
+    """Certification relationship for one observed three-part Doris patch."""
 
     CERTIFIED = "certified"
     TARGET_UNCERTIFIED = "target_uncertified"
@@ -347,6 +344,287 @@ EXPECTED_DOMAIN_CHILDREN: Mapping[str, tuple[str, ...]] = MappingProxyType(
         ),
     }
 )
+
+
+class PatchCertificationCase(ContractModel):
+    """One required Host and exposure-mode certification quadrant."""
+
+    transport: Literal["stdio", "streamable_http"]
+    exposure_mode: Literal["hierarchical", "flat"]
+    listed_tool_count: Annotated[int, Field(ge=1, le=64)]
+    domain_manifest_count: Annotated[int, Field(ge=0, le=8)]
+    read_only_query_passed: bool
+    write_operations_executed: Annotated[int, Field(ge=0, le=0)]
+
+    @model_validator(mode="after")
+    def _validate_case(self) -> Self:
+        expected_tools = 8 if self.exposure_mode == "hierarchical" else 47
+        expected_manifests = 8 if self.exposure_mode == "hierarchical" else 0
+        if self.listed_tool_count != expected_tools:
+            raise ValueError(
+                f"{self.exposure_mode} certification requires "
+                f"{expected_tools} listed tools"
+            )
+        if self.domain_manifest_count != expected_manifests:
+            raise ValueError(
+                f"{self.exposure_mode} certification requires "
+                f"{expected_manifests} domain manifests"
+            )
+        if not self.read_only_query_passed:
+            raise ValueError("certification requires a real read-only Doris query")
+        return self
+
+
+class PatchCertificationEvidence(ContractModel):
+    """Committed proof required before one three-part Doris patch is certified."""
+
+    certification_id: Identifier
+    version: NonEmptyText
+    master_fe_version_comment: NonEmptyText
+    follower_fe_version_comments: tuple[NonEmptyText, ...] = ()
+    backend_version_comments: Annotated[
+        tuple[NonEmptyText, ...],
+        Field(min_length=1),
+    ]
+    platform: Identifier
+    deployment_mode: Identifier
+    cases: Annotated[
+        tuple[PatchCertificationCase, ...],
+        Field(min_length=4, max_length=4),
+    ]
+    domain_names: Annotated[
+        tuple[Identifier, ...],
+        Field(min_length=8, max_length=8),
+    ]
+    child_contract_count: Annotated[int, Field(ge=47, le=47)]
+    evidence_sha256: Annotated[
+        str,
+        StringConstraints(
+            pattern=r"^[0-9a-f]{64}$",
+            strip_whitespace=True,
+        ),
+    ]
+    verified_on: date
+
+    @model_validator(mode="after")
+    def _validate_evidence(self) -> Self:
+        target = _parse_version_literal(self.version)
+        if target.prerelease is not None:
+            raise ValueError(
+                "certification evidence requires a three-part target version"
+            )
+        target_literal = _version_literal(target)
+        comments = (
+            self.master_fe_version_comment,
+            *self.follower_fe_version_comments,
+            *self.backend_version_comments,
+        )
+        for comment in comments:
+            observed = parse_doris_version_comment(comment)
+            if (
+                not observed.is_parsed
+                or observed.core != target_literal
+            ):
+                raise ValueError(
+                    "every certified FE and BE must report the Doris core "
+                    f"version {target_literal}"
+                )
+
+        expected_cases = {
+            ("stdio", "hierarchical"),
+            ("stdio", "flat"),
+            ("streamable_http", "hierarchical"),
+            ("streamable_http", "flat"),
+        }
+        actual_cases = {
+            (case.transport, case.exposure_mode) for case in self.cases
+        }
+        if actual_cases != expected_cases or len(actual_cases) != len(self.cases):
+            raise ValueError(
+                "certification evidence requires each transport and exposure "
+                "quadrant exactly once"
+            )
+        if self.domain_names != tuple(EXPECTED_DOMAIN_CHILDREN):
+            raise ValueError(
+                "certification evidence requires the exact ordered 8-domain "
+                "contract"
+            )
+        return self
+
+
+class PatchCertificationReport(ContractModel):
+    """Sanitized certification status for the currently observed cluster."""
+
+    minimum_supported_version: NonEmptyText
+    target_versions: tuple[NonEmptyText, ...]
+    certified_versions: tuple[NonEmptyText, ...]
+    observed_fe_versions: tuple[str | None, ...]
+    observed_be_versions: tuple[str | None, ...]
+    uniform_observed_version: str | None
+    status: VersionCertificationStatus
+    reason_code: ReasonCode
+    targeted: bool
+    certified: bool
+    evidence_ids: tuple[Identifier, ...]
+    limitations: tuple[NonEmptyText, ...] = ()
+
+
+class DorisPatchCertificationMatrix(ContractModel):
+    """Evidence-backed certification policy for three-part Doris patches."""
+
+    minimum_supported_version: NonEmptyText
+    target_versions: Annotated[
+        tuple[NonEmptyText, ...],
+        Field(min_length=1),
+    ]
+    evidence: tuple[PatchCertificationEvidence, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_matrix(self) -> Self:
+        minimum = _parse_version_literal(self.minimum_supported_version)
+        if minimum.prerelease is not None:
+            raise ValueError("minimum supported version must be stable")
+        targets = tuple(
+            _version_literal(_parse_version_literal(value))
+            for value in self.target_versions
+        )
+        if any(
+            _parse_version_literal(value).prerelease is not None
+            for value in self.target_versions
+        ):
+            raise ValueError(
+                "certification targets must use three-part versions"
+            )
+        _require_unique(targets, "patch certification targets")
+        evidence_versions = tuple(record.version for record in self.evidence)
+        _require_unique(evidence_versions, "patch certification evidence versions")
+        _require_unique(
+            tuple(record.certification_id for record in self.evidence),
+            "patch certification evidence IDs",
+        )
+        if not set(evidence_versions).issubset(targets):
+            raise ValueError(
+                "patch certification evidence must reference target versions"
+            )
+        return self
+
+    @property
+    def certified_versions(self) -> tuple[str, ...]:
+        """Return only patches backed by complete committed evidence."""
+        return tuple(record.version for record in self.evidence)
+
+    def evaluate(
+        self,
+        versions: DorisClusterVersionVector,
+    ) -> PatchCertificationReport:
+        """Evaluate three-part cluster-patch certification without guessing."""
+        fe_components = (versions.master_fe, *versions.follower_fes)
+        be_components = versions.backends
+        observed_fe = tuple(version.normalized for version in fe_components)
+        observed_be = tuple(version.normalized for version in be_components)
+        components = (*fe_components, *be_components)
+        if not be_components or any(not version.is_parsed for version in components):
+            return self._report(
+                observed_fe,
+                observed_be,
+                uniform_version=None,
+                status=VersionCertificationStatus.UNKNOWN,
+                reason_code="PATCH_CERTIFICATION_COMPONENT_VERSION_UNKNOWN",
+                limitations=(
+                    "Every FE and at least one BE must expose a parseable "
+                    "version before cluster-patch certification can be evaluated.",
+                ),
+            )
+
+        core_versions = tuple(version.core for version in components)
+        if len(set(core_versions)) != 1:
+            return self._report(
+                observed_fe,
+                observed_be,
+                uniform_version=None,
+                status=VersionCertificationStatus.UNKNOWN,
+                reason_code="PATCH_CERTIFICATION_MIXED_COMPONENT_VERSIONS",
+                limitations=(
+                    "Mixed FE or BE core versions are not covered by one patch "
+                    "certification.",
+                ),
+            )
+
+        observed = components[0]
+        literal = observed.core
+        if literal is None:
+            raise AssertionError("parsed Doris version must expose a core version")
+        target = literal in self.target_versions
+        matches = tuple(
+            record
+            for record in self.evidence
+            if record.version == literal
+        )
+        if matches:
+            return self._report(
+                observed_fe,
+                observed_be,
+                uniform_version=literal,
+                status=VersionCertificationStatus.CERTIFIED,
+                reason_code="PATCH_CERTIFICATION_EVIDENCE_VERIFIED",
+                targeted=True,
+                certified=True,
+                evidence_ids=tuple(
+                    record.certification_id for record in matches
+                ),
+            )
+        if target:
+            return self._report(
+                observed_fe,
+                observed_be,
+                uniform_version=literal,
+                status=VersionCertificationStatus.TARGET_UNCERTIFIED,
+                reason_code="PATCH_CERTIFICATION_TARGET_UNVERIFIED",
+                targeted=True,
+                limitations=(
+                    "This patch is a certification target, but no complete "
+                    "real-cluster evidence is committed.",
+                ),
+            )
+        return self._report(
+            observed_fe,
+            observed_be,
+            uniform_version=literal,
+            status=VersionCertificationStatus.OUTSIDE_TARGET,
+            reason_code="PATCH_CERTIFICATION_VERSION_OUTSIDE_TARGET",
+            limitations=(
+                "The observed three-part patch is outside the 1.0 "
+                "certification target set.",
+            ),
+        )
+
+    def _report(
+        self,
+        observed_fe: tuple[str | None, ...],
+        observed_be: tuple[str | None, ...],
+        *,
+        uniform_version: str | None,
+        status: VersionCertificationStatus,
+        reason_code: str,
+        targeted: bool = False,
+        certified: bool = False,
+        evidence_ids: tuple[str, ...] = (),
+        limitations: tuple[str, ...] = (),
+    ) -> PatchCertificationReport:
+        return PatchCertificationReport(
+            minimum_supported_version=self.minimum_supported_version,
+            target_versions=self.target_versions,
+            certified_versions=self.certified_versions,
+            observed_fe_versions=observed_fe,
+            observed_be_versions=observed_be,
+            uniform_observed_version=uniform_version,
+            status=status,
+            reason_code=reason_code,
+            targeted=targeted,
+            certified=certified,
+            evidence_ids=evidence_ids,
+            limitations=limitations,
+        )
 
 
 class DorisFeatureMatrix(ContractModel):
@@ -631,9 +909,9 @@ def _certification_status(
     version: DorisVersion | None,
     matrix: DorisFeatureMatrix,
 ) -> VersionCertificationStatus:
-    if version is None:
+    if version is None or version.core is None:
         return VersionCertificationStatus.UNKNOWN
-    literal = _version_literal(version)
+    literal = version.core
     if literal in matrix.certified_versions:
         return VersionCertificationStatus.CERTIFIED
     if literal in matrix.certification_targets:
@@ -1557,6 +1835,75 @@ FEATURE_DEFINITIONS = (
     ),
 )
 
+# Every record below is backed by a sanitized local evidence artifact whose
+# digest is committed here. Prerelease/build suffixes remain evidence only;
+# certification is keyed by the normalized three-part version.
+PATCH_CERTIFICATION_EVIDENCE: tuple[PatchCertificationEvidence, ...] = (
+    PatchCertificationEvidence(
+        certification_id="doris_4_0_5_linux_amd64",
+        version="4.0.5",
+        master_fe_version_comment=(
+            "doris version doris-4.0.5-rc01-59de8c4c524"
+        ),
+        backend_version_comments=(
+            "doris version doris-4.0.5-rc01-59de8c4c524",
+        ),
+        platform="linux_amd64",
+        deployment_mode="unknown",
+        cases=(
+            PatchCertificationCase(
+                transport="stdio",
+                exposure_mode="hierarchical",
+                listed_tool_count=8,
+                domain_manifest_count=8,
+                read_only_query_passed=True,
+                write_operations_executed=0,
+            ),
+            PatchCertificationCase(
+                transport="stdio",
+                exposure_mode="flat",
+                listed_tool_count=47,
+                domain_manifest_count=0,
+                read_only_query_passed=True,
+                write_operations_executed=0,
+            ),
+            PatchCertificationCase(
+                transport="streamable_http",
+                exposure_mode="hierarchical",
+                listed_tool_count=8,
+                domain_manifest_count=8,
+                read_only_query_passed=True,
+                write_operations_executed=0,
+            ),
+            PatchCertificationCase(
+                transport="streamable_http",
+                exposure_mode="flat",
+                listed_tool_count=47,
+                domain_manifest_count=0,
+                read_only_query_passed=True,
+                write_operations_executed=0,
+            ),
+        ),
+        domain_names=tuple(EXPECTED_DOMAIN_CHILDREN),
+        child_contract_count=47,
+        evidence_sha256=(
+            "2ac431322d6b550bd8449ca80312105f4"
+            "cc9cfec57f9b89362c088a2f97d4e9a"
+        ),
+        verified_on=SOURCE_VERIFIED_ON,
+    ),
+)
+
+DORIS_PATCH_CERTIFICATION_MATRIX = DorisPatchCertificationMatrix(
+    minimum_supported_version=PROJECT_MINIMUM_DORIS_VERSION,
+    target_versions=CERTIFICATION_TARGET_VERSIONS,
+    evidence=PATCH_CERTIFICATION_EVIDENCE,
+)
+
+CERTIFIED_DORIS_VERSIONS = (
+    DORIS_PATCH_CERTIFICATION_MATRIX.certified_versions
+)
+
 DORIS_FEATURE_MATRIX = DorisFeatureMatrix(
     minimum_supported_version=PROJECT_MINIMUM_DORIS_VERSION,
     certification_targets=CERTIFICATION_TARGET_VERSIONS,
@@ -1570,20 +1917,26 @@ __all__ = [
     "CERTIFICATION_TARGET_VERSIONS",
     "CERTIFIED_DORIS_VERSIONS",
     "DORIS_FEATURE_MATRIX",
+    "DORIS_PATCH_CERTIFICATION_MATRIX",
     "EXPECTED_DOMAIN_CHILDREN",
     "FEATURE_DEFINITIONS",
     "FEATURE_SOURCES",
+    "PATCH_CERTIFICATION_EVIDENCE",
     "PROJECT_MINIMUM_DORIS_VERSION",
     "PROJECT_SUPPORTED_RANGE",
     "CapabilityVersionScope",
     "ChildFeatureDefinition",
     "DorisClusterVersionVector",
     "DorisFeatureMatrix",
+    "DorisPatchCertificationMatrix",
     "DorisVersionConstraint",
     "DorisVersionRange",
     "FeatureSource",
     "FeatureSourceKind",
     "FeatureVersionEvaluation",
+    "PatchCertificationCase",
+    "PatchCertificationEvidence",
+    "PatchCertificationReport",
     "VersionCertificationStatus",
     "VersionRangeOperator",
     "matching_version_ranges",

--- a/test/integration/test_real_doris_transports.py
+++ b/test/integration/test_real_doris_transports.py
@@ -1362,6 +1362,15 @@ async def test_real_doris_hierarchical_cluster_domain_is_read_only_and_live(
         )
         master_fe_version = runtime["data"]["versions"]["master_fe"]
         assert master_fe_version
+        patch_certification = runtime["data"]["patch_certification"]
+        assert patch_certification["uniform_observed_version"]
+        assert patch_certification["status"] in {
+            "certified",
+            "target_uncertified",
+            "outside_target",
+        }
+        assert patch_certification["target_versions"]
+        assert isinstance(patch_certification["certified_versions"], list)
 
         nodes = await _call_domain_child(
             client,

--- a/test/tools/test_capability_registry.py
+++ b/test/tools/test_capability_registry.py
@@ -185,7 +185,7 @@ def test_evaluator_requires_version_probes_handler_and_call_permission() -> None
     assert available.status is AvailabilityStatus.AVAILABLE
     assert available.callable is True
     assert available.active_variant == "mysql_read_only"
-    assert available.reason_code == "CAPABILITY_VERIFIED_UNCERTIFIED"
+    assert available.reason_code == "CAPABILITY_VERIFIED"
     assert available.limitations == ()
     assert missing_probe.status is AvailabilityStatus.UNKNOWN
     assert missing_probe.reason_code == "CAPABILITY_PROBE_PENDING"
@@ -305,9 +305,7 @@ def test_compaction_prefers_native_tracker_and_uses_legacy_on_405() -> None:
     assert legacy.callable is True
     assert legacy.status is AvailabilityStatus.DEGRADED
     assert legacy.active_variant == "legacy_compaction_summary"
-    assert legacy.reason_code == (
-        "CAPABILITY_VERIFIED_DEGRADED_UNCERTIFIED"
-    )
+    assert legacy.reason_code == "CAPABILITY_VERIFIED_DEGRADED"
 
 
 def test_lakehouse_prefers_4_1_variants_and_falls_back_on_4_0() -> None:
@@ -724,7 +722,7 @@ def test_semantic_availability_keeps_call_time_validation_callable() -> None:
     assert listed.callable is True
     assert context.status is AvailabilityStatus.DEGRADED
     assert context.callable is True
-    assert context.reason_code == "CAPABILITY_VERIFIED_DEGRADED_UNCERTIFIED"
+    assert context.reason_code == "CAPABILITY_VERIFIED_DEGRADED"
     assert "Probe explicit_model_ref_valid is degraded." in context.limitations
     assert "Probe semantic_policy_ready is degraded." in context.limitations
 

--- a/test/tools/test_capability_runtime_integration.py
+++ b/test/tools/test_capability_runtime_integration.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Any
@@ -150,3 +151,39 @@ async def test_default_manager_detects_caches_and_dispatches() -> None:
         "EXPLAIN SELECT 1"
     ) == 1
     manager._exec_query_tool.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_runtime_capabilities_disclose_patch_certification() -> None:
+    connection_manager = _CapabilityConnectionManager()
+    manager = DorisToolsManager(connection_manager)  # type: ignore[arg-type]
+
+    manifest = await manager.domain_dispatcher.call_domain(
+        "doris_cluster",
+        {},
+        None,
+    )
+    result = await manager.domain_dispatcher.call_domain(
+        "doris_cluster",
+        {
+            "child_tool": "get_runtime_capabilities",
+            "arguments": {"detail": "summary"},
+            "manifest_version": manifest.manifest_version,
+        },
+        None,
+    )
+
+    assert result.mode == "result"
+    assert isinstance(result.data, Mapping)
+    payload = result.data["data"]
+    assert isinstance(payload, Mapping)
+    certification = payload["patch_certification"]
+    assert isinstance(certification, Mapping)
+    assert certification["uniform_observed_version"] == "4.0.5"
+    assert certification["status"] == "certified"
+    assert certification["targeted"] is True
+    assert certification["certified"] is True
+    assert certification["certified_versions"] == ("4.0.5",)
+    assert certification["evidence_ids"] == (
+        "doris_4_0_5_linux_amd64",
+    )

--- a/test/tools/test_doris_feature_matrix.py
+++ b/test/tools/test_doris_feature_matrix.py
@@ -28,14 +28,18 @@ from doris_mcp_server.tools.doris_feature_matrix import (
     CERTIFICATION_TARGET_VERSIONS,
     CERTIFIED_DORIS_VERSIONS,
     DORIS_FEATURE_MATRIX,
+    DORIS_PATCH_CERTIFICATION_MATRIX,
     EXPECTED_DOMAIN_CHILDREN,
     PROJECT_MINIMUM_DORIS_VERSION,
     CapabilityVersionScope,
     DorisClusterVersionVector,
     DorisFeatureMatrix,
+    DorisPatchCertificationMatrix,
     DorisVersionRange,
     FeatureSource,
     FeatureSourceKind,
+    PatchCertificationCase,
+    PatchCertificationEvidence,
     VersionCertificationStatus,
     matching_version_ranges,
 )
@@ -61,6 +65,43 @@ def _vector(
 
 def _matrix_payload() -> dict[str, Any]:
     return cast(dict[str, Any], DORIS_FEATURE_MATRIX.model_dump(mode="python"))
+
+
+def _certification_cases() -> tuple[PatchCertificationCase, ...]:
+    return tuple(
+        PatchCertificationCase(
+            transport=transport,
+            exposure_mode=mode,
+            listed_tool_count=8 if mode == "hierarchical" else 47,
+            domain_manifest_count=8 if mode == "hierarchical" else 0,
+            read_only_query_passed=True,
+            write_operations_executed=0,
+        )
+        for transport in ("stdio", "streamable_http")
+        for mode in ("hierarchical", "flat")
+    )
+
+
+def _certification_evidence(
+    version: str = "4.1.2",
+) -> PatchCertificationEvidence:
+    return PatchCertificationEvidence(
+        certification_id="doris_4_1_2_linux_amd64",
+        version=version,
+        master_fe_version_comment=(
+            f"Doris version doris-{version}-rc01-43f06a5e26 (Cloud Mode)"
+        ),
+        backend_version_comments=(
+            f"Doris version doris-{version}-rc02-43f06a5e26",
+        ),
+        platform="linux_amd64",
+        deployment_mode="cloud",
+        cases=_certification_cases(),
+        domain_names=tuple(EXPECTED_DOMAIN_CHILDREN),
+        child_contract_count=47,
+        evidence_sha256="a" * 64,
+        verified_on="2026-07-31",
+    )
 
 
 def test_matrix_contains_exact_8_domain_47_child_contract() -> None:
@@ -214,17 +255,112 @@ def test_sources_are_https_authorities_with_branch_ranges() -> None:
     assert {"#61819", "#62077", "#63206"} == set(release_412.pull_requests)
 
 
-def test_certification_targets_are_not_claimed_as_certified() -> None:
+def test_only_evidence_backed_targets_are_claimed_as_certified() -> None:
     assert PROJECT_MINIMUM_DORIS_VERSION == "3.0.0"
     assert DORIS_FEATURE_MATRIX.certification_targets == (CERTIFICATION_TARGET_VERSIONS)
-    assert DORIS_FEATURE_MATRIX.certified_versions == ()
-    assert CERTIFIED_DORIS_VERSIONS == ()
+    assert DORIS_FEATURE_MATRIX.certified_versions == ("4.0.5",)
+    assert CERTIFIED_DORIS_VERSIONS == ("4.0.5",)
+    assert DORIS_PATCH_CERTIFICATION_MATRIX.target_versions == (
+        CERTIFICATION_TARGET_VERSIONS
+    )
+    assert tuple(
+        record.version for record in DORIS_PATCH_CERTIFICATION_MATRIX.evidence
+    ) == ("4.0.5",)
+    assert (
+        DORIS_PATCH_CERTIFICATION_MATRIX.evidence[0].evidence_sha256
+        == "2ac431322d6b550bd8449ca80312105f4cc9cfec57f9b89362c088a2f97d4e9a"
+    )
     assert {
         "DORIS_RELEASE_3_0_3",
         "DORIS_RELEASE_3_1_4",
         "DORIS_RELEASE_4_0_5",
         "DORIS_RELEASE_4_1_3",
     } <= {source.source_id for source in DORIS_FEATURE_MATRIX.sources}
+
+
+def test_certification_uses_three_part_core_for_rc_and_ga_builds() -> None:
+    rc_versions = _vector("4.0.5-rc01")
+    ga_versions = _vector("4.0.5")
+    rc_feature = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_catalog",
+        child_name="list_tables",
+        versions=rc_versions,
+    )
+    ga_feature = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_catalog",
+        child_name="list_tables",
+        versions=ga_versions,
+    )
+    rc_report = DORIS_PATCH_CERTIFICATION_MATRIX.evaluate(rc_versions)
+    ga_report = DORIS_PATCH_CERTIFICATION_MATRIX.evaluate(ga_versions)
+
+    assert rc_feature.certification_status is (
+        VersionCertificationStatus.CERTIFIED
+    )
+    assert ga_feature.certification_status is (
+        VersionCertificationStatus.CERTIFIED
+    )
+    assert rc_report.uniform_observed_version == "4.0.5"
+    assert ga_report.uniform_observed_version == "4.0.5"
+    assert rc_report.observed_fe_versions == ("4.0.5rc1",)
+    assert rc_report.observed_be_versions == ("4.0.5rc1",)
+    assert rc_report.status is VersionCertificationStatus.CERTIFIED
+    assert ga_report.status is VersionCertificationStatus.CERTIFIED
+    assert rc_report.evidence_ids == ("doris_4_0_5_linux_amd64",)
+    assert ga_report.evidence_ids == rc_report.evidence_ids
+
+
+def test_complete_real_host_evidence_certifies_its_three_part_patch() -> None:
+    evidence = _certification_evidence()
+    matrix = DorisPatchCertificationMatrix(
+        minimum_supported_version="3.0.0",
+        target_versions=CERTIFICATION_TARGET_VERSIONS,
+        evidence=(evidence,),
+    )
+    report = matrix.evaluate(_vector("4.1.2-rc03"))
+
+    assert matrix.certified_versions == ("4.1.2",)
+    assert report.uniform_observed_version == "4.1.2"
+    assert report.status is VersionCertificationStatus.CERTIFIED
+    assert report.targeted is True
+    assert report.certified is True
+    assert report.evidence_ids == ("doris_4_1_2_linux_amd64",)
+
+
+def test_patch_certification_fails_closed_for_unknown_or_mixed_components() -> None:
+    unknown = DORIS_PATCH_CERTIFICATION_MATRIX.evaluate(
+        DorisClusterVersionVector.from_comments(
+            master_fe="Doris version doris-4.1.2",
+            backends=(),
+        )
+    )
+    mixed = DORIS_PATCH_CERTIFICATION_MATRIX.evaluate(
+        _vector("4.1.2", backends=("4.1.1",))
+    )
+
+    assert unknown.status is VersionCertificationStatus.UNKNOWN
+    assert unknown.reason_code == "PATCH_CERTIFICATION_COMPONENT_VERSION_UNKNOWN"
+    assert mixed.status is VersionCertificationStatus.UNKNOWN
+    assert mixed.reason_code == "PATCH_CERTIFICATION_MIXED_COMPONENT_VERSIONS"
+    assert mixed.uniform_observed_version is None
+
+
+def test_patch_evidence_rejects_incomplete_host_or_component_proof() -> None:
+    evidence = _certification_evidence()
+    payload = evidence.model_dump(mode="python")
+    payload["cases"] = payload["cases"][:-1]
+    with pytest.raises(
+        ValidationError,
+        match="at least 4 items|each transport and exposure",
+    ):
+        PatchCertificationEvidence.model_validate(payload)
+
+    payload = evidence.model_dump(mode="python")
+    payload["backend_version_comments"] = (
+        "Doris version doris-4.1.1-43f06a5e26",
+    )
+    with pytest.raises(ValidationError, match="Doris core version 4.1.2"):
+        PatchCertificationEvidence.model_validate(payload)
 
 
 @pytest.mark.parametrize(
@@ -392,11 +528,9 @@ def test_compaction_child_keeps_a_degraded_legacy_variant() -> None:
 
     assert result.compatible is True
     assert result.matched_variants == ("legacy_compaction_summary",)
-    assert result.certification_status is (
-        VersionCertificationStatus.TARGET_UNCERTIFIED
-    )
-    assert result.certification_target is True
-    assert result.certified is False
+    assert result.certification_status is VersionCertificationStatus.CERTIFIED
+    assert result.certification_target is False
+    assert result.certified is True
 
 
 def test_lineage_native_and_audit_paths_are_both_explicit() -> None:


### PR DESCRIPTION
## Summary

- add an evidence-backed Doris patch certification matrix keyed only by normalized `major.minor.patch`
- expose sanitized patch-certification status through `doris_cluster.get_runtime_capabilities`
- certify the `4.0.5` bucket from real FE/BE and Host-quadrant evidence while retaining prerelease/build details only as metadata
- document the policy and current certified set in README and CHANGELOG

## Version policy

- RC, GA, commit hashes, and deployment hints do not create separate certification buckets
- missing or unparseable components and mixed three-part FE/BE versions fail closed
- target patches without complete evidence remain `target_uncertified`

## Validation

- `uv run pytest -q -W error`: 1738 passed, 81 skipped; 67.65% coverage
- `uv lock --check`
- `uv run ruff check .`
- `uv run mypy doris_mcp_server`
- `uv run bandit -q -c pyproject.toml -r .`
- `uv build`
- post-rebase focused regression: 107 passed, 24 skipped
- real Doris `4.0.5-rc01`: stdio and Streamable HTTP in hierarchical and Flat modes; 8 domains / 47 children, real read-only query passed, administration absent, zero write operations
