### PR TITLE
release: prepare Doris MCP Server 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: uv lock --check
       - name: Sync development environment
         run: uv sync --frozen --group dev
+      - name: Verify generated 1.0 tool catalog
+        run: uv run python generate_tool_catalog.py --check
       - name: Ruff
         run: uv run ruff check .
       - name: Mypy
@@ -44,6 +46,7 @@ jobs:
         run: >-
           uv run bandit -q -c pyproject.toml -r
           doris_mcp_server doris_mcp_client generate_requirements.py
+          generate_tool_catalog.py
 
   test:
     name: Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ under **Unreleased** until a new version is selected and published.
 
 ## [Unreleased]
 
+No unreleased changes.
+
+## [1.0.0] - 2026-07-31
+
 ### Added
 
 - MCP `2026-07-28` stateless protocol support on Streamable HTTP and stdio,
@@ -129,6 +133,12 @@ under **Unreleased** until a new version is selected and published.
   three-part versions, with complete Host-quadrant proof requirements and
   fail-closed runtime disclosure for unknown or mixed component versions;
   Doris `4.0.5` is the first certified target.
+- Normalized all Doris capability, range, and certification decisions to
+  `major.minor.patch`; RC, GA, commit, and deployment metadata remain evidence
+  only and never create a separate support result.
+- Published the 1.0 migration guide and release notes, and generated the exact
+  8-domain/47-child tool catalog from the runtime catalog as a checked-in,
+  CI-verified release artifact.
 
 ### Fixed
 
@@ -265,7 +275,8 @@ under **Unreleased** until a new version is selected and published.
 
 - First tagged release in this repository.
 
-[Unreleased]: https://github.com/apache/doris-mcp-server/compare/0.6.1...HEAD
+[Unreleased]: https://github.com/apache/doris-mcp-server/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/apache/doris-mcp-server/compare/0.6.1...1.0.0
 [0.6.1]: https://github.com/apache/doris-mcp-server/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/apache/doris-mcp-server/compare/0.5.1...0.6.0
 [0.5.1]: https://github.com/apache/doris-mcp-server/compare/0.5.0...0.5.1

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Doris MCP (Model Context Protocol) Server is a backend service built with Python
 
 ## Release Status
 
-The current package metadata and latest Git tag are `0.6.1`. The `master`
-branch also contains changes made after that tag; those changes are recorded
-under [Unreleased](CHANGELOG.md#unreleased) until the next version is selected
-and published.
+The package metadata for this release line is `1.0.0`. See
+[GitHub Releases](https://github.com/apache/doris-mcp-server/releases) for the
+latest published tag. Changes made after the latest release are recorded under
+[Unreleased](CHANGELOG.md#unreleased).
 
 MCP `2026-07-28` protocol compatibility on `master` is **Generally Available
 (GA)** for Streamable HTTP and stdio. The supported protocol contract has
@@ -43,6 +43,11 @@ constraints. Review the [changelog](CHANGELOG.md), the
 [protocol support matrix](#protocol-and-transport-matrix), and the
 [deployment constraints](#deployment-constraints) before deploying it outside
 a controlled environment.
+
+Before upgrading, review the
+[1.0.0 migration guide](docs/migration-1.0.0.md), the
+[1.0.0 release notes](docs/release-notes-1.0.0.md), and the generated
+[8-domain/47-child tool catalog](docs/tool-registry.md).
 
 ## Highlights from v0.6.0
 
@@ -104,7 +109,7 @@ a controlled environment.
 pip install doris-mcp-server
 
 # Install specific version
-pip install doris-mcp-server==0.6.1
+pip install doris-mcp-server==1.0.0
 ```
 
 > **💡 Packaged Commands**: `doris-mcp-server` starts the MCP server.
@@ -492,7 +497,8 @@ exposure modes requires the Host to reconnect.
 
 Runtime certification is keyed by the normalized three-part Doris version
 (`major.minor.patch`). Prerelease labels, commit hashes, and deployment hints
-remain visible as evidence but do not create separate certification buckets.
+remain visible as evidence but do not affect capability ranges or create
+separate certification buckets.
 
 The 1.0 target set is `3.0.3`, `3.1.4`, `4.0.5`, `4.0.6`, `4.0.7`, `4.1.0`,
 `4.1.1`, `4.1.2`, and `4.1.3`. A target is reported as certified only after
@@ -2399,9 +2405,10 @@ cat logs/doris_mcp_server_critical.log
    or override another cluster. This multi-instance mode requires the HTTP
    transport with static-token authentication. A stdio process has one global
    database route, so run separate stdio processes when clients need separate
-   clusters. `exec_adbc_query` is intentionally fail-closed on token-bound
-   routes because the current Arrow Flight client is process-global; use
-   `doris_query.execute_query` or a separate MCP process for that cluster.
+   clusters. `doris_query.execute_adbc_query` is intentionally fail-closed on
+   token-bound routes because the current Arrow Flight client is
+   process-global; use `doris_query.execute_query` or a separate MCP process
+   for that cluster.
 
 ### Q: How is Doris-backed OAuth different from external OAuth/OIDC?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,8 +32,8 @@ Doris MCP Server 是一个基于 Python 和 FastAPI 的
 
 ## 发布状态
 
-当前包版本和最新 Git 标签为 `0.6.1`。`master` 分支还包含标签之后、尚未发布的
-变更，这些内容记录在 [CHANGELOG 的 Unreleased 小节](CHANGELOG.md#unreleased)。
+The authoritative package version and release status are maintained in the
+[English README](README.md) and [CHANGELOG](CHANGELOG.md).
 
 `master` 分支上的 MCP `2026-07-28` 协议兼容性已在 Streamable HTTP 和 stdio
 两种传输上达到 GA。这个结论仅指协议兼容性；项目包元数据仍为 **Beta**，部署前
@@ -69,7 +69,7 @@ Doris MCP Server 是一个基于 Python 和 FastAPI 的
 ### 从 PyPI 安装
 
 ```bash
-pip install doris-mcp-server==0.6.1
+pip install doris-mcp-server==1.0.0
 ```
 
 安装后会提供两个命令：

--- a/docs/migration-1.0.0.md
+++ b/docs/migration-1.0.0.md
@@ -1,0 +1,122 @@
+# Migrating to Doris MCP Server 1.0.0
+
+Version 1.0.0 replaces the pre-1.0 direct tool surface with one validated
+read-only catalog. This is an intentional breaking change: pre-1.0 tool names
+are not registered as aliases and cannot be called after the upgrade.
+
+## Exposure modes
+
+The default `hierarchical` mode exposes eight stable domain tools:
+
+- `doris_catalog`
+- `doris_query`
+- `doris_cluster`
+- `doris_pipeline`
+- `doris_search`
+- `doris_governance`
+- `doris_lakehouse`
+- `doris_semantic`
+
+Call a domain with an empty object to receive its authorized child manifest.
+Use the returned exact child name, input schema, and manifest version for the
+next call:
+
+```json
+{}
+```
+
+```json
+{
+  "child_tool": "list_tables",
+  "arguments": {
+    "database": "analytics"
+  },
+  "manifest_version": "<value returned by discovery>"
+}
+```
+
+Hosts that cannot use progressive disclosure may set
+`MCP_TOOL_EXPOSURE_MODE=flat` before startup. Flat mode exposes 47
+collision-free formal names such as `doris_catalog_list_tables` and
+`doris_query_execute_query`. Changing the mode requires a Server restart and a
+Host reconnect. Flat mode does not restore pre-1.0 names.
+
+The generated [tool catalog](tool-registry.md) is the authoritative list of
+all eight domains, 47 children, and 25 pre-1.0 migration inputs.
+
+## Required Host changes
+
+1. Remove cached pre-1.0 tool definitions.
+2. Restart the Server after selecting the exposure mode.
+3. Reconnect the Host and run `tools/list`.
+4. In hierarchical mode, discover a domain before calling a child.
+5. Use exact schemas from the current manifest; do not infer arguments from a
+   previous release.
+6. Rediscover when the Server returns a stale-manifest response.
+
+Top-level registration remains stable across user intent changes. A Host can
+move from catalog discovery to cluster inspection by calling another already
+registered domain; it does not need dynamic tool re-registration.
+
+## Common tool migrations
+
+| Pre-1.0 call | Hierarchical 1.0 child | Flat 1.0 name |
+|---|---|---|
+| `exec_query` | `doris_query.execute_query` | `doris_query_execute_query` |
+| `get_db_list` | `doris_catalog.list_databases` | `doris_catalog_list_databases` |
+| `get_db_table_list` | `doris_catalog.list_tables` | `doris_catalog_list_tables` |
+| `get_catalog_list` | `doris_catalog.list_catalogs` | `doris_catalog_list_catalogs` |
+| `get_sql_explain` | `doris_query.explain_query` | `doris_query_explain_query` |
+| `get_sql_profile` | `doris_query.get_query_profile` | `doris_query_get_query_profile` |
+| `exec_adbc_query` | `doris_query.execute_adbc_query` | `doris_query_execute_adbc_query` |
+| `analyze_data_flow_dependencies` | `doris_pipeline.analyze_data_dependencies` | `doris_pipeline_analyze_data_dependencies` |
+
+Five pre-1.0 table calls now contribute to sections of
+`doris_catalog.get_table_context`:
+
+- `get_table_basic_info` becomes section `basic`.
+- `get_table_schema` becomes section `schema`.
+- `get_table_comment` and `get_table_column_comments` become section
+  `comments`.
+- `get_table_indexes` becomes section `indexes`.
+
+Use the generated catalog for the complete mapping. Migration entries document
+internal handler reuse; they do not make the old call names discoverable or
+callable.
+
+## Authorization changes
+
+OAuth discovery and call scopes use exact domain and child identifiers.
+Pre-1.0 tool scopes and wildcard guesses are rejected. Discovery permission
+does not imply execution permission, and Doris RBAC remains the final data
+authorization boundary.
+
+The optional Ossie semantic domain is default-off. Every model-specific call
+requires the exact `model_ref` returned by discovery; the Server does not
+guess a model from the prompt.
+
+## Protocol and transport
+
+MCP `2026-07-28` is the modern protocol on Streamable HTTP and stdio. The
+isolated `2025-11-25` HTTP migration adapter remains default-off at
+`/mcp/legacy` and does not restore pre-1.0 tool names. Enable it only for a
+bounded protocol migration by setting `ENABLE_LEGACY_HTTP_ADAPTER=true`.
+
+## Doris version handling
+
+The minimum supported Doris version is `3.0.0`. Patch certification uses only
+the normalized `major.minor.patch` value. RC or GA labels, commit hashes, and
+deployment hints remain diagnostic evidence. They do not affect capability
+ranges or create separate certification buckets.
+
+At the 1.0.0 release boundary, `4.0.5` is evidence-backed and certified. The
+other target versions remain explicitly `target_uncertified` until their real
+cluster gates are complete. Runtime capability discovery is authoritative for
+each connected cluster.
+
+## Safety boundary
+
+Version 1.0.0 exposes read-only domains. The reserved `doris_admin` domain is
+not registered, and no management write operation is available. Custom
+providers remain explicit, allowlisted extensions rather than members of the
+built-in 8/47 contract.

--- a/docs/release-notes-1.0.0.md
+++ b/docs/release-notes-1.0.0.md
@@ -1,0 +1,87 @@
+# Doris MCP Server 1.0.0 Release Notes
+
+Doris MCP Server 1.0.0 establishes the first versioned public contract for
+progressive, capability-aware Apache Doris tooling over MCP `2026-07-28`.
+
+The MCP protocol contract is generally available on Streamable HTTP and stdio.
+The Python package retains its Beta deployment classifier because several
+distributed deployment shapes remain intentionally constrained.
+
+## Highlights
+
+- Eight stable, read-only top-level domains with progressive child discovery.
+- Forty-seven collision-free child capabilities across catalog, query,
+  cluster, pipeline, search, governance, lakehouse, and semantic concerns.
+- A startup-time `flat` fallback for Hosts that cannot use progressive
+  disclosure.
+- Runtime Doris version, feature, provider, permission, and availability
+  evidence with fail-closed behavior.
+- Native Doris lineage integration for 4.0.6 and later when the companion
+  provider is available, with explicit audit-based fallback behavior.
+- Optional Apache Ossie semantic grounding with exact `model_ref` selection.
+- MCP `2026-07-28` stateless request handling, bounded schemas and results,
+  trace propagation, and deterministic product identity.
+- Static token, JWT, external OAuth/OIDC, and Doris-backed OAuth boundaries.
+
+The generated [tool catalog](tool-registry.md) contains the exact 8-domain and
+47-child release surface.
+
+## Breaking changes
+
+- Pre-1.0 direct tool names are removed without an alias window.
+- Hierarchical discovery is the default exposure mode.
+- Flat mode uses formal names such as `doris_query_execute_query`, not
+  pre-1.0 names.
+- Authorization uses exact domain and child scope identifiers.
+- Semantic model-specific calls require an explicit `model_ref`.
+- The modern HTTP endpoint accepts MCP `2026-07-28`; the isolated legacy
+  protocol adapter is default-off.
+
+See the [migration guide](migration-1.0.0.md) for call shapes, Host behavior,
+configuration, and old-to-new mappings.
+
+## Doris compatibility
+
+The project minimum is Doris `3.0.0`. The 1.0 target patch set is:
+
+- `3.0.3`
+- `3.1.4`
+- `4.0.5`
+- `4.0.6`
+- `4.0.7`
+- `4.1.0`
+- `4.1.1`
+- `4.1.2`
+- `4.1.3`
+
+Capability ranges and certification are keyed only by `major.minor.patch`;
+RC or GA labels do not affect the result or create separate buckets. Doris
+`4.0.5` is the first evidence-backed certified target. Every other target
+remains `target_uncertified` until the same real cluster gate is complete.
+This status is a certification statement, not a claim that all other versions
+are unusable.
+
+## Verified release boundaries
+
+The release gate covers:
+
+- warnings-as-errors unit and integration tests;
+- Ruff, Mypy, Bandit, and lock-file validation;
+- source distribution and clean-wheel installation;
+- official MCP `2026-07-28` stateless conformance;
+- stdio and Streamable HTTP;
+- hierarchical and Flat exposure;
+- stable 8-domain and 47-child contracts across processes;
+- real read-only Doris calls with zero management writes.
+
+## Known limits
+
+- `doris_admin` is reserved but not registered.
+- Doris-backed OAuth uses process-local state and is not a multi-worker or
+  multi-node mode.
+- ADBC execution is fail-closed on token-bound routes because the current
+  Arrow Flight client is process-global.
+- Ossie semantic grounding is optional, read-only, and does not compile or
+  execute semantic model expressions.
+- Native lineage requires a queryable companion provider; audit inference is
+  the primary path before Doris 4.0.6 and a degraded fallback afterward.

--- a/docs/tool-registry.md
+++ b/docs/tool-registry.md
@@ -1,18 +1,98 @@
-# Doris MCP Domain Tool Registry
+# Doris MCP Hierarchical Domain Catalog
 
-<!-- Generated from DomainManifestService; do not edit by hand. -->
+<!-- Generated from DorisDomainCatalog; do not edit by hand. -->
 
-| Domain tool | Read-only boundary | Child count | Discovery |
-|---|---|---:|---|
-| `doris_catalog` | Explore Doris catalogs, databases, tables, schemas, comments, indexes, key models, storage metadata, and object sizes. | 5 | Call with `{}` |
-| `doris_query` | Execute read-only Doris SQL, inspect plans and profiles, review slow queries, and use the optional ADBC provider. | 7 | Call with `{}` |
-| `doris_cluster` | Inspect Doris health, nodes, tasks, monitoring, memory, cache, compaction, workload, compute groups, and runtime capabilities. | 11 | Call with `{}` |
-| `doris_pipeline` | Inspect ingestion, load health, materialized views, data freshness, and upstream or downstream dependencies. | 5 | Call with `{}` |
-| `doris_search` | Search Doris data with text, vector, or hybrid retrieval and inspect or diagnose search analyzers and indexes. | 4 | Call with `{}` |
-| `doris_governance` | Analyze columns and storage, inspect lineage and access evidence, read audit metadata, and review UDF or authentication mappings. | 8 | Call with `{}` |
-| `doris_lakehouse` | Inspect external catalogs, lakehouse tables, snapshots, partitions, pushdown behavior, and Variant semi-structured columns. | 3 | Call with `{}` |
-| `doris_semantic` | Discover validated Ossie models bound to Doris and read permission-filtered semantic summaries, context, and mapping status. | 4 | Call with `{}` |
+| Domain | Child count | Enablement | Discovery |
+|---|---:|---|---|
+| `doris_catalog` | 5 | `readonly_domain_enabled` | `authorized_child_discovery` |
+| `doris_query` | 7 | `readonly_domain_enabled` | `authorized_child_discovery` |
+| `doris_cluster` | 11 | `readonly_domain_enabled` | `authorized_child_discovery` |
+| `doris_pipeline` | 5 | `readonly_domain_enabled` | `authorized_child_discovery` |
+| `doris_search` | 4 | `readonly_domain_enabled` | `authorized_child_discovery` |
+| `doris_governance` | 8 | `readonly_domain_enabled` | `authorized_child_discovery` |
+| `doris_lakehouse` | 3 | `readonly_domain_enabled` | `authorized_child_discovery` |
+| `doris_semantic` | 4 | `readonly_domain_enabled` | `authorized_child_discovery` |
 
-MCP `tools/list` exposes only these eight stable read-only domains. Call a domain with an empty object to receive its authorized, bounded child manifest. The manifest contains exact child names, schemas, version support, availability, evidence, and risk annotations.
+## Formal child tools
 
-A discoverable child that is not supported by the current runtime remains in the manifest with `callable=false`. A child without discovery permission is omitted entirely. Internal handlers, custom providers, and pre-1.0 flat names are not advertised by `tools/list`.
+| Feature ID | Handler binding | Authorization | Variants |
+|---|---|---|---|
+| `doris_catalog.list_catalogs` | `child:doris_catalog:list_catalogs` | `child:call:doris_catalog:list_catalogs` | `catalog_metadata` |
+| `doris_catalog.list_databases` | `child:doris_catalog:list_databases` | `child:call:doris_catalog:list_databases` | `database_metadata` |
+| `doris_catalog.list_tables` | `child:doris_catalog:list_tables` | `child:call:doris_catalog:list_tables` | `table_metadata` |
+| `doris_catalog.get_table_context` | `child:doris_catalog:get_table_context` | `child:call:doris_catalog:get_table_context` | `base_sections`, `vector_search_metadata`, `variant_v3_metadata` |
+| `doris_catalog.get_table_size` | `child:doris_catalog:get_table_size` | `child:call:doris_catalog:get_table_size` | `partition_statistics` |
+| `doris_query.execute_query` | `child:doris_query:execute_query` | `child:call:doris_query:execute_query` | `mysql_read_only` |
+| `doris_query.explain_query` | `child:doris_query:explain_query` | `child:call:doris_query:explain_query` | `base_explain`, `search_plan_facets` |
+| `doris_query.get_query_profile` | `child:doris_query:get_query_profile` | `child:call:doris_query:get_query_profile` | `query_profile` |
+| `doris_query.diagnose_query_performance` | `child:doris_query:diagnose_query_performance` | `child:call:doris_query:diagnose_query_performance` | `deterministic_query_diagnosis` |
+| `doris_query.list_slow_queries` | `child:doris_query:list_slow_queries` | `child:call:doris_query:list_slow_queries` | `audit_slow_queries` |
+| `doris_query.get_adbc_connection_info` | `child:doris_query:get_adbc_connection_info` | `child:call:doris_query:get_adbc_connection_info` | `adbc_flight_sql` |
+| `doris_query.execute_adbc_query` | `child:doris_query:execute_adbc_query` | `child:call:doris_query:execute_adbc_query` | `adbc_read_only` |
+| `doris_cluster.get_cluster_overview` | `child:doris_cluster:get_cluster_overview` | `child:call:doris_cluster:get_cluster_overview` | `cluster_summary` |
+| `doris_cluster.list_cluster_nodes` | `child:doris_cluster:list_cluster_nodes` | `child:call:doris_cluster:list_cluster_nodes` | `cluster_nodes` |
+| `doris_cluster.list_active_tasks` | `child:doris_cluster:list_active_tasks` | `child:call:doris_cluster:list_active_tasks` | `unified_task_progress`, `legacy_task_views` |
+| `doris_cluster.get_monitoring_metrics` | `child:doris_cluster:get_monitoring_metrics` | `child:call:doris_cluster:get_monitoring_metrics` | `observability_4_0_7`, `base_metrics` |
+| `doris_cluster.get_memory_stats` | `child:doris_cluster:get_memory_stats` | `child:call:doris_cluster:get_memory_stats` | `memory_trackers` |
+| `doris_cluster.get_cache_status` | `child:doris_cluster:get_cache_status` | `child:call:doris_cluster:get_cache_status` | `advanced_cache_types`, `file_cache_queue_metrics`, `file_cache` |
+| `doris_cluster.get_compaction_status` | `child:doris_cluster:get_compaction_status` | `child:call:doris_cluster:get_compaction_status` | `compaction_task_tracker`, `legacy_compaction_summary` |
+| `doris_cluster.get_workload_group_status` | `child:doris_cluster:get_workload_group_status` | `child:call:doris_cluster:get_workload_group_status` | `workload_group_metrics` |
+| `doris_cluster.get_compute_group_status` | `child:doris_cluster:get_compute_group_status` | `child:call:doris_cluster:get_compute_group_status` | `compute_group` |
+| `doris_cluster.analyze_resource_growth` | `child:doris_cluster:analyze_resource_growth` | `child:call:doris_cluster:analyze_resource_growth` | `historical_resource_metrics` |
+| `doris_cluster.get_runtime_capabilities` | `child:doris_cluster:get_runtime_capabilities` | `child:call:doris_cluster:get_runtime_capabilities` | `capability_snapshot` |
+| `doris_pipeline.get_ingestion_status` | `child:doris_pipeline:get_ingestion_status` | `child:call:doris_pipeline:get_ingestion_status` | `load_jobs`, `continuous_load` |
+| `doris_pipeline.diagnose_ingestion` | `child:doris_pipeline:diagnose_ingestion` | `child:call:doris_pipeline:diagnose_ingestion` | `deterministic_ingestion_diagnosis` |
+| `doris_pipeline.get_materialized_view_status` | `child:doris_pipeline:get_materialized_view_status` | `child:call:doris_pipeline:get_materialized_view_status` | `materialized_view_metadata`, `mtmv_compute_group` |
+| `doris_pipeline.monitor_data_freshness` | `child:doris_pipeline:monitor_data_freshness` | `child:call:doris_pipeline:monitor_data_freshness` | `freshness_evidence` |
+| `doris_pipeline.analyze_data_dependencies` | `child:doris_pipeline:analyze_data_dependencies` | `child:call:doris_pipeline:analyze_data_dependencies` | `audit_sql_dependencies` |
+| `doris_search.search_data` | `child:doris_search:search_data` | `child:call:doris_search:search_data` | `vector_hybrid_search`, `inverted_text_search` |
+| `doris_search.preview_text_analysis` | `child:doris_search:preview_text_analysis` | `child:call:doris_search:preview_text_analysis` | `tokenizer_preview` |
+| `doris_search.inspect_search_indexes` | `child:doris_search:inspect_search_indexes` | `child:call:doris_search:inspect_search_indexes` | `ann_index_metadata`, `inverted_index_metadata` |
+| `doris_search.diagnose_search_query` | `child:doris_search:diagnose_search_query` | `child:call:doris_search:diagnose_search_query` | `search_query_diagnosis` |
+| `doris_governance.analyze_columns` | `child:doris_governance:analyze_columns` | `child:call:doris_governance:analyze_columns` | `column_statistics` |
+| `doris_governance.analyze_table_storage` | `child:doris_governance:analyze_table_storage` | `child:call:doris_governance:analyze_table_storage` | `base_storage`, `storage_v3_variant` |
+| `doris_governance.get_lineage_capability_status` | `child:doris_governance:get_lineage_capability_status` | `child:call:doris_governance:get_lineage_capability_status` | `audit_lineage_status`, `native_lineage_status` |
+| `doris_governance.trace_column_lineage` | `child:doris_governance:trace_column_lineage` | `child:call:doris_governance:trace_column_lineage` | `audit_sql_inference_primary`, `native_lineage_events`, `audit_sql_inference_fallback` |
+| `doris_governance.analyze_data_access_patterns` | `child:doris_governance:analyze_data_access_patterns` | `child:call:doris_governance:analyze_data_access_patterns` | `audit_access_history` |
+| `doris_governance.get_recent_audit_logs` | `child:doris_governance:get_recent_audit_logs` | `child:call:doris_governance:get_recent_audit_logs` | `audit_log`, `audit_log_4_0_7` |
+| `doris_governance.list_udfs` | `child:doris_governance:list_udfs` | `child:call:doris_governance:list_udfs` | `base_udf_metadata`, `python_udf_family` |
+| `doris_governance.get_auth_mapping_status` | `child:doris_governance:get_auth_mapping_status` | `child:call:doris_governance:get_auth_mapping_status` | `ldap_mapping`, `oidc_role_mapping` |
+| `doris_lakehouse.inspect_external_catalog` | `child:doris_lakehouse:inspect_external_catalog` | `child:call:doris_lakehouse:inspect_external_catalog` | `external_catalog_metadata` |
+| `doris_lakehouse.inspect_lakehouse_table` | `child:doris_lakehouse:inspect_lakehouse_table` | `child:call:doris_lakehouse:inspect_lakehouse_table` | `lakehouse_lifecycle_4_1`, `lakehouse_table_metadata` |
+| `doris_lakehouse.inspect_variant_column` | `child:doris_lakehouse:inspect_variant_column` | `child:call:doris_lakehouse:inspect_variant_column` | `variant_advanced_4_1`, `variant_type` |
+| `doris_semantic.list_semantic_models` | `child:doris_semantic:list_semantic_models` | `child:call:doris_semantic:list_semantic_models` | `ossie_model_registry` |
+| `doris_semantic.get_semantic_model_summary` | `child:doris_semantic:get_semantic_model_summary` | `child:call:doris_semantic:get_semantic_model_summary` | `ossie_model_summary` |
+| `doris_semantic.get_semantic_context` | `child:doris_semantic:get_semantic_context` | `child:call:doris_semantic:get_semantic_context` | `ossie_semantic_context` |
+| `doris_semantic.get_semantic_mapping_status` | `child:doris_semantic:get_semantic_mapping_status` | `child:call:doris_semantic:get_semantic_mapping_status` | `ossie_doris_mapping` |
+
+## Pre-1.0 migration coverage
+
+| Flat tool | Handler | Formal feature | Mode | Section |
+|---|---|---|---|---|
+| `exec_query` | `_exec_query_tool` | `doris_query.execute_query` | `adapted` | - |
+| `get_table_schema` | `_get_table_schema_tool` | `doris_catalog.get_table_context` | `composite_section` | `schema` |
+| `get_db_table_list` | `_get_db_table_list_tool` | `doris_catalog.list_tables` | `adapted` | - |
+| `get_db_list` | `_get_db_list_tool` | `doris_catalog.list_databases` | `adapted` | - |
+| `get_table_comment` | `_get_table_comment_tool` | `doris_catalog.get_table_context` | `composite_section` | `comments` |
+| `get_table_column_comments` | `_get_table_column_comments_tool` | `doris_catalog.get_table_context` | `composite_section` | `comments` |
+| `get_table_indexes` | `_get_table_indexes_tool` | `doris_catalog.get_table_context` | `composite_section` | `indexes` |
+| `get_recent_audit_logs` | `_get_recent_audit_logs_tool` | `doris_governance.get_recent_audit_logs` | `adapted` | - |
+| `get_catalog_list` | `_get_catalog_list_tool` | `doris_catalog.list_catalogs` | `adapted` | - |
+| `get_sql_explain` | `_get_sql_explain_tool` | `doris_query.explain_query` | `adapted` | - |
+| `get_sql_profile` | `_get_sql_profile_tool` | `doris_query.get_query_profile` | `adapted` | - |
+| `get_table_data_size` | `_get_table_data_size_tool` | `doris_catalog.get_table_size` | `adapted` | - |
+| `get_monitoring_metrics` | `_get_monitoring_metrics_tool` | `doris_cluster.get_monitoring_metrics` | `adapted` | - |
+| `get_memory_stats` | `_get_memory_stats_tool` | `doris_cluster.get_memory_stats` | `adapted` | - |
+| `get_table_basic_info` | `_get_table_basic_info_tool` | `doris_catalog.get_table_context` | `composite_section` | `basic` |
+| `analyze_columns` | `_analyze_columns_tool` | `doris_governance.analyze_columns` | `adapted` | - |
+| `analyze_table_storage` | `_analyze_table_storage_tool` | `doris_governance.analyze_table_storage` | `adapted` | - |
+| `trace_column_lineage` | `_trace_column_lineage_tool` | `doris_governance.trace_column_lineage` | `adapted` | - |
+| `monitor_data_freshness` | `_monitor_data_freshness_tool` | `doris_pipeline.monitor_data_freshness` | `adapted` | - |
+| `analyze_data_access_patterns` | `_analyze_data_access_patterns_tool` | `doris_governance.analyze_data_access_patterns` | `adapted` | - |
+| `analyze_data_flow_dependencies` | `_analyze_data_flow_dependencies_tool` | `doris_pipeline.analyze_data_dependencies` | `adapted` | - |
+| `analyze_slow_queries_topn` | `_analyze_slow_queries_topn_tool` | `doris_query.list_slow_queries` | `adapted` | - |
+| `analyze_resource_growth_curves` | `_analyze_resource_growth_curves_tool` | `doris_cluster.analyze_resource_growth` | `adapted` | - |
+| `exec_adbc_query` | `_exec_adbc_query_tool` | `doris_query.execute_adbc_query` | `adapted` | - |
+| `get_adbc_connection_info` | `_get_adbc_connection_info_tool` | `doris_query.get_adbc_connection_info` | `atomic` | - |
+
+This document describes internal 1.0 routing contracts. The pre-1.0 flat names are migration inputs, not registered 1.0 tool aliases.

--- a/doris_mcp_server/_version.py
+++ b/doris_mcp_server/_version.py
@@ -16,4 +16,4 @@
 # under the License.
 """Build-time product version source."""
 
-__version__ = "0.6.1"
+__version__ = "1.0.0"

--- a/doris_mcp_server/tools/domain_manifest.py
+++ b/doris_mcp_server/tools/domain_manifest.py
@@ -452,38 +452,8 @@ class DomainManifestService:
         return list(self._tools)
 
     def render_markdown(self) -> str:
-        """Render deterministic public documentation from the domain catalog."""
-        lines = [
-            "# Doris MCP Domain Tool Registry",
-            "",
-            "<!-- Generated from DomainManifestService; do not edit by hand. -->",
-            "",
-            "| Domain tool | Read-only boundary | Child count | Discovery |",
-            "|---|---|---:|---|",
-        ]
-        for domain in self._catalog.domains:
-            lines.append(
-                f"| `{domain.name}` | {domain.description} | "
-                f"{len(domain.children)} | Call with `{{}}` |"
-            )
-        lines.extend(
-            [
-                "",
-                "MCP `tools/list` exposes only these eight stable read-only "
-                "domains. Call a domain with an empty object to receive its "
-                "authorized, bounded child manifest. The manifest contains "
-                "exact child names, schemas, version support, availability, "
-                "evidence, and risk annotations.",
-                "",
-                "A discoverable child that is not supported by the current "
-                "runtime remains in the manifest with `callable=false`. A child "
-                "without discovery permission is omitted entirely. Internal "
-                "handlers, custom providers, and pre-1.0 flat names are not "
-                "advertised by `tools/list`.",
-                "",
-            ]
-        )
-        return "\n".join(lines)
+        """Render the complete deterministic 1.0 tool catalog."""
+        return self._catalog.render_markdown()
 
     async def call(
         self,

--- a/doris_mcp_server/tools/doris_feature_matrix.py
+++ b/doris_mcp_server/tools/doris_feature_matrix.py
@@ -70,7 +70,7 @@ PullRequestReference = Annotated[
 ]
 
 _VERSION_LITERAL_PATTERN = re.compile(
-    r"\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)\d*)?",
+    r"\d+\.\d+\.\d+",
     re.IGNORECASE,
 )
 _RANGE_CLAUSE_PATTERN = re.compile(
@@ -812,7 +812,7 @@ def _version_literal(version: DorisVersion) -> str:
     core = version.core
     if core is None:
         raise ValueError("Cannot format an unparsed Doris version")
-    return f"{core}-{version.prerelease}" if version.prerelease else core
+    return core
 
 
 def _minimum_parsed_version(
@@ -1411,7 +1411,6 @@ FEATURE_DEFINITIONS = (
         _variant(
             "compaction_task_tracker",
             ranges=(">=4.0.6,<4.1.0", ">=4.1.1"),
-            excluded_ranges=(">=4.1.0-alpha0,<4.1.1",),
             system_objects=("information_schema.doris_be_compaction_tasks",),
             probes=("compaction_system_table_or_http_api",),
             sources=("DORIS_RELEASE_4_0_6", "DORIS_RELEASE_4_1_1"),

--- a/doris_mcp_server/tools/doris_version.py
+++ b/doris_mcp_server/tools/doris_version.py
@@ -44,17 +44,11 @@ _VERSION_PATTERN = re.compile(
     """,
     re.IGNORECASE | re.VERBOSE,
 )
-_PRERELEASE_PATTERN = re.compile(
-    r"(?P<kind>alpha|beta|rc)(?P<number>\d*)",
-    re.IGNORECASE,
-)
 _DEPLOYMENT_PATTERNS = (
     ("cloud", re.compile(r"\bcloud\s+mode\b", re.IGNORECASE)),
     ("shared_data", re.compile(r"\bshared[-\s]+data\b", re.IGNORECASE)),
     ("shared_nothing", re.compile(r"\bshared[-\s]+nothing\b", re.IGNORECASE)),
 )
-_PRERELEASE_RANK = {"alpha": 0, "beta": 1, "rc": 2}
-_NORMALIZED_PRERELEASE = {"alpha": "a", "beta": "b", "rc": "rc"}
 
 
 class DorisVersionParseStatus(StrEnum):
@@ -90,13 +84,8 @@ class DorisVersion:
 
     @property
     def normalized(self) -> str | None:
-        core = self.core
-        if core is None or self.prerelease is None:
-            return core
-
-        prerelease = _parse_prerelease(self.prerelease)
-        kind, number = prerelease
-        return f"{core}{_NORMALIZED_PRERELEASE[kind]}{number}"
+        """Return the three-part version used for every capability decision."""
+        return self.core
 
     def compare(self, other: DorisVersion) -> int:
         left = self._comparison_key()
@@ -106,7 +95,7 @@ class DorisVersion:
     def is_at_least(self, other: DorisVersion) -> bool:
         return self.compare(other) >= 0
 
-    def _comparison_key(self) -> tuple[int, int, int, int, int]:
+    def _comparison_key(self) -> tuple[int, int, int]:
         if (
             not self.is_parsed
             or self.major is None
@@ -115,20 +104,7 @@ class DorisVersion:
         ):
             raise ValueError("Cannot compare an unparsed Doris version")
 
-        if self.prerelease is None:
-            prerelease_rank = len(_PRERELEASE_RANK)
-            prerelease_number = 0
-        else:
-            kind, prerelease_number = _parse_prerelease(self.prerelease)
-            prerelease_rank = _PRERELEASE_RANK[kind]
-
-        return (
-            self.major,
-            self.minor,
-            self.patch,
-            prerelease_rank,
-            prerelease_number,
-        )
+        return (self.major, self.minor, self.patch)
 
 
 def parse_doris_version_comment(comment: str) -> DorisVersion:
@@ -177,15 +153,6 @@ async def probe_doris_version(connection: DorisConnection) -> DorisVersion:
         max_bytes=_VERSION_COMMENT_MAX_BYTES,
     )
     return parse_doris_version_rows(result.data)
-
-
-def _parse_prerelease(value: str) -> tuple[str, int]:
-    match = _PRERELEASE_PATTERN.fullmatch(value)
-    if match is None:
-        raise ValueError(f"Unsupported Doris prerelease: {value}")
-    kind = match.group("kind").lower()
-    number = int(match.group("number") or "0")
-    return kind, number
 
 
 def _detect_deployment_hint(comment: str) -> str | None:

--- a/generate_tool_catalog.py
+++ b/generate_tool_catalog.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Generate the checked-in 1.0 domain and child tool catalog."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from doris_mcp_server.tools.domain_catalog import DORIS_DOMAIN_CATALOG
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent
+OUTPUT_PATH = REPOSITORY_ROOT / "docs" / "tool-registry.md"
+
+
+def render_catalog() -> str:
+    """Render the exact catalog source of truth with a terminal newline."""
+    return DORIS_DOMAIN_CATALOG.render_markdown()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate the Doris MCP Server 1.0 tool catalog."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail when the checked-in catalog differs from the source.",
+    )
+    args = parser.parse_args()
+    rendered = render_catalog()
+
+    if args.check:
+        if not OUTPUT_PATH.exists() or OUTPUT_PATH.read_text(
+            encoding="utf-8"
+        ) != rendered:
+            parser.error(
+                "docs/tool-registry.md is stale; run generate_tool_catalog.py"
+            )
+        return 0
+
+    OUTPUT_PATH.write_text(rendered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ include = [
     "/doris_mcp_server",
     "/CHANGELOG.md",
     "/README.md",
+    "/docs/migration-1.0.0.md",
+    "/docs/release-notes-1.0.0.md",
+    "/docs/tool-registry.md",
     "/LICENSE.txt",
     "/NOTICE",
 ]

--- a/test/deployment/test_github_actions_contract.py
+++ b/test/deployment/test_github_actions_contract.py
@@ -77,11 +77,13 @@ def test_quality_test_and_package_gates_cover_the_release_contract():
 
     assert "uv lock --check" in quality
     assert "uv sync --frozen --group dev" in quality
+    assert "uv run python generate_tool_catalog.py --check" in quality
     assert "uv run ruff check ." in quality
     assert "uv run mypy doris_mcp_server" in quality
     assert (
         "uv run bandit -q -c pyproject.toml -r "
-        "doris_mcp_server doris_mcp_client generate_requirements.py"
+        "doris_mcp_server doris_mcp_client generate_requirements.py "
+        "generate_tool_catalog.py"
     ) in " ".join(quality.split())
 
     assert "uv sync --frozen --group dev" in tests

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -1,0 +1,96 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Release artifacts must remain generated, English, and identity-aligned."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+from doris_mcp_server import __version__
+from doris_mcp_server.tools.domain_catalog import (
+    DORIS_DOMAIN_CATALOG,
+    FORMAL_CHILD_FEATURE_IDS,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+TOOL_CATALOG = REPOSITORY_ROOT / "docs" / "tool-registry.md"
+MIGRATION_GUIDE = REPOSITORY_ROOT / "docs" / "migration-1.0.0.md"
+RELEASE_NOTES = REPOSITORY_ROOT / "docs" / "release-notes-1.0.0.md"
+HAN_TEXT = re.compile(r"[\u3400-\u9fff]")
+
+
+def test_release_identity_and_documents_are_1_0_0() -> None:
+    readme = (REPOSITORY_ROOT / "README.md").read_text(encoding="utf-8")
+    chinese_readme = (REPOSITORY_ROOT / "README.zh-CN.md").read_text(
+        encoding="utf-8"
+    )
+    changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert __version__ == "1.0.0"
+    assert "pip install doris-mcp-server==1.0.0" in readme
+    assert "pip install doris-mcp-server==1.0.0" in chinese_readme
+    assert "[1.0.0] - 2026-07-31" in changelog
+    assert "[Unreleased]: " in changelog
+    assert "compare/1.0.0...HEAD" in changelog
+    assert "docs/migration-1.0.0.md" in readme
+    assert "docs/release-notes-1.0.0.md" in readme
+    assert "docs/tool-registry.md" in readme
+
+
+def test_source_distribution_includes_release_documents() -> None:
+    pyproject = tomllib.loads(
+        (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    included = set(pyproject["tool"]["hatch"]["build"]["targets"]["sdist"]["include"])
+
+    assert {
+        "/docs/migration-1.0.0.md",
+        "/docs/release-notes-1.0.0.md",
+        "/docs/tool-registry.md",
+    }.issubset(included)
+
+
+def test_generated_tool_catalog_matches_the_runtime_source() -> None:
+    catalog = TOOL_CATALOG.read_text(encoding="utf-8")
+    summary = DORIS_DOMAIN_CATALOG.summary()
+
+    assert catalog == DORIS_DOMAIN_CATALOG.render_markdown()
+    assert summary.domain_count == 8
+    assert summary.child_count == 47
+    assert summary.migrated_flat_tool_count == 25
+    assert len(FORMAL_CHILD_FEATURE_IDS) == 47
+    assert all(f"`{feature_id}`" in catalog for feature_id in FORMAL_CHILD_FEATURE_IDS)
+
+
+def test_new_release_documents_are_english_only() -> None:
+    for path in (TOOL_CATALOG, MIGRATION_GUIDE, RELEASE_NOTES):
+        content = path.read_text(encoding="utf-8")
+        assert not HAN_TEXT.search(content), path
+
+
+def test_migration_guide_does_not_promise_legacy_aliases() -> None:
+    guide = MIGRATION_GUIDE.read_text(encoding="utf-8")
+    normalized = " ".join(guide.split())
+
+    assert "not registered as aliases" in guide
+    assert "Flat mode does not restore pre-1.0 names." in guide
+    assert "do not make the old call names discoverable or callable" in normalized
+    assert "MCP_TOOL_EXPOSURE_MODE=flat" in guide
+    assert "ENABLE_LEGACY_HTTP_ADAPTER=true" in guide

--- a/test/tools/test_capability_detector.py
+++ b/test/tools/test_capability_detector.py
@@ -172,7 +172,7 @@ async def test_detector_builds_version_vector_and_extends_domains_lazily() -> No
 
     assert base.route.fingerprint == "route-a"
     assert base.capability_generation == 3
-    assert base.version_vector.master_fe.normalized == "4.0.5rc1"
+    assert base.version_vector.master_fe.normalized == "4.0.5"
     assert len(base.version_vector.follower_fes) == 1
     assert len(base.version_vector.backends) == 2
     assert base.mixed_versions is False
@@ -792,7 +792,7 @@ async def test_detector_ignores_explicitly_dead_backend_for_version_gating() -> 
 
     assert tuple(
         version.normalized for version in snapshot.version_vector.backends
-    ) == ("4.0.5rc1",)
+    ) == ("4.0.5",)
     assert evaluation.compatible is True
 
 
@@ -827,7 +827,7 @@ async def test_detector_uses_fallback_for_unknown_master_and_retains_follower() 
         variant_name="native_lineage_status",
     )
 
-    assert snapshot.version_vector.master_fe.normalized == "4.0.5rc1"
+    assert snapshot.version_vector.master_fe.normalized == "4.0.5"
     assert len(snapshot.version_vector.follower_fes) == 1
     assert snapshot.version_vector.follower_fes[0].is_parsed is False
     assert evaluation.compatible is False
@@ -1149,7 +1149,7 @@ async def test_cluster_probe_keeps_405_compaction_on_real_legacy_evidence(
 
     snapshot = await detector.detect_domain(base, "doris_cluster", None)
 
-    assert snapshot.version_vector.master_fe.normalized == "4.0.5rc1"
+    assert snapshot.version_vector.master_fe.normalized == "4.0.5"
     assert (
         snapshot.probe("information_schema.doris_be_compaction_tasks").status
         is CapabilityProbeStatus.UNSUPPORTED

--- a/test/tools/test_domain_manifest.py
+++ b/test/tools/test_domain_manifest.py
@@ -310,8 +310,8 @@ async def test_realistic_runtime_evidence_stays_within_manifest_budget() -> None
             reason_code="CAPABILITY_VERIFIED_DEGRADED_UNCERTIFIED",
             active_variant="legacy_compaction_summary",
             detected_versions={
-                "master_fe": ("4.0.5rc1",),
-                "be": ("4.0.5rc1",),
+                "master_fe": ("4.0.5",),
+                "be": ("4.0.5",),
             },
             evidence_sources=(
                 "version_probe",

--- a/test/tools/test_doris_feature_matrix.py
+++ b/test/tools/test_doris_feature_matrix.py
@@ -302,8 +302,8 @@ def test_certification_uses_three_part_core_for_rc_and_ga_builds() -> None:
     )
     assert rc_report.uniform_observed_version == "4.0.5"
     assert ga_report.uniform_observed_version == "4.0.5"
-    assert rc_report.observed_fe_versions == ("4.0.5rc1",)
-    assert rc_report.observed_be_versions == ("4.0.5rc1",)
+    assert rc_report.observed_fe_versions == ("4.0.5",)
+    assert rc_report.observed_be_versions == ("4.0.5",)
     assert rc_report.status is VersionCertificationStatus.CERTIFIED
     assert ga_report.status is VersionCertificationStatus.CERTIFIED
     assert rc_report.evidence_ids == ("doris_4_0_5_linux_amd64",)
@@ -366,12 +366,12 @@ def test_patch_evidence_rejects_incomplete_host_or_component_proof() -> None:
 @pytest.mark.parametrize(
     ("expression", "matching", "not_matching"),
     [
-        (">=3.0.0", "4.1.3", "3.0.0-rc01"),
+        (">=3.0.0", "3.0.0-rc01", "2.1.9"),
         (">=4.0.6,<4.1.0", "4.0.7", "4.1.0"),
         ("==4.1.0", "4.1.0", "4.1.1"),
         (">4.1.0", "4.1.1", "4.1.0"),
         ("<=4.0.6", "4.0.6", "4.0.7"),
-        ("<4.0.6", "4.0.6-rc02", "4.0.6"),
+        ("<4.0.6", "4.0.5-rc02", "4.0.6-rc02"),
     ],
 )
 def test_version_range_operators(
@@ -402,6 +402,7 @@ def test_version_range_normalizes_spacing() -> None:
         "4.0.6",
         "=>4.0.6",
         ">=4.0",
+        ">=4.0.6-rc01",
         ">=4.0.6,",
         ">=4.0.6,<4.0.6",
         ">=4.1.0,<4.0.0",
@@ -437,7 +438,7 @@ def test_unknown_version_never_matches_a_range() -> None:
     assert DorisVersionRange(">=3.0.0").contains(unknown) is False
 
 
-def test_version_range_orders_rc_before_stable_and_ignores_commit() -> None:
+def test_version_range_uses_core_and_ignores_release_metadata() -> None:
     stable_range = DorisVersionRange(">=4.0.6")
     release_candidate = parse_doris_version_comment(
         "Doris version doris-4.0.6-rc03-43f06a5e26"
@@ -446,7 +447,7 @@ def test_version_range_orders_rc_before_stable_and_ignores_commit() -> None:
         "Doris version doris-4.0.6-abcdef1234"
     )
 
-    assert stable_range.contains(release_candidate) is False
+    assert stable_range.contains(release_candidate) is True
     assert stable_range.contains(stable_with_commit) is True
     assert DorisVersionRange("==4.0.6").contains(stable_with_commit) is True
 
@@ -554,7 +555,7 @@ def test_lineage_native_and_audit_paths_are_both_explicit() -> None:
         ("4.1.0", False),
         ("4.1.1", False),
         ("4.1.2", False),
-        ("4.1.3-rc01", False),
+        ("4.1.3-rc01", True),
         ("4.1.3", True),
     ],
 )
@@ -856,7 +857,7 @@ def test_matrix_rejects_a_prerelease_minimum() -> None:
     payload = _matrix_payload()
     payload["minimum_supported_version"] = "3.0.0-rc01"
 
-    with pytest.raises(ValidationError, match="minimum supported version"):
+    with pytest.raises(ValidationError, match="version literal"):
         DorisFeatureMatrix.model_validate(payload)
 
 

--- a/test/tools/test_doris_version.py
+++ b/test/tools/test_doris_version.py
@@ -42,7 +42,7 @@ def test_version_probe_uses_version_comment() -> None:
             "rc03",
             "43f06a5e26",
             "cloud",
-            "3.0.3rc3",
+            "3.0.3",
         ),
         (
             "Apache Doris version 4.0.7",
@@ -101,16 +101,16 @@ def test_unknown_version_comments_fail_closed(comment: str) -> None:
     assert version.normalized is None
 
 
-def test_comparison_ignores_commit_and_orders_prereleases() -> None:
+def test_comparison_uses_only_three_part_version() -> None:
     alpha = parse_doris_version_comment("Doris version 3.0.3-alpha1")
     beta = parse_doris_version_comment("Doris version 3.0.3-beta2")
     release_candidate = parse_doris_version_comment("Doris version 3.0.3-rc03")
     stable_a = parse_doris_version_comment("Doris version 3.0.3-43f06a5e26")
     stable_b = parse_doris_version_comment("Doris version 3.0.3-abcdef1234")
 
-    assert beta.compare(alpha) > 0
-    assert release_candidate.compare(beta) > 0
-    assert stable_a.compare(release_candidate) > 0
+    assert beta.compare(alpha) == 0
+    assert release_candidate.compare(beta) == 0
+    assert stable_a.compare(release_candidate) == 0
     assert stable_a.compare(stable_b) == 0
     assert stable_a.is_at_least(release_candidate) is True
 
@@ -160,7 +160,7 @@ async def test_probe_executes_exact_read_only_query() -> None:
 
     version = await probe_doris_version(connection)
 
-    assert version.normalized == "3.0.3rc3"
+    assert version.normalized == "3.0.3"
     assert version.deployment_hint == "cloud"
     connection.execute.assert_awaited_once_with(
         DORIS_VERSION_COMMENT_QUERY,


### PR DESCRIPTION
## Summary

- Set the package and Server identity to 1.0.0.
- Publish the 1.0 migration guide, release notes, and a generated 8-domain/47-child tool catalog.
- Verify catalog drift in CI and include the release documents in the source distribution.
- Normalize all Doris capability, version-range, and certification decisions to major.minor.patch. RC, GA, commit, and deployment metadata remain diagnostic evidence only.
- Keep the pre-1.0 direct tool names removed, with no alias compatibility window.

## Compatibility and safety

- Hierarchical exposure remains the default eight-domain surface; Flat remains the explicit 47-tool fallback.
- Doris 4.0.5 is the only evidence-backed certified patch in this release. Other target patches remain target_uncertified.
- The reserved administration domain remains unregistered and no management write operation is exposed.
- The Python package retains its Beta deployment classifier while the MCP 2026-07-28 protocol contract is GA on the supported transports.

## Verification

- Full warnings-as-errors suite: 1744 passed, 81 skipped; 67.62% repository coverage.
- Coverage domains: protocol 90.34%, authentication 81.55%, core managers 87.03%.
- Ruff, Mypy, Bandit, lock-file validation, and generated-catalog drift checks passed.
- Official MCP 2026-07-28 stateless conformance: 25/25 passed, 0 failures, 0 warnings.
- Real Doris acceptance passed for stdio and Streamable HTTP in hierarchical and Flat modes, with real read-only queries and zero write operations.
- The observed prerelease build remained available as raw evidence while FE, BE, capability, and certification versions normalized to 4.0.5.
- Wheel and source distribution builds passed, including clean-wheel CLI, import, version, and runtime-dependency smoke tests.
