### PR TITLE
Add MetricFlow consumers and Doris 2.x capability gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,25 @@ under **Unreleased** until a new version is selected and published.
 
 ## [Unreleased]
 
+### Added
+
+- Added eight default-off MetricFlow consumer children to `doris_semantic`
+  for exact-model discovery, status, metrics, group-bys, saved queries,
+  dimension values, Doris SQL compilation, and bounded execution through the
+  existing MCP Query runtime.
+- Added a bounded `doris-mcp-metricflow/v1` sidecar contract and bilingual
+  Doris 2.0+ version capability matrix.
+
 ### Changed
+
+- Expanded the stable public contract from 47 to 55 children while retaining
+  the same eight top-level domains and progressive-disclosure budgets.
+- Lowered the project-wide Doris baseline from 3.0.0 to 2.0.0 and moved
+  version-dependent behavior into per-child release, runtime-probe, provider,
+  route, and permission gates.
+- Made ADBC an advanced default-off path that requires explicit end-user
+  ADBC/Arrow Flight SQL intent and `explicit_adbc=true`; ordinary queries use
+  `doris_query.execute_query`.
 
 - Rebuilt the root English and Simplified Chinese READMEs as concise 1.0 entry
   points instead of mixing architecture, operations, integration, and release
@@ -36,7 +54,7 @@ under **Unreleased** until a new version is selected and published.
   guidance.
 - Published the detailed 1.0 release record in
   [Issue #189](https://github.com/apache/doris-mcp-server/issues/189), including
-  the complete 8-domain/47-child surface, capability detection, security,
+  the complete 8-domain/55-child surface, capability detection, security,
   reliability, compatibility, migration, and verification boundaries.
 - Added Simplified Chinese editions of the custom Tool Provider and Doris
   fine-grained access-control guides, and included the complete documentation
@@ -44,6 +62,12 @@ under **Unreleased** until a new version is selected and published.
 
 ### Fixed
 
+- Kept the fully available 12-child Semantic manifest below the 16 KiB
+  progressive-disclosure budget by publishing only the child call signature;
+  the Server still applies the complete validation schema at execution time.
+- Added real Doris HTTP and stdio coverage for all eight MetricFlow consumer
+  children, including compile-only behavior and guarded execution of compiled
+  SQL through the standard Query runtime.
 - Migrated the opt-in real Doris process integration suite from removed legacy
   tool names to the 1.0 hierarchical domain discovery and exact Child
   execution contract across Streamable HTTP and stdio.
@@ -93,9 +117,9 @@ under **Unreleased** until a new version is selected and published.
 - A read-only Lakehouse domain with capability-gated external-catalog,
   lakehouse-table, snapshot, partition, pushdown, and Variant-shape
   inspection.
-- An experimental read-only Apache Ossie Core semantic-grounding domain with
-  four capability-gated children, revisioned model-summary resources, and
-  explicit server-private Doris binding manifests.
+- An experimental read-only Semantic domain with four Apache Ossie Core
+  grounding children, eight MetricFlow consumer children, revisioned
+  model-summary resources, and explicit server-private Doris bindings.
 - A fail-closed `doris_admin` architecture reservation that defines future
   high-risk action, scope, preview/execute, confirmation, idempotency, and
   rollback contracts without registering any management capability.
@@ -161,7 +185,7 @@ under **Unreleased** until a new version is selected and published.
   `major.minor.patch`; RC, GA, commit, and deployment metadata remain evidence
   only and never create a separate support result.
 - Published the 1.0 migration guide and release notes, and generated the exact
-  8-domain/47-child tool catalog from the runtime catalog as a checked-in,
+  8-domain/55-child tool catalog from the runtime catalog as a checked-in,
   CI-verified release artifact.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ under the License.
 
 Apache Doris MCP Server exposes read-only Apache Doris capabilities to MCP
 Hosts and AI agents over MCP `2026-07-28`. Version 1.0 replaces a large flat
-tool surface with eight stable domains and forty-seven progressively disclosed
+tool surface with eight stable domains and fifty-five progressively disclosed
 child capabilities, while keeping runtime availability, authorization, input
 schemas, output schemas, and failure behavior explicit.
 
@@ -36,7 +36,7 @@ classifier remains **Beta**, and the documented deployment limits still apply.
 
 Before upgrading, read the [1.0 release notes](docs/release-notes-1.0.0.md),
 the [1.0 migration guide](docs/migration-1.0.0.md), and the generated
-[8-domain/47-child registry](docs/tool-registry.md). The detailed release
+[8-domain/55-child registry](docs/tool-registry.md). The detailed release
 record is [Issue #189](https://github.com/apache/doris-mcp-server/issues/189).
 
 ## Architecture at a glance
@@ -58,18 +58,18 @@ The default `hierarchical` mode exposes these domains:
 | Domain | Children | Responsibility |
 |---|---:|---|
 | `doris_catalog` | 5 | catalogs, databases, tables, table context, size |
-| `doris_query` | 7 | query, explain, profile, diagnosis, slow queries, ADBC |
+| `doris_query` | 7 | query, explain, profile, diagnosis, slow queries, explicit ADBC |
 | `doris_cluster` | 11 | nodes, tasks, metrics, memory, cache, compaction, workloads |
 | `doris_pipeline` | 5 | ingestion, materialized views, freshness, dependencies |
 | `doris_search` | 4 | text/vector/hybrid search, analyzers, indexes, diagnosis |
 | `doris_governance` | 8 | quality, storage, lineage, audit, UDFs, auth mapping |
 | `doris_lakehouse` | 3 | external catalogs, lakehouse tables, Variant |
-| `doris_semantic` | 4 | optional read-only Apache Ossie grounding |
+| `doris_semantic` | 12 | optional Apache Ossie grounding and MetricFlow consumption |
 
 Call a domain with `{}` to discover its authorized children and exact schemas.
 Call the same domain again with `child_tool`, `arguments`, and the returned
 `manifest_version`. Hosts that cannot use progressive disclosure may set
-`MCP_TOOL_EXPOSURE_MODE=flat` before startup; this exposes the same 47 children
+`MCP_TOOL_EXPOSURE_MODE=flat` before startup; this exposes the same 55 children
 under collision-free formal names and does not restore pre-1.0 aliases.
 
 See [Architecture](docs/architecture/overview.md),
@@ -81,7 +81,7 @@ See [Architecture](docs/architecture/overview.md),
 Requirements:
 
 - Python 3.12 or later;
-- Apache Doris 3.0.0 or later;
+- Apache Doris 2.0.0 or later;
 - network access to the Doris FE MySQL endpoint, normally port `9030`.
 
 Install the pinned release:
@@ -153,8 +153,10 @@ Schema validation, and sanitized trace propagation. Unsupported or
 misconfigured capabilities remain discoverable with `callable=false` and fail
 closed when called.
 
-Current limits include process-local Doris-backed OAuth, fail-closed ADBC on
-token-bound routes, optional read-only Ossie grounding, and best-effort native
+Current limits include process-local Doris-backed OAuth, explicit-only ADBC
+that is disabled by default and fail-closed on token-bound routes, optional
+read-only Ossie grounding, an optional MetricFlow compiler sidecar whose SQL
+must execute through the bounded MCP query runtime, and best-effort native
 lineage delivery. See [Reliability and limits](docs/operations/reliability.md).
 
 ## Documentation
@@ -171,6 +173,8 @@ Primary guides:
 - [Request and data flow](docs/architecture/request-lifecycle.md)
 - [Tool domains](docs/capabilities/tool-domains.md)
 - [Capability availability](docs/capabilities/availability.md)
+- [Doris version capability matrix](docs/capabilities/doris-version-matrix.md)
+- [MetricFlow integration](docs/integrations/metricflow.md)
 - [MCP 2026-07-28 contract](docs/protocol/mcp-2026-07-28.md)
 - [Security model](docs/security/security-model.md)
 - [Deployment](docs/operations/deployment.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,7 +23,7 @@ under the License.
 
 Apache Doris MCP Server 通过 MCP `2026-07-28`，向 MCP Host 和 AI Agent
 提供只读的 Apache Doris 能力。1.0 版本把过去庞大的扁平工具集合重构为 8 个
-稳定一级领域和 47 个渐进披露的二级能力，同时明确表达运行时可用性、权限、输入
+稳定一级领域和 55 个渐进披露的二级能力，同时明确表达运行时可用性、权限、输入
 Schema、输出 Schema 与失败行为。
 
 ## 发布状态
@@ -34,7 +34,7 @@ Python 包分类仍为 **Beta**，已记录的部署限制仍然有效。
 
 升级前请阅读 [1.0 发布说明](docs/releases/1.0.0.zh-CN.md)、
 [1.0 迁移指南](docs/migration/1.0.0.zh-CN.md)和自动生成的
-[8 领域 / 47 子能力目录](docs/tool-registry.md)。详细发布记录见
+[8 领域 / 55 子能力目录](docs/tool-registry.md)。详细发布记录见
 [Issue #189](https://github.com/apache/doris-mcp-server/issues/189)。
 
 ## 架构概览
@@ -56,18 +56,18 @@ MCP Host
 | 领域 | Child 数量 | 职责 |
 |---|---:|---|
 | `doris_catalog` | 5 | Catalog、数据库、表、表上下文、大小 |
-| `doris_query` | 7 | 查询、Explain、Profile、诊断、慢查询、ADBC |
+| `doris_query` | 7 | 查询、Explain、Profile、诊断、慢查询、显式 ADBC |
 | `doris_cluster` | 11 | 节点、任务、指标、内存、缓存、Compaction、工作负载 |
 | `doris_pipeline` | 5 | 导入、物化视图、新鲜度、依赖关系 |
 | `doris_search` | 4 | 文本/向量/混合检索、分词、索引、诊断 |
 | `doris_governance` | 8 | 质量、存储、血缘、审计、UDF、认证映射 |
 | `doris_lakehouse` | 3 | 外部 Catalog、湖仓表、Variant |
-| `doris_semantic` | 4 | 可选的只读 Apache Ossie 语义接入 |
+| `doris_semantic` | 12 | 可选 Apache Ossie Grounding 与 MetricFlow 消费 |
 
 使用 `{}` 调用一级领域，可以获得当前身份有权发现的 Child 和精确 Schema；
 随后用 `child_tool`、`arguments` 和返回的 `manifest_version` 调用同一个领域。
 无法使用渐进披露的 Host 可以在启动前设置 `MCP_TOOL_EXPOSURE_MODE=flat`，
-以无冲突正式名称公开同样的 47 个 Child；该模式不会恢复 1.0 以前的旧名称。
+以无冲突正式名称公开同样的 55 个 Child；该模式不会恢复 1.0 以前的旧名称。
 
 详见[总体架构](docs/architecture/overview.zh-CN.md)、
 [请求与数据链路](docs/architecture/request-lifecycle.zh-CN.md)和
@@ -78,7 +78,7 @@ MCP Host
 运行要求：
 
 - Python 3.12 或更高版本；
-- Apache Doris 3.0.0 或更高版本；
+- Apache Doris 2.0.0 或更高版本；
 - 可以访问 Doris FE MySQL 端口，通常为 `9030`。
 
 安装固定版本：
@@ -145,9 +145,11 @@ Server 使用确定性 Manifest 与错误模型、签名并带有效期的游标
 Schema 校验以及清洗后的 Trace 传播。未支持或配置错误的 Child 仍可在有权限时
 以 `callable=false` 被发现，真正调用时按 Fail Closed 处理。
 
-当前限制包括：Doris OAuth 状态只存在于单进程、Token 路由上的 ADBC
-Fail Closed、Ossie 只做可选只读 Grounding，以及原生血缘事件采用异步
-Best-effort 投递。详见[可靠性与限制](docs/operations/reliability.zh-CN.md)。
+当前限制包括：Doris OAuth 状态只存在于单进程；ADBC 默认关闭，只有用户明确
+指定 ADBC/Arrow Flight SQL 时才能调用，并在 Token 路由上 Fail Closed；Ossie
+只做可选只读 Grounding；MetricFlow 依赖可选编译 Sidecar，编译后的 SQL 必须
+回到 MCP 有界查询运行时执行；原生血缘事件采用异步 Best-effort 投递。详见
+[可靠性与限制](docs/operations/reliability.zh-CN.md)。
 
 ## 文档体系
 
@@ -162,6 +164,8 @@ Best-effort 投递。详见[可靠性与限制](docs/operations/reliability.zh-C
 - [请求与数据链路](docs/architecture/request-lifecycle.zh-CN.md)
 - [工具领域](docs/capabilities/tool-domains.zh-CN.md)
 - [能力可用性](docs/capabilities/availability.zh-CN.md)
+- [Doris 版本能力矩阵](docs/capabilities/doris-version-matrix.zh-CN.md)
+- [MetricFlow 接入](docs/integrations/metricflow.zh-CN.md)
 - [MCP 2026-07-28 合同](docs/protocol/mcp-2026-07-28.zh-CN.md)
 - [安全模型](docs/security/security-model.zh-CN.md)
 - [部署](docs/operations/deployment.zh-CN.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,9 +50,11 @@ migration, and release concerns.
 
 ## Capabilities
 
-- [Tool domains](capabilities/tool-domains.md) — the 8-domain/47-child contract.
+- [Tool domains](capabilities/tool-domains.md) — the 8-domain/55-child contract.
 - [Capability availability](capabilities/availability.md) — version parsing,
   probes, providers, permissions, manifests, and fail-closed behavior.
+- [Doris version capability matrix](capabilities/doris-version-matrix.md) —
+  the 2.0+ baseline and release-aware feature gates.
 - [Generated tool registry](tool-registry.md) — authoritative generated names,
   handler bindings, authorization identifiers, variants, and migration inputs.
 
@@ -82,6 +84,7 @@ migration, and release concerns.
 
 - [Configuration reference](reference/configuration.md)
 - [Host integrations](integrations/hosts.md)
+- [MetricFlow integration](integrations/metricflow.md)
 - [Custom tool providers](custom-tool-providers.md)
 
 ## Development, migration, and releases

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -47,9 +47,11 @@ under the License.
 
 ## 能力
 
-- [工具领域](capabilities/tool-domains.zh-CN.md)——8 领域 / 47 Child 合同。
+- [工具领域](capabilities/tool-domains.zh-CN.md)——8 领域 / 55 Child 合同。
 - [能力可用性](capabilities/availability.zh-CN.md)——版本解析、Probe、Provider、
   权限、Manifest 和 Fail Closed 行为。
+- [Doris 版本能力矩阵](capabilities/doris-version-matrix.zh-CN.md)——2.0+ 基线与
+  Release-aware 特性 Gate。
 - [自动生成工具目录](tool-registry.md)——正式名称、Handler 绑定、授权标识、
   Variant 和迁移输入的唯一事实源。
 
@@ -78,6 +80,7 @@ under the License.
 
 - [配置参考](reference/configuration.zh-CN.md)
 - [Host 集成](integrations/hosts.zh-CN.md)
+- [MetricFlow 接入](integrations/metricflow.zh-CN.md)
 - [自定义 Tool Provider](custom-tool-providers.zh-CN.md)
 
 ## 开发、迁移与发布

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -68,6 +68,7 @@ flowchart TB
     subgraph Backends["Backends and optional providers"]
       Doris["Apache Doris FE / BE"]
       Ossie["Apache Ossie model repository"]
+      MetricFlow["MetricFlow compiler sidecar"]
       Lineage["Queryable lineage store"]
       Flight["ADBC / Arrow Flight SQL"]
     end
@@ -75,6 +76,7 @@ flowchart TB
     Client --> Transport
     Routes --> Doris
     Runtime --> Ossie
+    Runtime --> MetricFlow
     Runtime --> Lineage
     Runtime --> Flight
 ```
@@ -161,7 +163,7 @@ step that returns exact child names and schemas.
 External business APIs can be added through explicit Python entry points and
 the `MCP_TOOL_PROVIDERS` allowlist. Provider tools have their own lifecycle,
 schemas, audit metadata, and rate limits. They are not members of the built-in
-8/47 contract and cannot shadow built-in names.
+8/55 contract and cannot shadow built-in names.
 
 ### Apache Ossie
 
@@ -169,6 +171,20 @@ The semantic domain consumes reviewed Ossie models for read-only grounding.
 Models remain owned by the semantic repository. The Server requires exact
 `model_ref` selection and a private Doris binding manifest; it does not guess,
 author, compile, or execute semantic expressions.
+
+### MetricFlow
+
+The semantic domain also consumes MetricFlow models through a default-off
+sidecar protocol. The provider owns model loading and Doris SQL compilation;
+the Server requires an exact `model_ref` and keeps SQL validation, Doris route,
+RBAC, execution limits, audit, and results inside `DorisQueryRuntime`. The
+provider does not execute Doris SQL.
+
+### ADBC
+
+ADBC is a default-off advanced Query variant, not an automatic query route.
+Both ADBC children require explicit end-user ADBC/Arrow Flight SQL intent and
+`explicit_adbc=true`; ordinary SQL remains on `execute_query`.
 
 ### Native lineage
 
@@ -200,7 +216,7 @@ preview/confirm/idempotency/rollback security contract.
 
 ## Invariants
 
-- Exactly eight built-in read-only domains and forty-seven built-in children.
+- Exactly eight built-in read-only domains and fifty-five built-in children.
 - One exact handler and authorization identifier per child.
 - One catalog drives hierarchical mode, flat mode, generated docs, and tests.
 - No old-name alias window.

--- a/docs/architecture/overview.zh-CN.md
+++ b/docs/architecture/overview.zh-CN.md
@@ -66,6 +66,7 @@ flowchart TB
     subgraph Backends["后端与可选 Provider"]
       Doris["Apache Doris FE / BE"]
       Ossie["Apache Ossie 模型仓库"]
+      MetricFlow["MetricFlow 编译 Sidecar"]
       Lineage["可查询血缘存储"]
       Flight["ADBC / Arrow Flight SQL"]
     end
@@ -73,6 +74,7 @@ flowchart TB
     Client --> Transport
     Routes --> Doris
     Runtime --> Ossie
+    Runtime --> MetricFlow
     Runtime --> Lineage
     Runtime --> Flight
 ```
@@ -145,13 +147,26 @@ Doris 对查询执行、元数据、Catalog 联邦、工作负载状态、存储
 
 外部业务 API 可以通过显式 Python Entry Point 与 `MCP_TOOL_PROVIDERS` Allowlist
 接入。Provider Tool 拥有独立生命周期、Schema、审计元数据和限流，不属于内置
-8/47 合同，也不能覆盖内置名称。
+8/55 合同，也不能覆盖内置名称。
 
 ### Apache Ossie
 
 Semantic 领域消费经过审查的 Ossie 模型进行只读 Grounding。模型仍归语义仓库
 管理。Server 要求精确 `model_ref` 和私有 Doris Binding Manifest，不会猜模型、
 编写模型、编译或执行语义表达式。
+
+### MetricFlow
+
+Semantic 领域还通过默认关闭的 Sidecar 协议消费 MetricFlow Model。Provider 负责
+加载模型和编译 Doris SQL；Server 要求精确 `model_ref`，并把 SQL 校验、Doris
+路由、RBAC、执行限额、审计和结果保留在 `DorisQueryRuntime` 内。Provider 不执行
+Doris SQL。
+
+### ADBC
+
+ADBC 是默认关闭的高级 Query Variant，不是自动查询路由。两个 ADBC Child 都要求
+终端用户明确指定 ADBC/Arrow Flight SQL 并传 `explicit_adbc=true`；普通 SQL
+继续使用 `execute_query`。
 
 ### 原生血缘
 
@@ -181,7 +196,7 @@ Rollback 等安全合同。
 
 ## 不变量
 
-- 内置能力严格为 8 个只读领域与 47 个 Child。
+- 内置能力严格为 8 个只读领域与 55 个 Child。
 - 每个 Child 只有一个精确 Handler 与授权标识。
 - Hierarchical、Flat、自动生成文档和测试共用同一目录。
 - 不保留旧名称 Alias 窗口。

--- a/docs/capabilities/availability.md
+++ b/docs/capabilities/availability.md
@@ -29,12 +29,12 @@ current Apache Doris route. These are deliberately different concepts.
 
 Availability combines:
 
-1. **Catalog contract** — the child exists in the reviewed 8/47 catalog.
+1. **Catalog contract** — the child exists in the reviewed 8/55 catalog.
 2. **Normalized version** — the relevant active Doris component satisfies the
    declared `major.minor.patch` range.
 3. **Live feature probe** — required SQL metadata, system table, function, or
    allowlisted HTTP endpoint is observable.
-4. **Provider readiness** — optional ADBC, Ossie, or lineage provider is
+4. **Provider readiness** — optional ADBC, Ossie, MetricFlow, or lineage provider is
    configured and healthy.
 5. **Deployment mode** — required classic/cloud/compute behavior is compatible.
 6. **Route coherence** — active component versions and request route can be
@@ -123,6 +123,8 @@ This design lets the Host explain:
 - a required system table or function is absent;
 - a provider is disabled or unhealthy;
 - a companion lineage store is incomplete;
+- MetricFlow is disabled, its sidecar is unhealthy, or Doris SQL compilation is unavailable;
+- ADBC was not explicitly requested even though its provider is configured;
 - a route has mixed/unknown component versions;
 - the Doris identity cannot observe required metadata;
 - configuration is missing or invalid.
@@ -147,7 +149,7 @@ Hierarchical mode resolves availability during domain discovery. Flat mode
 also obtains each formal child from the current authorized manifest before
 returning it in `tools/list`. Both modes therefore share:
 
-- the same 47 children;
+- the same 55 children;
 - the same exact scopes;
 - the same dynamic availability;
 - the same schemas and dispatcher;
@@ -160,11 +162,17 @@ Flat mode is a Host compatibility fallback, not a capability bypass.
 Release certification records evidence gathered against named Doris patch
 targets. Runtime support is decided for the connected route.
 
-The 1.0 target set is `3.0.3`, `3.1.4`, `4.0.5`, `4.0.6`, `4.0.7`, `4.1.0`,
-`4.1.1`, `4.1.2`, and `4.1.3`. At the release boundary, `4.0.5` is the first
+The project baseline is Doris `2.0.0+`. The 1.0 target set is `2.0.15`,
+`2.1.11`, `3.0.3`, `3.1.4`, `4.0.5`, `4.0.6`, `4.0.7`, `4.1.0`, `4.1.1`,
+`4.1.2`, and `4.1.3`. At the release boundary, `4.0.5` is the first
 fully certified target. A target marked `target_uncertified` is not treated as
 automatically broken; its runtime manifests remain authoritative and honest
 about observed support.
+
+The baseline does not mean every child works on 2.0. Features introduced later
+remain discoverable with `callable=false`, a stable reason code, and the
+required version/provider/probe evidence. The reviewed release-note mapping is
+documented in the [Doris version capability matrix](doris-version-matrix.md).
 
 ## Example: lineage selection
 
@@ -181,6 +189,17 @@ For `trace_column_lineage`:
 This is the intended pattern for every version- and provider-dependent child:
 state the active evidence path, do not infer success from version alone, and
 never silently substitute one evidence class for another.
+
+## Example: ADBC selection
+
+- Doris 2.0 routes keep both ADBC children discoverable but not callable;
+- Doris 2.1.0 introduces Arrow Flight SQL, while 2.1.0-2.1.4 are reported as
+  degraded because later 2.1 patches fixed empty-result and metadata behavior;
+- provider installation, configured Flight endpoints, and live probes remain
+  mandatory on every eligible version;
+- a tool call must also carry `explicit_adbc=true`, which represents an end
+  user request that explicitly selected ADBC or Arrow Flight SQL;
+- an ordinary SQL request always uses `doris_query.execute_query`.
 
 ## Operator checklist
 

--- a/docs/capabilities/availability.zh-CN.md
+++ b/docs/capabilities/availability.zh-CN.md
@@ -28,10 +28,10 @@ under the License.
 
 Availability 综合以下条件：
 
-1. **Catalog 合同**——Child 存在于经过审查的 8/47 目录。
+1. **Catalog 合同**——Child 存在于经过审查的 8/55 目录。
 2. **归一化版本**——相关活动 Doris 组件满足声明的 `major.minor.patch` 范围。
 3. **实时特性 Probe**——必需 SQL 元数据、系统表、函数或允许的 HTTP 端点可见。
-4. **Provider 就绪**——可选 ADBC、Ossie 或 Lineage Provider 已配置且健康。
+4. **Provider 就绪**——可选 ADBC、Ossie、MetricFlow 或 Lineage Provider 已配置且健康。
 5. **部署模式**——所需 Classic/Cloud/Compute 行为兼容。
 6. **路由一致性**——活动组件版本和请求路由可以安全评估；未知或混合证据可能
    Fail Closed。
@@ -110,6 +110,8 @@ Host 与应用必须读取结构化对象。
 - 必需系统表或函数不存在；
 - Provider 未启用或不健康；
 - Companion Lineage Store 不完整；
+- MetricFlow 未启用、Sidecar 不健康或无法编译 Doris SQL；
+- 虽然配置了 ADBC，但用户没有明确指定 ADBC；
 - 路由存在混合或未知组件版本；
 - Doris 身份看不到必需元数据；
 - 配置缺失或无效。
@@ -131,7 +133,7 @@ Host 与应用必须读取结构化对象。
 Hierarchical 模式在领域发现时解析 Availability。Flat 模式也会先从当前授权
 Manifest 获取每个正式 Child，再放入 `tools/list`。两者因此共用：
 
-- 同样的 47 个 Child；
+- 同样的 55 个 Child；
 - 同样的精确 Scope；
 - 同样的动态 Availability；
 - 同样的 Schema 与 Dispatcher；
@@ -144,10 +146,15 @@ Flat 是 Host 兼容回退，不是能力绕过。
 Release Certification 记录命名 Doris Patch 上收集的证据；Runtime Support 则
 针对实际连接路由判断。
 
-1.0 目标集合为 `3.0.3`、`3.1.4`、`4.0.5`、`4.0.6`、`4.0.7`、
-`4.1.0`、`4.1.1`、`4.1.2`、`4.1.3`。发布边界上，`4.0.5` 是首个
+项目基线为 Doris `2.0.0+`。1.0 目标集合为 `2.0.15`、`2.1.11`、
+`3.0.3`、`3.1.4`、`4.0.5`、`4.0.6`、`4.0.7`、`4.1.0`、`4.1.1`、
+`4.1.2`、`4.1.3`。发布边界上，`4.0.5` 是首个
 完整认证目标。`target_uncertified` 不等于必然不可用；运行时 Manifest 仍然是
 该连接集群上观察到的权威结果。
+
+基线不表示 2.0 可以调用所有 Child。后续版本才出现的功能仍然可发现，但会以
+`callable=false`、稳定 Reason Code 以及所需版本/Provider/Probe 证据说明原因。
+Release Note 映射见 [Doris 版本能力矩阵](doris-version-matrix.zh-CN.md)。
 
 ## 示例：血缘路径选择
 
@@ -162,6 +169,16 @@ Release Certification 记录命名 Doris Patch 上收集的证据；Runtime Supp
 
 这也是所有版本/Provider 相关 Child 的设计模式：说明实际证据路径，不根据版本
 单独推定成功，也不把一种证据静默冒充另一种证据。
+
+## 示例：ADBC 选择
+
+- Doris 2.0 路由仍能发现两个 ADBC Child，但不可调用；
+- Doris 2.1.0 引入 Arrow Flight SQL；2.1.0-2.1.4 会标为 Degraded，因为后续
+  2.1 Patch 修复了空结果与元数据行为；
+- 所有符合版本的路由仍必须通过 Provider 安装、Flight Endpoint 配置和实时探测；
+- 调用还必须传 `explicit_adbc=true`，表示终端用户明确指定了 ADBC 或 Arrow
+  Flight SQL；
+- 普通 SQL 请求始终使用 `doris_query.execute_query`。
 
 ## 操作人员检查清单
 

--- a/docs/capabilities/doris-version-matrix.md
+++ b/docs/capabilities/doris-version-matrix.md
@@ -1,0 +1,98 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Doris version capability matrix
+
+[English](doris-version-matrix.md) | [简体中文](doris-version-matrix.zh-CN.md)
+
+Doris MCP Server supports Apache Doris `2.0.0+` as its project baseline. This
+is not a promise that every child is callable on every release. Each child is
+filtered by a machine-readable conjunction of normalized three-part version,
+live feature probes, provider readiness, deployment mode, route coherence,
+authorization, and Doris object visibility.
+
+The source of truth is `doris_feature_matrix.py`; this page summarizes the
+release-note review relevant to the public MCP surface. It is not a replacement
+for the complete Apache Doris release notes.
+
+## Release families
+
+| Doris range | MCP-relevant capability baseline | Important gates |
+|---|---|---|
+| `2.0.x` | Catalog metadata, MySQL read-only query/Explain/Profile, load and MV evidence, workload groups, audit-based governance, external catalogs, inverted-index text search, and optional semantic providers. | Every path still requires its live metadata, endpoint, provider, and permission probes. ADBC and Variant are unavailable by version. |
+| `2.1.0-2.1.4` | Adds Arrow Flight SQL/ADBC and Variant type inspection. | ADBC is `degraded` on these early patches and still requires an installed provider, Flight endpoints, live probes, and explicit end-user ADBC intent. |
+| `2.1.5-2.1.x` | Keeps the 2.1 surface with improved Flight SQL result behavior; later patches improve metadata and serialization/error behavior. | `2.1.5+` clears the early-release maturity gate, but runtime probes remain mandatory. |
+| `3.x` | All supported 2.x foundations plus the metadata/runtime improvements exposed by the connected patch. | There is no global 3.x-only MCP gate. Availability remains per child and per route. |
+| `4.0.0-4.0.5` | Adds ANN/vector and vector-plus-inverted hybrid search variants and plan/index facets. | Index type, metric, dimension, functions, and actual metadata must match the request. |
+| `4.0.6` | Adds the native lineage event path and compaction task-tracker path. | Native lineage also requires compatible FE plugins and a healthy queryable companion store. Audit inference remains an explicit degraded fallback. |
+| `4.0.7` | Adds enhanced observability/audit/cache evidence and selected MTMV compute-group evidence. | Exact metadata/metrics fields are probed; absent fields select base or degraded variants. |
+| `4.1.0` | Adds Storage V3/advanced Variant facets, lakehouse lifecycle facets, continuous-load evidence, and advanced cache variants. | Base children remain available when advanced facets are absent; advanced sections report their own status. |
+| `4.1.1` | Adds unified task progress and the 4.1 compaction task-tracker path. | Falls back to legacy task or compaction summaries when the required objects are absent. |
+| `4.1.2` | Adds OIDC role-mapping evidence and selected MTMV compute-group support. | Provider, system object, deployment-mode, and visibility probes are required. |
+| `4.1.3+` | Adds Python UDF/UDAF/UDTF family metadata. | The base UDF metadata path remains separate and can work on older releases. |
+
+## Child-family mapping
+
+| Public children | Minimum version | Later variant or provider rule |
+|---|---:|---|
+| `doris_catalog.*` | `2.0.0` | ANN/BM25 context facets require `4.0+`; Storage V3 Variant context requires `4.1+`. |
+| `execute_query`, `explain_query`, `get_query_profile`, `diagnose_query_performance`, `list_slow_queries` | `2.0.0` | Query/profile/audit evidence is probed independently. Search plan facets require `4.0+`. |
+| `get_adbc_connection_info`, `execute_adbc_query` | `2.1.0` | Default-off, explicit-only advanced path; `2.1.0-2.1.4` degraded; never chosen for ordinary SQL. |
+| `doris_cluster.*` | `2.0.0` | Newer cache, compaction, observability, task, and compute-group facets select their documented variants. |
+| `doris_pipeline.*` | `2.0.0` | Continuous load requires `4.1+`; selected MTMV compute-group evidence requires `4.0.7` or `4.1.2+`. |
+| Inverted text search paths | `2.0.0` | Requires compatible inverted index and search/tokenizer syntax probes. |
+| ANN/vector/hybrid search paths | `4.0.0` | Requires compatible ANN/index/metric/dimension evidence; text-only fallback can remain callable. |
+| Governance and audit-based lineage | `2.0.0` | Audit provider is primary before `4.0.6`; native lineage is preferred only when all native prerequisites pass. |
+| Native lineage | `4.0.6` | Requires companion plugin plus queryable store; version alone is insufficient. |
+| `inspect_external_catalog`, base lakehouse inspection | `2.0.0` | Requires an external-catalog provider and visible metadata. |
+| `inspect_variant_column` | `2.1.0` | Storage V3/sparse/doc-mode facets require `4.1+`. |
+| Ossie children | `2.0.0` project baseline | Default-off; exact `model_ref`, reviewed model store, private binding, policy, route, and permission probes. |
+| MetricFlow children | `2.0.0` project baseline | Default-off; exact `model_ref`, provider protocol, model metadata, Doris-dialect compilation, SQL guard, and Query runtime probes. |
+
+## ADBC decision rule
+
+ADBC is intentionally not an automatic optimization. Both formal ADBC calls
+require `explicit_adbc=true`; the Server rejects the call otherwise. A Host or
+model must use ordinary `doris_query.execute_query` unless the end user
+explicitly asks for ADBC or Arrow Flight SQL. This prevents ambiguous tool
+selection and acknowledges that Flight endpoints and cluster tuning are an
+advanced deployment concern.
+
+## Source set
+
+The matrix records stable source identifiers and verification dates. Primary
+sources include:
+
+- [Doris 2.0.0 release notes](https://doris.apache.org/docs/3.0/releasenotes/v2.0/release-2.0.0)
+- [Doris 2.0.15 release notes](https://doris.apache.org/docs/2.0/releasenotes/v2.0/release-2.0.15)
+- [Doris 2.1.0 release notes](https://doris.apache.org/docs/3.x/releasenotes/v2.1/release-2.1.0/)
+- [Doris 2.1.11 release notes](https://doris.apache.org/releases/v2.1/release-2.1.11/)
+- [Doris 2.1 Arrow Flight SQL guide](https://doris.apache.org/docs/2.1/db-connect/arrow-flight-sql-connect/)
+- [Doris 3.0.0 release notes](https://doris.apache.org/docs/3.x/releasenotes/v3.0/release-3.0.0/)
+- [Doris 3.1.0 release notes](https://doris.apache.org/docs/4.x/releasenotes/v3.1/release-3.1.0/)
+- [Doris 3.x documentation](https://doris.apache.org/docs/3.x/)
+- [Doris 4.0.0 release notes](https://doris.apache.org/releases/v4.0/release-4.0.0/)
+- [Doris 4.0.6 release notes](https://doris.apache.org/releases/v4.0/release-4.0.6/)
+- [Doris 4.0.7 release notes](https://doris.apache.org/releases/v4.0/release-4.0.7/)
+- [Doris 4.1.0 release notes](https://doris.apache.org/releases/v4.1/release-4.1.0/)
+- [Doris 4.x documentation](https://doris.apache.org/docs/4.x/)
+
+Patch certification and runtime support are separate. A route can be supported
+without being a certified release target; the runtime manifest remains the
+authority for the current identity and route.

--- a/docs/capabilities/doris-version-matrix.zh-CN.md
+++ b/docs/capabilities/doris-version-matrix.zh-CN.md
@@ -1,0 +1,91 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Doris 版本能力矩阵
+
+[English](doris-version-matrix.md) | 简体中文
+
+Doris MCP Server 的项目基线是 Apache Doris `2.0.0+`。这不表示每个版本都能
+调用全部 Child。每个 Child 都由一组机器可读条件共同过滤：归一化三位数版本、
+实时特性探测、Provider 就绪、部署形态、路由一致性、授权以及 Doris 对象可见性。
+
+事实源是 `doris_feature_matrix.py`；本文汇总与公开 MCP 能力有关的 Release Note
+审查结果，不替代完整 Apache Doris Release Note。
+
+## 版本族
+
+| Doris 范围 | MCP 相关能力基线 | 重要 Gate |
+|---|---|---|
+| `2.0.x` | Catalog 元数据、MySQL 只读 Query/Explain/Profile、Load/MV 证据、Workload Group、基于 Audit 的治理、外部 Catalog、倒排索引文本检索和可选语义 Provider。 | 每条路径仍需通过元数据、Endpoint、Provider 与权限探测。ADBC 和 Variant 因版本不可用。 |
+| `2.1.0-2.1.4` | 增加 Arrow Flight SQL/ADBC 与 Variant 类型查看。 | 早期 Patch 的 ADBC 标为 `degraded`；仍需 Provider、Flight Endpoint、实时探测和用户明确指定 ADBC。 |
+| `2.1.5-2.1.x` | 保留 2.1 能力，并改善 Flight SQL 空结果行为；后续 Patch 继续改善元数据、序列化与错误处理。 | `2.1.5+` 通过早期版本成熟度 Gate，但实时探测仍然必需。 |
+| `3.x` | 支持 2.x 基础，并按连接 Patch 公开相应元数据/运行时改善。 | MCP 没有全局 3.x Gate，仍按 Child 和路由判断。 |
+| `4.0.0-4.0.5` | 增加 ANN/向量以及向量+倒排混合检索 Variant，并增加 Plan/Index 特征。 | Index 类型、Metric、Dimension、函数和实际元数据必须匹配请求。 |
+| `4.0.6` | 增加原生血缘事件路径和 Compaction Task Tracker 路径。 | 原生血缘还要求兼容 FE Plugin 与健康可查询 Companion Store；Audit Inference 是显式 Degraded 回退。 |
+| `4.0.7` | 增强 Observability/Audit/Cache 证据和部分 MTMV Compute Group 证据。 | 精确探测字段；字段缺失时选择 Base 或 Degraded Variant。 |
+| `4.1.0` | 增加 Storage V3/高级 Variant、湖仓 Lifecycle、Continuous Load 与高级 Cache Variant。 | 高级部分不可用时，基础 Child 仍可工作并单独报告状态。 |
+| `4.1.1` | 增加统一 Task Progress 与 4.1 Compaction Task Tracker 路径。 | 必需对象不存在时回退到旧 Task/Compaction Summary。 |
+| `4.1.2` | 增加 OIDC Role Mapping 证据和部分 MTMV Compute Group 支持。 | 必须通过 Provider、系统对象、部署形态与可见性探测。 |
+| `4.1.3+` | 增加 Python UDF/UDAF/UDTF 家族元数据。 | Base UDF 元数据路径独立存在，旧版本仍可使用。 |
+
+## Child 家族映射
+
+| 公开 Child | 最低版本 | 后续 Variant 或 Provider 规则 |
+|---|---:|---|
+| `doris_catalog.*` | `2.0.0` | ANN/BM25 Context 要求 `4.0+`；Storage V3 Variant Context 要求 `4.1+`。 |
+| `execute_query`、`explain_query`、`get_query_profile`、`diagnose_query_performance`、`list_slow_queries` | `2.0.0` | Query/Profile/Audit 证据独立探测；Search Plan 特征要求 `4.0+`。 |
+| `get_adbc_connection_info`、`execute_adbc_query` | `2.1.0` | 默认关闭、必须显式指定；`2.1.0-2.1.4` Degraded；普通 SQL 绝不自动选择。 |
+| `doris_cluster.*` | `2.0.0` | 新 Cache、Compaction、Observability、Task、Compute Group 特征按对应 Variant 选择。 |
+| `doris_pipeline.*` | `2.0.0` | Continuous Load 要求 `4.1+`；部分 MTMV Compute Group 证据要求 `4.0.7` 或 `4.1.2+`。 |
+| 倒排文本检索路径 | `2.0.0` | 要求兼容倒排索引和 Search/Tokenizer 语法探测。 |
+| ANN/向量/混合检索路径 | `4.0.0` | 要求 ANN/Index/Metric/Dimension 证据兼容；文本回退可以继续调用。 |
+| Governance 与 Audit 血缘 | `2.0.0` | `4.0.6` 前以 Audit Provider 为主；只有全部原生条件通过才优先 Native。 |
+| 原生血缘 | `4.0.6` | 需要 Companion Plugin 与 Queryable Store；仅版本符合不够。 |
+| `inspect_external_catalog`、基础 Lakehouse 查看 | `2.0.0` | 需要外部 Catalog Provider 与可见元数据。 |
+| `inspect_variant_column` | `2.1.0` | Storage V3/Sparse/Doc Mode 特征要求 `4.1+`。 |
+| Ossie Child | `2.0.0` 项目基线 | 默认关闭；要求精确 `model_ref`、已审查模型库、私有 Binding、Policy、Route 与权限探测。 |
+| MetricFlow Child | `2.0.0` 项目基线 | 默认关闭；要求精确 `model_ref`、Provider 协议、模型元数据、Doris Dialect 编译、SQL Guard 与 Query Runtime 探测。 |
+
+## ADBC 决策规则
+
+ADBC 不是自动优化。两个 ADBC 正式调用都要求 `explicit_adbc=true`，Server 会
+独立拒绝缺少该字段的请求。除非终端用户明确要求 ADBC 或 Arrow Flight SQL，
+Host/模型都必须使用普通 `doris_query.execute_query`。这样可以避免工具选择歧义，
+也明确 Flight Endpoint 与集群调参属于高级部署事项。
+
+## 来源集合
+
+矩阵记录稳定 Source ID 和审查日期。主要一手来源包括：
+
+- [Doris 2.0.0 Release Note](https://doris.apache.org/docs/3.0/releasenotes/v2.0/release-2.0.0)
+- [Doris 2.0.15 Release Note](https://doris.apache.org/docs/2.0/releasenotes/v2.0/release-2.0.15)
+- [Doris 2.1.0 Release Note](https://doris.apache.org/docs/3.x/releasenotes/v2.1/release-2.1.0/)
+- [Doris 2.1.11 Release Note](https://doris.apache.org/releases/v2.1/release-2.1.11/)
+- [Doris 2.1 Arrow Flight SQL 指南](https://doris.apache.org/docs/2.1/db-connect/arrow-flight-sql-connect/)
+- [Doris 3.0.0 Release Note](https://doris.apache.org/docs/3.x/releasenotes/v3.0/release-3.0.0/)
+- [Doris 3.1.0 Release Note](https://doris.apache.org/docs/4.x/releasenotes/v3.1/release-3.1.0/)
+- [Doris 3.x 文档](https://doris.apache.org/docs/3.x/)
+- [Doris 4.0.0 Release Note](https://doris.apache.org/releases/v4.0/release-4.0.0/)
+- [Doris 4.0.6 Release Note](https://doris.apache.org/releases/v4.0/release-4.0.6/)
+- [Doris 4.0.7 Release Note](https://doris.apache.org/releases/v4.0/release-4.0.7/)
+- [Doris 4.1.0 Release Note](https://doris.apache.org/releases/v4.1/release-4.1.0/)
+- [Doris 4.x 文档](https://doris.apache.org/docs/4.x/)
+
+Patch Certification 与 Runtime Support 相互独立。某个路由即使不是已认证目标，
+仍可能被支持；对当前身份和路由而言，Runtime Manifest 才是权威结果。

--- a/docs/capabilities/tool-domains.md
+++ b/docs/capabilities/tool-domains.md
@@ -22,7 +22,7 @@ under the License.
 [English](tool-domains.md) | [简体中文](tool-domains.zh-CN.md)
 
 Version 1.0 has one built-in read-only catalog: eight top-level domains and
-forty-seven exact children. This page explains product intent. The generated
+fifty-five exact children. This page explains product intent. The generated
 [tool registry](../tool-registry.md) is authoritative for formal feature IDs,
 handler bindings, authorization identifiers, variants, and migration inputs.
 
@@ -71,10 +71,13 @@ one ambiguous object.
 | `get_query_profile` | Retrieve a bounded FE query profile. | Requires FE HTTP/profile evidence and never returns credentials. |
 | `diagnose_query_performance` | Produce deterministic findings from plan/profile/query evidence. | Evidence-based rules; no invented confidence score. |
 | `list_slow_queries` | List bounded slow-query evidence. | Requires readable audit history; raw sensitive SQL fields are sanitized. |
-| `get_adbc_connection_info` | Report Arrow Flight SQL/ADBC readiness. | Sanitized provider/endpoint evidence only. |
-| `execute_adbc_query` | Execute a bounded read-only query through ADBC. | Optional provider; fail-closed on token-bound routes in 1.0. |
+| `get_adbc_connection_info` | Report Arrow Flight SQL/ADBC readiness. | Advanced, default-off, and valid only after explicit user intent selects ADBC. |
+| `execute_adbc_query` | Execute a bounded read-only query through ADBC. | Requires `explicit_adbc=true`; never substitutes for ordinary `execute_query`; fail-closed on token-bound routes. |
 
-The query domain accepts SQL because SQL is the native Doris query interface,
+Ordinary SQL always uses `execute_query`. The two ADBC children are an
+advanced path for requests that explicitly name ADBC or Arrow Flight SQL;
+their schemas require `explicit_adbc=true`, and the runtime independently
+enforces the same condition. The query domain accepts SQL because SQL is the native Doris query interface,
 but it does not expose DDL, DML, administrative SQL, arbitrary stacked
 statements, or an unbounded result channel.
 
@@ -141,7 +144,7 @@ companion store. Version `4.0.6+` alone does not make it callable.
 | `inspect_lakehouse_table` | Inspect table format, snapshots, partitions, lifecycle, and pushdown evidence. | 4.1 lifecycle facets are reported separately from base metadata. |
 | `inspect_variant_column` | Inspect Variant type and bounded shape evidence. | Sample values and sensitive paths are excluded; advanced 4.1 facets are capability-gated. |
 
-## `doris_semantic` — optional Apache Ossie consumer
+## `doris_semantic` — optional semantic consumers
 
 | Child | Purpose | Important behavior |
 |---|---|---|
@@ -149,15 +152,24 @@ companion store. Version `4.0.6+` alone does not make it callable.
 | `get_semantic_model_summary` | Return a bounded summary for one exact `model_ref`. | No prompt-based model guessing. |
 | `get_semantic_context` | Build deterministic read-only grounding context. | Requires exact model, route-aware mapping, and Doris visibility. |
 | `get_semantic_mapping_status` | Explain private Doris binding readiness. | Reports status/reasons without exposing the private binding manifest. |
+| `list_metricflow_models` | List configured MetricFlow model references. | Provider is default-off; model selection never uses prompt guessing. |
+| `get_metricflow_status` | Return provider/model validation status. | Requires one exact `model_ref`. |
+| `list_metricflow_metrics` | List bounded metrics and optional dimensions. | Requires one exact `model_ref`; supports bounded filtering. |
+| `get_metricflow_group_bys` | Return valid group-by dimensions for selected metrics. | Provider validates the metric set against the exact model. |
+| `list_metricflow_saved_queries` | List bounded saved-query metadata. | Does not execute saved queries. |
+| `get_metricflow_dimension_values` | Compile and execute a bounded dimension-value query. | Provider compiles Doris SQL; MCP SQL guard and Query runtime execute it. |
+| `compile_metricflow_query` | Compile a structured MetricFlow request to Doris SQL. | Compile-only; returns no query result and does not bypass the SQL guard. |
+| `execute_metricflow_query` | Compile and execute a bounded MetricFlow request. | Execution always returns to `DorisQueryRuntime` for routing, RBAC, limits, audit, and redaction. |
 
-Ossie owns semantic definitions. The MCP Server consumes them and maps them to
-Doris evidence; it does not become the semantic model authoring or execution
-engine.
+Ossie owns semantic definitions. MetricFlow owns metric semantics and query
+compilation. The MCP Server is a governed consumer: it does not author either
+model, does not guess a model, and does not permit a provider to execute Doris
+SQL outside the MCP Query runtime. See [MetricFlow integration](../integrations/metricflow.md).
 
 ## Reserved and extension surfaces
 
 - `doris_admin` is intentionally not registered.
-- Custom providers are explicit extensions and not counted in 8/47.
+- Custom providers are explicit extensions and not counted in 8/55.
 - MCP resources and prompts remain separate protocol surfaces; they are not
   hidden child tools.
 - Pre-1.0 tool names are not callable aliases.

--- a/docs/capabilities/tool-domains.zh-CN.md
+++ b/docs/capabilities/tool-domains.zh-CN.md
@@ -21,7 +21,7 @@ under the License.
 
 [English](tool-domains.md) | 简体中文
 
-1.0 只有一套内置只读目录：8 个顶级领域、47 个精确 Child。本文解释产品语义；
+1.0 只有一套内置只读目录：8 个顶级领域、55 个精确 Child。本文解释产品语义；
 自动生成的[工具目录](../tool-registry.md)才是 Feature ID、Handler Binding、授权
 标识、Variant 和迁移输入的权威事实源。
 
@@ -68,9 +68,11 @@ Warning，不会把部分可用的元数据压成一个含义不清的对象。
 | `get_query_profile` | 获取有界 FE Query Profile。 | 依赖 FE HTTP/Profile 证据，绝不返回凭据。 |
 | `diagnose_query_performance` | 根据 Plan/Profile/Query 证据生成确定性结论。 | 基于规则与证据，不编造置信度。 |
 | `list_slow_queries` | 列出有界慢查询证据。 | 需要可读审计历史，敏感 SQL 字段会清洗。 |
-| `get_adbc_connection_info` | 报告 Arrow Flight SQL/ADBC 就绪状态。 | 只返回清洗后的 Provider/Endpoint 证据。 |
-| `execute_adbc_query` | 通过 ADBC 执行有界只读查询。 | 可选 Provider；1.0 在 Token 绑定路由上 Fail Closed。 |
+| `get_adbc_connection_info` | 报告 Arrow Flight SQL/ADBC 就绪状态。 | 高级能力，默认关闭；只有用户明确指定 ADBC 后才可使用。 |
+| `execute_adbc_query` | 通过 ADBC 执行有界只读查询。 | 必须传 `explicit_adbc=true`；绝不替代普通 `execute_query`；Token 绑定路由 Fail Closed。 |
 
+普通 SQL 始终使用 `execute_query`。两个 ADBC Child 只服务于用户明确点名 ADBC
+或 Arrow Flight SQL 的高级请求；Schema 与运行时都会强制 `explicit_adbc=true`。
 Query 领域允许 SQL，因为 SQL 是 Doris 原生查询接口；但不会公开 DDL、DML、
 管理 SQL、任意堆叠语句或无界结果通道。
 
@@ -136,7 +138,7 @@ DSL 片段或任意 Filter SQL。
 | `inspect_lakehouse_table` | 查看表格式、Snapshot、分区、Lifecycle 和 Pushdown 证据。 | 4.1 Lifecycle 特征与基础元数据分开报告。 |
 | `inspect_variant_column` | 查看 Variant 类型与有界 Shape 证据。 | 不返回 Sample Value/敏感 Path；高级 4.1 特征受能力 Gate。 |
 
-## `doris_semantic`——可选 Apache Ossie Consumer
+## `doris_semantic`——可选语义消费者
 
 | Child | 用途 | 重要行为 |
 |---|---|---|
@@ -144,14 +146,23 @@ DSL 片段或任意 Filter SQL。
 | `get_semantic_model_summary` | 为一个精确 `model_ref` 返回有界摘要。 | 不根据 Prompt 猜模型。 |
 | `get_semantic_context` | 构建确定性的只读 Grounding Context。 | 需要精确模型、路由级映射与 Doris 可见性。 |
 | `get_semantic_mapping_status` | 解释私有 Doris Binding 就绪状态。 | 返回状态/原因，不公开私有 Binding Manifest。 |
+| `list_metricflow_models` | 列出已配置的 MetricFlow Model Reference。 | Provider 默认关闭；不根据 Prompt 猜模型。 |
+| `get_metricflow_status` | 返回 Provider/Model 校验状态。 | 需要一个精确 `model_ref`。 |
+| `list_metricflow_metrics` | 列出有界 Metric 和可选 Dimension。 | 需要精确 `model_ref`，支持有界过滤。 |
+| `get_metricflow_group_bys` | 返回所选 Metric 可用的 Group-by Dimension。 | Provider 在精确模型内验证 Metric 集合。 |
+| `list_metricflow_saved_queries` | 列出有界 Saved Query 元数据。 | 不执行 Saved Query。 |
+| `get_metricflow_dimension_values` | 编译并执行有界 Dimension Value 查询。 | Provider 编译 Doris SQL，MCP SQL Guard 与 Query Runtime 执行。 |
+| `compile_metricflow_query` | 把结构化 MetricFlow 请求编译为 Doris SQL。 | 只编译，不返回查询结果，也不能绕过 SQL Guard。 |
+| `execute_metricflow_query` | 编译并执行有界 MetricFlow 请求。 | 执行必须回到 `DorisQueryRuntime`，统一处理路由、RBAC、限额、审计与脱敏。 |
 
-Ossie 拥有语义定义；MCP Server 消费它并映射到 Doris 证据，不会成为语义模型
-创作或执行引擎。
+Ossie 拥有语义定义；MetricFlow 拥有指标语义与查询编译。MCP Server 是受治理
+消费者：不创作模型、不猜模型，也不允许 Provider 绕过 MCP Query Runtime 直接
+执行 Doris SQL。详见 [MetricFlow 接入](../integrations/metricflow.zh-CN.md)。
 
 ## 预留与扩展面
 
 - `doris_admin` 故意不注册。
-- 自定义 Provider 是显式扩展，不计入 8/47。
+- 自定义 Provider 是显式扩展，不计入 8/55。
 - MCP Resource 与 Prompt 是独立协议面，不是隐藏 Child。
 - 1.0 以前的 Tool 名称不是可调用 Alias。
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -90,7 +90,7 @@ Before adding or changing a child:
 8. Regenerate the catalog and update English/Chinese documentation.
 9. Update `CHANGELOG.md` in the same pull request.
 
-The current release contract is eight domains and forty-seven children. A
+The current release contract is eight domains and fifty-five children. A
 change to those counts is intentional API work, not an incidental handler edit.
 
 ## Custom providers
@@ -200,7 +200,7 @@ without exposing credentials or private endpoints.
 
 - Product version, CLI identity, package metadata, release docs, and Changelog
   agree.
-- Generated 8/47 registry matches runtime exactly.
+- Generated 8/55 registry matches runtime exactly.
 - English/Chinese documentation links are valid.
 - Target Doris patch certification claims match collected evidence.
 - Known limitations remain explicit.

--- a/docs/development/contributing.zh-CN.md
+++ b/docs/development/contributing.zh-CN.md
@@ -85,7 +85,7 @@ uv run python generate_tool_catalog.py --check
 8. 重新生成目录并更新英文/中文文档。
 9. 同一 PR 更新 `CHANGELOG.md`。
 
-当前 Release 合同是 8 Domain / 47 Child。数量变化属于有意识 API 工作，不是
+当前 Release 合同是 8 Domain / 55 Child。数量变化属于有意识 API 工作，不是
 普通 Handler 修改的副作用。
 
 ## 自定义 Provider
@@ -185,7 +185,7 @@ Private Endpoint。
 ## Release 检查清单
 
 - Product Version、CLI Identity、Package Metadata、Release Doc、Changelog 一致。
-- 自动生成 8/47 Registry 与 Runtime 完全相同。
+- 自动生成 8/55 Registry 与 Runtime 完全相同。
 - 英文/中文文档链接有效。
 - Target Doris Patch Certification 与证据一致。
 - Known Limitation 保持明确。

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -28,7 +28,7 @@ addresses and placeholder credentials.
 ## 1. Prerequisites
 
 - Python 3.12 or later.
-- Apache Doris 3.0.0 or later.
+- Apache Doris 2.0.0 or later. Later-version features are filtered dynamically.
 - FE MySQL endpoint access, normally port `9030`.
 - FE HTTP endpoint access, normally port `8030`, for profile and selected
   operational capabilities.
@@ -158,7 +158,7 @@ Hosts without progressive-disclosure support may set:
 export MCP_TOOL_EXPOSURE_MODE=flat
 ```
 
-Restart the Server and reconnect the Host. Flat mode exposes the same 47
+Restart the Server and reconnect the Host. Flat mode exposes the same 55
 children under formal names such as `doris_catalog_list_tables`.
 
 ## 7. Verify the installation

--- a/docs/getting-started/quickstart.zh-CN.md
+++ b/docs/getting-started/quickstart.zh-CN.md
@@ -27,7 +27,7 @@ Hierarchical Discovery 的调用形态。示例只使用回环地址与占位凭
 ## 1. 前置条件
 
 - Python 3.12 或更高版本。
-- Apache Doris 3.0.0 或更高版本。
+- Apache Doris 2.0.0 或更高版本；后续版本特性由运行时动态过滤。
 - 可以访问 FE MySQL 端口，通常为 `9030`。
 - 如需 Profile 与部分运维能力，可以访问 FE HTTP 端口，通常为 `8030`。
 - 如需 BE 级监控，需要显式配置允许访问的 BE HTTP 地址。
@@ -155,7 +155,7 @@ export MCP_TOOL_EXPOSURE_MODE=flat
 ```
 
 随后重启 Server 并让 Host 重新连接。Flat 模式使用
-`doris_catalog_list_tables` 等正式名称公开同样的 47 个 Child。
+`doris_catalog_list_tables` 等正式名称公开同样的 55 个 Child。
 
 ## 7. 验证安装
 

--- a/docs/integrations/hosts.md
+++ b/docs/integrations/hosts.md
@@ -90,7 +90,7 @@ After restart and reconnect, `tools/list` returns formal names such as:
 - `doris_query_execute_query`
 - `doris_cluster_get_cluster_overview`
 
-Flat mode exposes the same authorized 47-child catalog and availability. It
+Flat mode exposes the same authorized 55-child catalog and availability. It
 does not provide pre-1.0 aliases, dynamic registration, or a security bypass.
 The context cost is higher, so hierarchical mode is preferred.
 
@@ -194,17 +194,17 @@ Hosts should:
 | feed discovered child schemas to model | required | not required |
 | handle structured content | recommended | recommended |
 | handle stale-manifest rediscovery | required | not normally sent by flat call |
-| context budget for 47 tools | not required | required |
+| context budget for 55 tools | not required | required |
 | restart after exposure-mode change | required | required |
 
-If a Host cannot consume progressive manifests and also cannot accommodate 47
+If a Host cannot consume progressive manifests and also cannot accommodate 55
 bounded formal tools, it is not currently compatible with the full 1.0 tool
 surface. Do not solve this by probabilistic Server-side routing.
 
 ## Host test sequence
 
 1. Confirm `server/discover` identity/version.
-2. Confirm `tools/list` returns 8 domains (hierarchical) or 47 formal children
+2. Confirm `tools/list` returns 8 domains (hierarchical) or 55 formal children
    before authorization filtering (flat contract baseline).
 3. Discover Catalog and call `list_tables`.
 4. Switch to Cluster in the same conversation and call overview/capabilities.

--- a/docs/integrations/hosts.zh-CN.md
+++ b/docs/integrations/hosts.zh-CN.md
@@ -80,7 +80,7 @@ export MCP_TOOL_EXPOSURE_MODE=flat
 - `doris_query_execute_query`
 - `doris_cluster_get_cluster_overview`
 
-Flat 公开同一套经过授权的 47 Child Catalog 与 Availability。它不提供旧名称 Alias、
+Flat 公开同一套经过授权的 55 Child Catalog 与 Availability。它不提供旧名称 Alias、
 动态注册或安全绕过。上下文成本更高，因此优先 Hierarchical。
 
 ## stdio 配置
@@ -177,16 +177,16 @@ Host 应当：
 | 把发现 Child Schema 交给模型 | 必需 | 不需要 |
 | 处理 Structured Content | 推荐 | 推荐 |
 | 处理 Stale-manifest Rediscovery | 必需 | Flat Call 通常不发送 |
-| 47 Tool Context Budget | 不需要 | 必需 |
+| 55 Tool Context Budget | 不需要 | 必需 |
 | Exposure Mode 变化后重启 | 必需 | 必需 |
 
-如果 Host 既不能消费 Progressive Manifest，也容纳不了 47 个有界正式 Tool，它就
+如果 Host 既不能消费 Progressive Manifest，也容纳不了 55 个有界正式 Tool，它就
 暂时无法接入完整 1.0 工具面。不能用概率 Server-side Routing 规避这个问题。
 
 ## Host 测试序列
 
 1. 确认 `server/discover` Identity/Version。
-2. 确认 `tools/list` 返回 8 Domain（Hierarchical），或在授权过滤前符合 47 Formal
+2. 确认 `tools/list` 返回 8 Domain（Hierarchical），或在授权过滤前符合 55 Formal
    Child 基线（Flat）。
 3. 发现 Catalog 并调用 `list_tables`。
 4. 同一对话切换 Cluster，调用 Overview/Capabilities。

--- a/docs/integrations/metricflow.md
+++ b/docs/integrations/metricflow.md
@@ -1,0 +1,171 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# MetricFlow integration
+
+[English](metricflow.md) | [简体中文](metricflow.zh-CN.md)
+
+The `doris_semantic` domain can consume MetricFlow models through an optional,
+administrator-configured sidecar. MetricFlow remains the owner of metric
+semantics and query compilation. Doris MCP Server owns MCP discovery,
+authorization, route selection, Doris RBAC, read-only SQL validation, query
+limits, execution, audit metadata, redaction, and result schemas.
+
+The project does not bundle a native Doris MetricFlow/dbt adapter. An operator
+must supply a reviewed provider that can load the selected MetricFlow project
+and compile requests to valid Doris SQL. The MCP integration is therefore a
+stable consumer boundary, not a claim that stock MetricFlow can connect to
+Doris without an adapter or dialect implementation.
+
+## Public children
+
+| Child | Provider operation | Execution behavior |
+|---|---|---|
+| `list_metricflow_models` | `list_models` | Metadata only; no `model_ref` is guessed. |
+| `get_metricflow_status` | `get_status` | Validates one exact `model_ref`. |
+| `list_metricflow_metrics` | `list_metrics` | Bounded metric/dimension metadata. |
+| `get_metricflow_group_bys` | `get_group_bys` | Returns valid group-by choices for selected metrics. |
+| `list_metricflow_saved_queries` | `list_saved_queries` | Metadata only; does not execute saved queries. |
+| `get_metricflow_dimension_values` | `compile_dimension_values` | Provider compiles; MCP Query runtime executes bounded read-only SQL. |
+| `compile_metricflow_query` | `compile_query` | Compile-only; returns provider evidence and Doris SQL. |
+| `execute_metricflow_query` | `compile_query` | Provider compiles; MCP Query runtime validates and executes. |
+
+Every model-specific call requires an exact `model_ref`. The Server does not
+rank, infer, or select a model from natural-language text.
+
+## Compile and execution boundary
+
+```text
+MCP Host
+  -> doris_semantic child + exact model_ref
+  -> authorization and dynamic availability
+  -> MetricFlow sidecar: model inspection or Doris SQL compilation only
+  -> MCP ReadOnlySQLGuard
+  -> request-specific DorisQueryRuntime
+  -> Doris route, RBAC, timeout/row/byte limits, audit and redaction
+  -> schema-validated MCP result
+```
+
+The sidecar never receives Doris credentials from this protocol and is not
+allowed to return an already executed query result for compile operations.
+`execute_metricflow_query` and `get_metricflow_dimension_values` accept only
+compiled SQL and send it through the same bounded runtime as
+`doris_query.execute_query`.
+
+## Sidecar protocol
+
+The Server starts the configured executable without a shell, sends one JSON
+object on stdin, reads one bounded JSON object from stdout, and then waits for
+the process to exit. The protocol version is `doris-mcp-metricflow/v1`.
+
+Request:
+
+```json
+{
+  "protocol_version": "doris-mcp-metricflow/v1",
+  "request_id": "server-generated-uuid",
+  "operation": "compile_query",
+  "arguments": {
+    "model_ref": "commerce/main",
+    "dialect": "doris",
+    "request": {
+      "metrics": ["orders"],
+      "group_by": ["customer__country"]
+    }
+  }
+}
+```
+
+Success response:
+
+```json
+{
+  "protocol_version": "doris-mcp-metricflow/v1",
+  "request_id": "same-server-generated-uuid",
+  "ok": true,
+  "data": {
+    "sql": "SELECT ..."
+  }
+}
+```
+
+Failure response:
+
+```json
+{
+  "protocol_version": "doris-mcp-metricflow/v1",
+  "request_id": "same-server-generated-uuid",
+  "ok": false,
+  "error": {
+    "reason_code": "METRICFLOW_MODEL_NOT_FOUND"
+  }
+}
+```
+
+The Server verifies operation allowlisting, request correlation, protocol
+version, process status, timeout, UTF-8/JSON structure, response type, and
+output limits. Provider stderr and raw internal errors are not returned to the
+model.
+
+Collection operations return `data.items` as an array and may set
+`data.truncated=true`. Compile operations must return a non-empty `data.sql`.
+The SQL must pass the MCP read-only guard before it can execute.
+
+## Configuration
+
+```bash
+export METRICFLOW_ENABLED=true
+export METRICFLOW_PROVIDER_COMMAND_JSON='["/opt/doris-mcp/bin/metricflow-provider"]'
+export METRICFLOW_PROJECT_DIRECTORY=/srv/dbt
+export METRICFLOW_TIMEOUT_SECONDS=30
+export METRICFLOW_MAX_OUTPUT_BYTES=2097152
+```
+
+The executable and optional project directory must use absolute paths. The
+command is stored as a JSON array to preserve argument boundaries and avoid
+shell interpretation. Configuration validation rejects an enabled provider
+without a command, relative executables, empty command arrays, invalid bounds,
+and malformed JSON.
+
+## Availability and authorization
+
+The eight MetricFlow children stay in the stable catalog. When the provider is
+disabled or unhealthy they remain discoverable to an authorized identity with
+`callable=false` and a stable reason code. Model-dependent probes are evaluated
+at call time because an empty domain discovery request cannot validate an
+unknown future `model_ref`.
+
+OAuth deployments must explicitly enable semantic tools and grant
+`semantic:read` plus the exact discovery/execution scope. Doris RBAC remains
+the final authority once compiled SQL reaches the request-specific route.
+
+## Provider acceptance checklist
+
+- Load only operator-approved MetricFlow projects and exact model references.
+- Implement every advertised operation or report a stable failure code.
+- Compile with `dialect=doris`; never silently emit SQL for another dialect.
+- Never execute Doris SQL or accept Doris credentials in the sidecar protocol.
+- Bound model enumeration, metric lists, saved queries, group-bys, and SQL size.
+- Produce deterministic output for the same model revision and request.
+- Validate against real Doris with read-only and negative-write tests before
+  enabling the provider in production.
+
+MetricFlow command semantics are documented by
+[dbt Labs](https://docs.getdbt.com/docs/build/metricflow-commands); the engine
+source is available in the [MetricFlow repository](https://github.com/dbt-labs/metricflow).

--- a/docs/integrations/metricflow.zh-CN.md
+++ b/docs/integrations/metricflow.zh-CN.md
@@ -1,0 +1,156 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# MetricFlow 接入
+
+[English](metricflow.md) | 简体中文
+
+`doris_semantic` 可以通过可选、由管理员配置的 Sidecar 消费 MetricFlow Model。
+MetricFlow 继续拥有指标语义与查询编译；Doris MCP Server 负责 MCP 发现、授权、
+路由选择、Doris RBAC、只读 SQL 校验、查询限额、执行、审计元数据、脱敏和结果
+Schema。
+
+项目不内置 Doris 原生 MetricFlow/dbt Adapter。操作人员必须提供经过审查、能加载
+指定 MetricFlow Project 并编译合法 Doris SQL 的 Provider。因此这里提供的是稳定
+Consumer 边界，不代表原版 MetricFlow 无需 Adapter 或 Dialect 实现就能连接 Doris。
+
+## 公开 Child
+
+| Child | Provider Operation | 执行行为 |
+|---|---|---|
+| `list_metricflow_models` | `list_models` | 只读元数据，不猜 `model_ref`。 |
+| `get_metricflow_status` | `get_status` | 校验一个精确 `model_ref`。 |
+| `list_metricflow_metrics` | `list_metrics` | 有界 Metric/Dimension 元数据。 |
+| `get_metricflow_group_bys` | `get_group_bys` | 返回所选 Metric 的合法 Group-by 选项。 |
+| `list_metricflow_saved_queries` | `list_saved_queries` | 只读元数据，不执行 Saved Query。 |
+| `get_metricflow_dimension_values` | `compile_dimension_values` | Provider 编译，MCP Query Runtime 执行有界只读 SQL。 |
+| `compile_metricflow_query` | `compile_query` | 只编译，返回 Provider 证据与 Doris SQL。 |
+| `execute_metricflow_query` | `compile_query` | Provider 编译，MCP Query Runtime 校验并执行。 |
+
+每个 Model 相关调用都要求精确 `model_ref`。Server 不会从自然语言里排序、推断或
+选择模型。
+
+## 编译与执行边界
+
+```text
+MCP Host
+  -> doris_semantic Child + 精确 model_ref
+  -> 授权与动态 Availability
+  -> MetricFlow Sidecar：只做模型读取或 Doris SQL 编译
+  -> MCP ReadOnlySQLGuard
+  -> 请求级 DorisQueryRuntime
+  -> Doris Route、RBAC、超时/行数/字节限额、审计与脱敏
+  -> 通过 Schema 校验的 MCP Result
+```
+
+协议不会向 Sidecar 传 Doris 凭据；Compile Operation 也不允许返回已执行结果。
+`execute_metricflow_query` 和 `get_metricflow_dimension_values` 只接受编译 SQL，
+并把它送入与 `doris_query.execute_query` 相同的有界运行时。
+
+## Sidecar 协议
+
+Server 不经过 Shell 启动配置的可执行文件，在 stdin 写一个 JSON Object，从 stdout
+读取一个有界 JSON Object，并等待进程退出。协议版本是
+`doris-mcp-metricflow/v1`。
+
+请求：
+
+```json
+{
+  "protocol_version": "doris-mcp-metricflow/v1",
+  "request_id": "server-generated-uuid",
+  "operation": "compile_query",
+  "arguments": {
+    "model_ref": "commerce/main",
+    "dialect": "doris",
+    "request": {
+      "metrics": ["orders"],
+      "group_by": ["customer__country"]
+    }
+  }
+}
+```
+
+成功响应：
+
+```json
+{
+  "protocol_version": "doris-mcp-metricflow/v1",
+  "request_id": "same-server-generated-uuid",
+  "ok": true,
+  "data": {
+    "sql": "SELECT ..."
+  }
+}
+```
+
+失败响应：
+
+```json
+{
+  "protocol_version": "doris-mcp-metricflow/v1",
+  "request_id": "same-server-generated-uuid",
+  "ok": false,
+  "error": {
+    "reason_code": "METRICFLOW_MODEL_NOT_FOUND"
+  }
+}
+```
+
+Server 会校验 Operation Allowlist、Request Correlation、协议版本、进程状态、超时、
+UTF-8/JSON 结构、响应类型和输出上限。Provider stderr 与原始内部错误不会返回模型。
+
+Collection Operation 返回 `data.items` Array，可设置 `data.truncated=true`。
+Compile Operation 必须返回非空 `data.sql`，SQL 通过 MCP Read-only Guard 后才可执行。
+
+## 配置
+
+```bash
+export METRICFLOW_ENABLED=true
+export METRICFLOW_PROVIDER_COMMAND_JSON='["/opt/doris-mcp/bin/metricflow-provider"]'
+export METRICFLOW_PROJECT_DIRECTORY=/srv/dbt
+export METRICFLOW_TIMEOUT_SECONDS=30
+export METRICFLOW_MAX_OUTPUT_BYTES=2097152
+```
+
+Executable 和可选 Project Directory 必须使用绝对路径。Command 使用 JSON Array
+保存参数边界并避免 Shell 解释。配置校验会拒绝：启用后缺少 Command、相对
+Executable、空 Command Array、越界值和非法 JSON。
+
+## Availability 与授权
+
+8 个 MetricFlow Child 始终属于稳定 Catalog。Provider 关闭或不健康时，授权身份
+仍能发现它们，但会得到 `callable=false` 和稳定 Reason Code。Model 相关 Probe 在
+调用时校验，因为空参数的 Domain Discovery 无法提前校验未来未知的 `model_ref`。
+
+OAuth 部署必须显式启用 Semantic Tool，并授予 `semantic:read` 以及精确发现/执行
+Scope。编译 SQL 到达请求路由后，Doris RBAC 仍是最终权限边界。
+
+## Provider 验收清单
+
+- 只加载操作人员批准的 MetricFlow Project 与精确 Model Reference。
+- 实现所有声明 Operation，或返回稳定 Failure Code。
+- 使用 `dialect=doris` 编译，不静默输出其他 Dialect SQL。
+- Sidecar 协议不执行 Doris SQL，也不接收 Doris 凭据。
+- 对 Model、Metric、Saved Query、Group-by 与 SQL 大小全部设限。
+- 同一 Model Revision 与请求产生确定性结果。
+- 上生产前用真实 Doris 通过只读与负向写入测试。
+
+MetricFlow Command 语义见 [dbt Labs 文档](https://docs.getdbt.com/docs/build/metricflow-commands)，
+引擎源码见 [MetricFlow Repository](https://github.com/dbt-labs/metricflow)。

--- a/docs/migration-1.0.0.md
+++ b/docs/migration-1.0.0.md
@@ -39,13 +39,13 @@ next call:
 ```
 
 Hosts that cannot use progressive disclosure may set
-`MCP_TOOL_EXPOSURE_MODE=flat` before startup. Flat mode exposes 47
+`MCP_TOOL_EXPOSURE_MODE=flat` before startup. Flat mode exposes 55
 collision-free formal names such as `doris_catalog_list_tables` and
 `doris_query_execute_query`. Changing the mode requires a Server restart and a
 Host reconnect. Flat mode does not restore pre-1.0 names.
 
 The generated [tool catalog](tool-registry.md) is the authoritative list of
-all eight domains, 47 children, and 25 pre-1.0 migration inputs.
+all eight domains, 55 children, and 25 pre-1.0 migration inputs.
 
 ## Required Host changes
 
@@ -107,7 +107,7 @@ bounded protocol migration by setting `ENABLE_LEGACY_HTTP_ADAPTER=true`.
 
 ## Doris version handling
 
-The minimum supported Doris version is `3.0.0`. Patch certification uses only
+The minimum supported Doris version is `2.0.0`. Patch certification uses only
 the normalized `major.minor.patch` value. RC or GA labels, commit hashes, and
 deployment hints remain diagnostic evidence. They do not affect capability
 ranges or create separate certification buckets.
@@ -122,4 +122,4 @@ each connected cluster.
 Version 1.0.0 exposes read-only domains. The reserved `doris_admin` domain is
 not registered, and no management write operation is available. Custom
 providers remain explicit, allowlisted extensions rather than members of the
-built-in 8/47 contract.
+built-in 8/55 contract.

--- a/docs/migration/1.0.0.md
+++ b/docs/migration/1.0.0.md
@@ -38,7 +38,7 @@ Record before the upgrade:
 - Host support for progressive disclosure;
 - static/JWT/OAuth/Doris OAuth mode and scopes;
 - Doris route/account/patch and required FE/BE HTTP access;
-- ADBC, lineage, Ossie, or custom provider dependencies;
+- ADBC, lineage, Ossie, MetricFlow, or custom provider dependencies;
 - result/time/concurrency limits;
 - rollback package and configuration.
 
@@ -53,7 +53,11 @@ Do not upgrade the Server while leaving a Host with cached pre-1.0 schemas.
 - Runtime availability and `manifest_version` enter the call contract.
 - Five table metadata calls become sections of `get_table_context`.
 - ADBC moves into `doris_query`.
+- ADBC becomes default-off and requires explicit user intent plus
+  `explicit_adbc=true`; ordinary SQL stays on `execute_query`.
 - Semantic model-specific calls require exact `model_ref`.
+- `doris_semantic` adds eight MetricFlow consumer children while keeping
+  MetricFlow compilation separate from MCP-governed Doris execution.
 - Modern HTTP uses stateless MCP `2026-07-28` at `/mcp`.
 - `/mcp/legacy` is default-off and does not restore tool names.
 - `doris_admin` remains unavailable.
@@ -166,7 +170,7 @@ the adapter as a permanent architecture.
 
 ## Doris version and capability migration
 
-- Minimum supported Doris version is `3.0.0`.
+- Minimum supported Doris version is `2.0.0`.
 - Capability decisions use only normalized `major.minor.patch`.
 - RC/GA suffixes, commit hashes, and deployment hints are diagnostic only.
 - Runtime probes/providers/permissions remain required even when a version
@@ -175,6 +179,10 @@ the adapter as a permanent architecture.
   audit inference remains primary before 4.0.6 and degraded fallback after.
 - Certification and runtime support are separate; do not hard-code
   `target_uncertified` as unusable.
+- ADBC is unavailable on 2.0, version-eligible on 2.1+, and degraded on
+  2.1.0-2.1.4 before provider and live endpoint probes are considered.
+- Variant inspection starts at 2.1; ANN/vector/hybrid search starts at 4.0;
+  newer facets remain independently gated.
 
 ## Configuration migration
 
@@ -211,7 +219,9 @@ the adapter as a permanent architecture.
 
 ## Acceptance checklist
 
-- [ ] Host sees 8 domains or exact 47 formal children as intended.
+- [ ] Host sees 8 domains or exact 55 formal children as intended.
+- [ ] Ordinary SQL cannot select ADBC without explicit user intent.
+- [ ] MetricFlow compile-only and MCP-executed paths preserve the execution boundary.
 - [ ] No pre-1.0 name is discoverable/callable.
 - [ ] Catalog discovery and table context work.
 - [ ] Query read-only guard and bounds work.

--- a/docs/migration/1.0.0.zh-CN.md
+++ b/docs/migration/1.0.0.zh-CN.md
@@ -38,7 +38,7 @@ under the License.
 - Host 是否支持 Progressive Disclosure；
 - Static/JWT/OAuth/Doris OAuth 模式与 Scope；
 - Doris 路由、账号、Patch 与所需 FE/BE HTTP 访问；
-- ADBC、Lineage、Ossie 或自定义 Provider 依赖；
+- ADBC、Lineage、Ossie、MetricFlow 或自定义 Provider 依赖；
 - Result/Time/Concurrency Limit；
 - 回滚 Package 与配置。
 
@@ -53,7 +53,11 @@ under the License.
 - Runtime Availability 与 `manifest_version` 进入调用合同。
 - 5 个 Table Metadata Call 合并到 `get_table_context` Section。
 - ADBC 进入 `doris_query`。
+- ADBC 默认关闭，要求用户明确指定并传 `explicit_adbc=true`；普通 SQL 继续使用
+  `execute_query`。
 - Semantic Model-specific Call 要求精确 `model_ref`。
+- `doris_semantic` 新增 8 个 MetricFlow Consumer Child，并保持 MetricFlow 编译与
+  MCP 受治理 Doris 执行分离。
 - 现代 HTTP 在 `/mcp` 使用无状态 MCP `2026-07-28`。
 - `/mcp/legacy` 默认关闭，且不会恢复 Tool 名称。
 - `doris_admin` 仍不可用。
@@ -159,7 +163,7 @@ HTTP `2026-07-28`：
 
 ## Doris 版本与能力迁移
 
-- 最低 Doris 版本为 `3.0.0`。
+- 最低 Doris 版本为 `2.0.0`。
 - 能力决策只使用归一化 `major.minor.patch`。
 - RC/GA Suffix、Commit Hash 与 Deployment Hint 只用于诊断。
 - 版本范围满足后，仍需要 Runtime Probe/Provider/Permission。
@@ -167,6 +171,9 @@ HTTP `2026-07-28`：
   为主要路径，之后为 Degraded Fallback。
 - Certification 与 Runtime Support 分离，不能把 `target_uncertified` 硬编码为
   不可用。
+- ADBC 在 2.0 不可用，2.1+ 进入版本范围；2.1.0-2.1.4 在 Provider 和 Endpoint
+  实时探测前先标为 Degraded。
+- Variant 查看从 2.1 开始，ANN/向量/混合检索从 4.0 开始，后续特征独立 Gate。
 
 ## 配置迁移
 
@@ -203,7 +210,9 @@ HTTP `2026-07-28`：
 
 ## 验收清单
 
-- [ ] Host 按预期看到 8 Domain 或精确 47 Formal Child。
+- [ ] Host 按预期看到 8 Domain 或精确 55 Formal Child。
+- [ ] 普通 SQL 不会在缺少明确用户意图时选择 ADBC。
+- [ ] MetricFlow Compile-only 与 MCP 执行路径保持执行边界。
 - [ ] 1.0 以前名称均不可发现/调用。
 - [ ] Catalog Discovery 与 Table Context 可用。
 - [ ] Query Read-only Guard 与 Bounds 可用。

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -204,10 +204,14 @@ contract, not a per-request switch.
 
 ## Optional providers
 
-- **ADBC:** enable explicitly and configure Arrow Flight SQL ports; test route
-  isolation before production.
+- **ADBC:** enable the default-off advanced provider and configure Arrow Flight
+  SQL ports; ordinary queries still use MySQL, and ADBC calls require explicit
+  end-user intent plus `explicit_adbc=true`.
 - **Ossie:** set `OSSIE_ENABLED=true`, mount reviewed models and private Doris
   bindings, and grant explicit semantic scopes.
+- **MetricFlow:** configure an absolute reviewed sidecar command and project;
+  validate Doris-dialect compilation and real Doris read-only/negative-write
+  behavior before enabling it.
 - **Native lineage:** configure the canonical queryable store/provider and
   verify required columns and delivery health.
 - **Custom tools:** install the package and list its exact provider name in

--- a/docs/operations/deployment.zh-CN.md
+++ b/docs/operations/deployment.zh-CN.md
@@ -191,9 +191,12 @@ export MCP_TOOL_EXPOSURE_MODE=flat
 
 ## 可选 Provider
 
-- **ADBC：**显式启用并配置 Arrow Flight SQL 端口，上生产前测试路由隔离。
+- **ADBC：**启用默认关闭的高级 Provider 并配置 Arrow Flight SQL 端口；普通查询
+  继续使用 MySQL，ADBC 调用要求终端用户明确指定并传 `explicit_adbc=true`。
 - **Ossie：**设置 `OSSIE_ENABLED=true`，挂载已审查 Model 和私有 Doris Binding，
   并授权精确 Semantic Scope。
+- **MetricFlow：**配置绝对且经过审查的 Sidecar Command 与 Project；启用前验证
+  Doris Dialect 编译和真实 Doris 只读/负向写入行为。
 - **原生血缘：**配置规范可查询 Store/Provider，验证必需列和投递健康。
 - **自定义 Tool：**安装包，并把精确 Provider 名写入 `MCP_TOOL_PROVIDERS`。
 

--- a/docs/operations/reliability.md
+++ b/docs/operations/reliability.md
@@ -179,13 +179,17 @@ Limitations:
 - In-memory custom-provider quotas are per process.
 - Cache contents are local optimizations; correctness cannot depend on a shared
   cache.
-- Provider/model/binding files must be consistently deployed across replicas.
+- Provider/model/binding files and MetricFlow sidecar commands/projects must be
+  consistently deployed across replicas.
 
 ## Known limits
 
 - `doris_admin` is not registered.
-- ADBC query execution fails closed on token-bound routes.
+- ADBC is default-off, requires explicit end-user ADBC intent on every call,
+  and fails closed on token-bound routes.
 - Ossie is read-only grounding and does not execute semantic expressions.
+- MetricFlow support is a provider protocol, not a bundled Doris adapter. The
+  provider compiles only; SQL execution stays in the bounded Query runtime.
 - Native lineage delivery is asynchronous best effort and needs a queryable
   companion provider/store.
 - Audit-derived lineage/dependency evidence is bounded inference and may be

--- a/docs/operations/reliability.zh-CN.md
+++ b/docs/operations/reliability.zh-CN.md
@@ -168,13 +168,17 @@ Policy/Catalog 状态。
 - Doris OAuth 在 1.0 必须单 Worker、单实例边界。
 - 内存 Custom-provider Quota 为每进程独立。
 - Cache 只是本地优化，正确性不能依赖共享 Cache。
-- Provider/Model/Binding File 必须在各 Replica 一致部署。
+- Provider/Model/Binding File 与 MetricFlow Sidecar Command/Project 必须在各
+  Replica 一致部署。
 
 ## 已知限制
 
 - `doris_admin` 不注册。
-- ADBC 在 Token 绑定路由上 Fail Closed。
+- ADBC 默认关闭，每次调用都要求终端用户明确指定 ADBC，并在 Token 绑定路由上
+  Fail Closed。
 - Ossie 只读 Grounding，不执行语义表达式。
+- MetricFlow 支持是 Provider 协议，不是内置 Doris Adapter；Provider 只编译，
+  SQL 执行留在有界 Query Runtime。
 - 原生血缘异步 Best-effort，需要可查询 Companion Provider/Store。
 - Audit 血缘/依赖证据是有界推导，可能不完整。
 - Runtime Capability Support 不等于 Release Certification。

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -222,14 +222,23 @@ With independent replicas, configure the same
 ### ADBC unavailable
 
 Confirm `ADBC_ENABLED`, Arrow Flight SQL ports, provider installation, and live
-connectivity. ADBC execution intentionally fails closed on token-bound routes.
-Use the MySQL read-only query child when appropriate.
+connectivity. Confirm the end-user request explicitly selected ADBC and the
+call includes `explicit_adbc=true`. ADBC execution intentionally fails closed
+on token-bound routes. Use the MySQL read-only query child for ordinary SQL.
 
 ### Ossie model unavailable
 
 Confirm `OSSIE_ENABLED`, model directory, reviewed schema revision, exact
 `model_ref`, private binding manifest, semantic scopes, and Doris visibility.
 The Server never guesses a model.
+
+### MetricFlow model or compile unavailable
+
+Confirm `METRICFLOW_ENABLED`, the absolute provider command, project directory,
+sidecar protocol version, exact `model_ref`, Doris-dialect support, timeout and
+output bounds, semantic scopes, and Doris visibility. Provider stderr is
+intentionally hidden; inspect operator logs with secrets removed. The sidecar
+must compile only—Doris SQL execution belongs to the MCP Query runtime.
 
 ### Native lineage unavailable
 

--- a/docs/operations/troubleshooting.zh-CN.md
+++ b/docs/operations/troubleshooting.zh-CN.md
@@ -205,14 +205,22 @@ State Secret 不同或 Snapshot 改变。应不带 Cursor 重新开始 List。
 
 ### ADBC 不可用
 
-检查 `ADBC_ENABLED`、Arrow Flight SQL 端口、Provider 安装与实时连通。ADBC 在
-Token 绑定路由上故意 Fail Closed；适用时使用 MySQL 只读 Query Child。
+检查 `ADBC_ENABLED`、Arrow Flight SQL 端口、Provider 安装与实时连通。确认终端
+用户明确指定 ADBC，且调用包含 `explicit_adbc=true`。ADBC 在 Token 绑定路由上
+故意 Fail Closed；普通 SQL 使用 MySQL 只读 Query Child。
 
 ### Ossie Model 不可用
 
 检查 `OSSIE_ENABLED`、Model Directory、已审查 Schema Revision、精确
 `model_ref`、私有 Binding Manifest、Semantic Scope 和 Doris 可见性。Server
 不会猜模型。
+
+### MetricFlow Model 或编译不可用
+
+检查 `METRICFLOW_ENABLED`、绝对 Provider Command、Project Directory、Sidecar
+协议版本、精确 `model_ref`、Doris Dialect 支持、超时/输出上限、Semantic Scope
+和 Doris 可见性。Provider stderr 会故意隐藏；请在清除 Secret 后检查操作日志。
+Sidecar 只能编译，Doris SQL 执行属于 MCP Query Runtime。
 
 ### 原生血缘不可用
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -148,7 +148,7 @@ These are evidence/result bounds, not Doris permission grants.
 
 | Variable | Purpose |
 |---|---|
-| `ADBC_ENABLED` | enable optional ADBC provider |
+| `ADBC_ENABLED` | enable the optional advanced ADBC provider; default `false` |
 | `FE_ARROW_FLIGHT_SQL_PORT` | FE Flight SQL port |
 | `BE_ARROW_FLIGHT_SQL_PORT` | optional BE Flight port |
 | `ADBC_DEFAULT_MAX_ROWS` | default ADBC row limit |
@@ -157,7 +157,10 @@ These are evidence/result bounds, not Doris permission grants.
 | `ADBC_CONNECTION_TIMEOUT` | Flight connection timeout |
 
 ADBC remains subject to global result limits and fails closed on token-bound
-routes in 1.0.
+routes in 1.0. Enabling the provider does not authorize automatic selection:
+both ADBC child schemas and the runtime require `explicit_adbc=true`, which a
+Host should set only when the end user explicitly requests ADBC or Arrow
+Flight SQL. Ordinary queries use `doris_query.execute_query`.
 
 ## Apache Ossie semantic grounding
 
@@ -178,6 +181,22 @@ routes in 1.0.
 
 OAuth modes also require explicit semantic-channel enablement and
 `semantic:read`. Every model-specific call still needs exact `model_ref`.
+
+## MetricFlow semantic consumption
+
+| Variable | Purpose |
+|---|---|
+| `METRICFLOW_ENABLED` | enable the default-off MetricFlow consumer |
+| `METRICFLOW_PROVIDER_COMMAND_JSON` | absolute executable plus fixed arguments as a JSON string array |
+| `METRICFLOW_PROJECT_DIRECTORY` | optional absolute working directory for the provider |
+| `METRICFLOW_TIMEOUT_SECONDS` | provider process timeout, `1-120` seconds |
+| `METRICFLOW_MAX_OUTPUT_BYTES` | provider stdout limit, `1024-8388608` bytes |
+
+An enabled MetricFlow provider requires a non-empty command whose executable
+is absolute. The Server invokes it without a shell using protocol
+`doris-mcp-metricflow/v1`. The provider may inspect models and compile Doris
+SQL; all execution returns to the bounded MCP Query runtime. See
+[MetricFlow integration](../integrations/metricflow.md).
 
 ## Static token authentication
 

--- a/docs/reference/configuration.zh-CN.md
+++ b/docs/reference/configuration.zh-CN.md
@@ -143,7 +143,7 @@ Lakehouse：
 
 | 变量 | 用途 |
 |---|---|
-| `ADBC_ENABLED` | 启用可选 ADBC Provider |
+| `ADBC_ENABLED` | 启用可选高级 ADBC Provider；默认 `false` |
 | `FE_ARROW_FLIGHT_SQL_PORT` | FE Flight SQL Port |
 | `BE_ARROW_FLIGHT_SQL_PORT` | 可选 BE Flight Port |
 | `ADBC_DEFAULT_MAX_ROWS` | 默认 ADBC 行数 |
@@ -151,7 +151,10 @@ Lakehouse：
 | `ADBC_DEFAULT_RETURN_FORMAT` | `arrow`、`pandas` 或 `dict` |
 | `ADBC_CONNECTION_TIMEOUT` | Flight 连接超时 |
 
-ADBC 仍受全局结果上限约束，1.0 在 Token 绑定路由上 Fail Closed。
+ADBC 仍受全局结果上限约束，1.0 在 Token 绑定路由上 Fail Closed。启用 Provider
+不代表允许自动选择：两个 ADBC Child 的 Schema 和运行时都会要求
+`explicit_adbc=true`，Host 只应在终端用户明确要求 ADBC 或 Arrow Flight SQL 时
+设置。普通查询使用 `doris_query.execute_query`。
 
 ## Apache Ossie 语义 Grounding
 
@@ -172,6 +175,21 @@ ADBC 仍受全局结果上限约束，1.0 在 Token 绑定路由上 Fail Closed�
 
 OAuth 模式还要求显式 Semantic Channel 和 `semantic:read`。每个 Model-specific
 调用仍需要精确 `model_ref`。
+
+## MetricFlow 语义消费
+
+| 变量 | 用途 |
+|---|---|
+| `METRICFLOW_ENABLED` | 启用默认关闭的 MetricFlow Consumer |
+| `METRICFLOW_PROVIDER_COMMAND_JSON` | 以 JSON String Array 配置绝对 Executable 和固定参数 |
+| `METRICFLOW_PROJECT_DIRECTORY` | 可选 Provider 绝对 Working Directory |
+| `METRICFLOW_TIMEOUT_SECONDS` | Provider 进程超时，`1-120` 秒 |
+| `METRICFLOW_MAX_OUTPUT_BYTES` | Provider stdout 上限，`1024-8388608` 字节 |
+
+MetricFlow 启用时必须提供非空 Command，且 Executable 必须为绝对路径。Server
+不经过 Shell，通过 `doris-mcp-metricflow/v1` 调用。Provider 可以读取 Model 与
+编译 Doris SQL；所有执行必须回到有界 MCP Query Runtime。详见
+[MetricFlow 接入](../integrations/metricflow.zh-CN.md)。
 
 ## 静态 Token 认证
 

--- a/docs/release-notes-1.0.0.md
+++ b/docs/release-notes-1.0.0.md
@@ -13,7 +13,7 @@ distributed deployment shapes remain intentionally constrained.
 ## Highlights
 
 - Eight stable, read-only top-level domains with progressive child discovery.
-- Forty-seven collision-free child capabilities across catalog, query,
+- Fifty-five collision-free child capabilities across catalog, query,
   cluster, pipeline, search, governance, lakehouse, and semantic concerns.
 - A startup-time `flat` fallback for Hosts that cannot use progressive
   disclosure.
@@ -22,12 +22,14 @@ distributed deployment shapes remain intentionally constrained.
 - Native Doris lineage integration for 4.0.6 and later when the companion
   provider is available, with explicit audit-based fallback behavior.
 - Optional Apache Ossie semantic grounding with exact `model_ref` selection.
+- Optional MetricFlow consumption with exact `model_ref`, a compile-only
+  sidecar, and MCP-governed Doris execution.
 - MCP `2026-07-28` stateless request handling, bounded schemas and results,
   trace propagation, and deterministic product identity.
 - Static token, JWT, external OAuth/OIDC, and Doris-backed OAuth boundaries.
 
 The generated [tool catalog](tool-registry.md) contains the exact 8-domain and
-47-child release surface.
+55-child release surface.
 
 ## Breaking changes
 
@@ -45,8 +47,10 @@ configuration, and old-to-new mappings.
 
 ## Doris compatibility
 
-The project minimum is Doris `3.0.0`. The 1.0 target patch set is:
+The project minimum is Doris `2.0.0`. The 1.0 target patch set is:
 
+- `2.0.15`
+- `2.1.11`
 - `3.0.3`
 - `3.1.4`
 - `4.0.5`
@@ -74,7 +78,7 @@ The release gate covers:
 - official MCP `2026-07-28` stateless conformance;
 - stdio and Streamable HTTP;
 - hierarchical and Flat exposure;
-- stable 8-domain and 47-child contracts across processes;
+- stable 8-domain and 55-child contracts across processes;
 - real read-only Doris calls with zero management writes.
 
 ## Known limits
@@ -82,9 +86,12 @@ The release gate covers:
 - `doris_admin` is reserved but not registered.
 - Doris-backed OAuth uses process-local state and is not a multi-worker or
   multi-node mode.
-- ADBC execution is fail-closed on token-bound routes because the current
-  Arrow Flight client is process-global.
+- ADBC is default-off and requires explicit user intent plus
+  `explicit_adbc=true`; execution is fail-closed on token-bound routes because
+  the current Arrow Flight client is process-global.
 - Ossie semantic grounding is optional, read-only, and does not compile or
   execute semantic model expressions.
+- MetricFlow support requires an operator-supplied Doris-capable compiler
+  provider; the provider cannot bypass MCP-governed query execution.
 - Native lineage requires a queryable companion provider; audit inference is
   the primary path before Doris 4.0.6 and a degraded fallback afterward.

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -24,7 +24,7 @@ under the License.
 **Release tag:** `1.0.0`  
 **Published:** 2026-08-01  
 **Protocol baseline:** MCP `2026-07-28`  
-**Minimum Apache Doris version:** `3.0.0`
+**Minimum Apache Doris version:** `2.0.0`
 
 The detailed GitHub release record is
 [[RELEASE] Apache Doris MCP Server 1.0.0 Release](https://github.com/apache/doris-mcp-server/issues/189).
@@ -38,7 +38,7 @@ MCP Hosts and AI agents to Apache Doris. It replaces the pre-1.0 collection of
 independent direct tools with one capability-aware, read-only contract:
 
 - eight stable top-level domains;
-- forty-seven exact child capabilities;
+- fifty-five exact child capabilities;
 - deterministic progressive discovery and flat fallback;
 - runtime version, feature, provider, route, and permission evidence;
 - exact schemas, authorization identifiers, and typed result/error envelopes;
@@ -69,13 +69,13 @@ an alias window.
 | Domain | Children | Release scope |
 |---|---:|---|
 | `doris_catalog` | 5 | catalogs, databases, tables, four-section context, size |
-| `doris_query` | 7 | bounded query, Explain, Profile, diagnosis, slow queries, ADBC |
+| `doris_query` | 7 | bounded query, Explain, Profile, diagnosis, slow queries, explicit ADBC |
 | `doris_cluster` | 11 | topology, tasks, metrics, memory, cache, compaction, workloads, capabilities |
 | `doris_pipeline` | 5 | ingestion, diagnosis, materialized views, freshness, dependencies |
 | `doris_search` | 4 | text/vector/hybrid retrieval, analysis, indexes, diagnosis |
 | `doris_governance` | 8 | columns, storage, lineage, access, audit, UDFs, auth mapping |
 | `doris_lakehouse` | 3 | external catalogs, lakehouse tables, Variant |
-| `doris_semantic` | 4 | optional read-only Apache Ossie grounding |
+| `doris_semantic` | 12 | optional Apache Ossie grounding and MetricFlow consumption |
 
 See [Tool domains](../capabilities/tool-domains.md) and the generated
 [tool registry](../tool-registry.md) for all child names and bindings.
@@ -143,7 +143,7 @@ support results.
 - Request ID, duration, source, warnings, truncation, and sanitized tracing.
 - Explicit native/fallback paths for cluster, search, lakehouse, and lineage.
 
-## Native lineage and semantic grounding
+## Native lineage and semantic consumers
 
 Doris 4.0.6+ may use canonical events from a companion producer and queryable
 lineage store. Native mode requires live provider/store evidence. Bounded audit
@@ -155,12 +155,20 @@ read-only grounding. Every model-specific operation requires exact
 `model_ref`; private Doris bindings remain Server-side. The integration does
 not author models or compile/execute semantic expressions.
 
+MetricFlow integration adds eight exact-model consumer children for model
+status, metrics, group-bys, saved queries, dimension values, compilation, and
+execution. The optional provider compiles Doris SQL only; all execution returns
+to the MCP Query runtime for read-only validation, route/RBAC selection,
+limits, audit, redaction, and schema validation.
+
 ## Doris compatibility
 
-Minimum: `3.0.0`.
+Minimum: `2.0.0`.
 
 Target patch set:
 
+- `2.0.15`
+- `2.1.11`
 - `3.0.3`
 - `3.1.4`
 - `4.0.5`
@@ -184,7 +192,10 @@ target is not automatically unusable.
 - Added manifest availability and stale-generation handling.
 - Consolidated five table calls into `get_table_context` sections.
 - Moved ADBC under Query.
+- Made ADBC default-off and callable only with explicit user intent plus
+  `explicit_adbc=true`; ordinary SQL remains on `execute_query`.
 - Required exact `model_ref` for semantic calls.
+- Added eight MetricFlow consumer children with a compile-only sidecar boundary.
 - Standardized modern HTTP on MCP `2026-07-28` at `/mcp`.
 - Kept legacy protocol and administration boundaries isolated/default-off.
 
@@ -198,7 +209,7 @@ The release gate includes:
   tests;
 - protocol/authentication/core-manager coverage floors;
 - Ruff, Mypy, Bandit, and lock verification;
-- generated 8/47 catalog drift checks;
+- generated 8/55 catalog drift checks;
 - source distribution and clean-wheel installation;
 - official MCP `2026-07-28` stateless conformance;
 - stdio and Streamable HTTP process tests;
@@ -208,13 +219,15 @@ The release gate includes:
 PR [#187](https://github.com/apache/doris-mcp-server/pull/187) prepared the
 tag. PR [#188](https://github.com/apache/doris-mcp-server/pull/188) subsequently
 migrated the opt-in real Doris regression suite to the formal 1.0 surface
-without changing the 8/47 contract.
+before the later 8/55 semantic expansion.
 
 ## Known limitations
 
 - Doris-backed OAuth state is process-local and requires one worker.
-- ADBC is fail-closed on token-bound routes.
+- ADBC is default-off, explicit-only, and fail-closed on token-bound routes.
 - Ossie integration is optional, read-only grounding only.
+- MetricFlow requires an operator-supplied Doris-capable compiler provider;
+  no native MetricFlow/dbt Doris adapter is bundled.
 - Native lineage delivery is asynchronous best effort and provider-dependent.
 - Audit lineage/dependency inference is bounded and may be incomplete.
 - Subscription/change notifications remain unavailable.

--- a/docs/releases/1.0.0.zh-CN.md
+++ b/docs/releases/1.0.0.zh-CN.md
@@ -24,7 +24,7 @@ under the License.
 **Release Tag：**`1.0.0`  
 **发布时间：** 2026-08-01  
 **协议基线：** MCP `2026-07-28`  
-**最低 Apache Doris 版本：**`3.0.0`
+**最低 Apache Doris 版本：**`2.0.0`
 
 GitHub 详细发布记录：
 [[RELEASE] Apache Doris MCP Server 1.0.0 Release](https://github.com/apache/doris-mcp-server/issues/189)。
@@ -37,7 +37,7 @@ GitHub 详细发布记录：
 1.0 以前相互独立的直接 Tool 重构为一套能力感知、只读合同：
 
 - 8 个稳定一级领域；
-- 47 个精确 Child 能力；
+- 55 个精确 Child 能力；
 - 确定性渐进发现与 Flat 回退；
 - 运行时版本、特性、Provider、路由与权限证据；
 - 精确 Schema、Authorization ID 和类型化 Result/Error Envelope；
@@ -64,13 +64,13 @@ Domain 一直注册，因此模型可以在同一对话中从 Catalog 切换到 
 | Domain | Child 数量 | Release Scope |
 |---|---:|---|
 | `doris_catalog` | 5 | Catalog、Database、Table、四 Section Context、Size |
-| `doris_query` | 7 | 有界 Query、Explain、Profile、Diagnosis、Slow Query、ADBC |
+| `doris_query` | 7 | 有界 Query、Explain、Profile、Diagnosis、Slow Query、显式 ADBC |
 | `doris_cluster` | 11 | Topology、Task、Metric、Memory、Cache、Compaction、Workload、Capability |
 | `doris_pipeline` | 5 | Ingestion、Diagnosis、MV、Freshness、Dependency |
 | `doris_search` | 4 | Text/Vector/Hybrid、Analysis、Index、Diagnosis |
 | `doris_governance` | 8 | Column、Storage、Lineage、Access、Audit、UDF、Auth Mapping |
 | `doris_lakehouse` | 3 | External Catalog、Lakehouse Table、Variant |
-| `doris_semantic` | 4 | 可选只读 Apache Ossie Grounding |
+| `doris_semantic` | 12 | 可选 Apache Ossie Grounding 与 MetricFlow 消费 |
 
 全部 Child 名称和 Binding 见[工具领域](../capabilities/tool-domains.zh-CN.md)与自动
 生成[工具目录](../tool-registry.md)。
@@ -132,7 +132,7 @@ Domain 一直注册，因此模型可以在同一对话中从 Catalog 切换到 
 - Request ID、Duration、Source、Warning、Truncation 与清洗 Trace。
 - Cluster、Search、Lakehouse、Lineage 的显式 Native/Fallback Path。
 
-## 原生血缘与语义 Grounding
+## 原生血缘与语义消费者
 
 Doris 4.0.6+ 可以消费 Companion Producer 写入可查询 Lineage Store 的规范事件。
 Native 模式要求实时 Provider/Store 证据。4.0.6 以前以有界 Audit Inference 为主要
@@ -142,12 +142,19 @@ Native 模式要求实时 Provider/Store 证据。4.0.6 以前以有界 Audit In
 每个 Model-specific Operation 要求精确 `model_ref`；私有 Doris Binding 保留在
 Server 侧。集成不会创作模型，也不会编译/执行语义表达式。
 
+MetricFlow 集成新增 8 个精确 Model Consumer Child，覆盖 Model Status、Metric、
+Group-by、Saved Query、Dimension Value、编译与执行。可选 Provider 只编译 Doris
+SQL；所有执行回到 MCP Query Runtime，统一处理只读校验、Route/RBAC、限额、
+审计、脱敏和 Schema Validation。
+
 ## Doris 兼容性
 
-最低版本：`3.0.0`。
+最低版本：`2.0.0`。
 
 目标 Patch：
 
+- `2.0.15`
+- `2.1.11`
 - `3.0.3`
 - `3.1.4`
 - `4.0.5`
@@ -170,7 +177,10 @@ Host Quadrant 前保持 `target_uncertified`。运行时能力发现仍为权威
 - 引入 Manifest Availability 与 Stale Generation。
 - 5 个 Table Call 合并到 `get_table_context` Section。
 - ADBC 进入 Query Domain。
+- ADBC 默认关闭，只有用户明确指定并传 `explicit_adbc=true` 才可调用；普通 SQL
+  继续使用 `execute_query`。
 - Semantic Call 要求精确 `model_ref`。
+- 新增 8 个 MetricFlow Consumer Child，并采用只编译 Sidecar 边界。
 - 现代 HTTP 在 `/mcp` 统一为 MCP `2026-07-28`。
 - Legacy Protocol 与 Administration 保持隔离/默认关闭。
 
@@ -183,7 +193,7 @@ Release Gate 包括：
 - Warnings-as-errors Unit、Integration、Protocol、Security、Deployment Test；
 - Protocol/Authentication/Core-manager Coverage Floor；
 - Ruff、Mypy、Bandit 与 Lock Verification；
-- 自动生成 8/47 Catalog Drift Check；
+- 自动生成 8/55 Catalog Drift Check；
 - Source Distribution 与 Clean-wheel Install；
 - 官方 MCP `2026-07-28` Stateless Conformance；
 - stdio 与 Streamable HTTP Process Test；
@@ -192,13 +202,15 @@ Release Gate 包括：
 
 PR [#187](https://github.com/apache/doris-mcp-server/pull/187) 准备 Release Tag；
 PR [#188](https://github.com/apache/doris-mcp-server/pull/188) 随后把 Opt-in 真实
-Doris Regression Suite 迁移到正式 1.0 工具面，没有改变 8/47 合同。
+Doris Regression Suite 迁移到正式 1.0 工具面，早于后续 8/55 Semantic 扩展。
 
 ## 已知限制
 
 - Doris OAuth 状态在进程内，要求单 Worker。
-- ADBC 在 Token 绑定路由上 Fail Closed。
+- ADBC 默认关闭、必须显式指定，并在 Token 绑定路由上 Fail Closed。
 - Ossie 集成只做可选只读 Grounding。
+- MetricFlow 需要操作人员提供支持 Doris 的 Compiler Provider；项目不内置
+  MetricFlow/dbt Doris Adapter。
 - Native Lineage 异步 Best-effort，依赖 Provider。
 - Audit Lineage/Dependency Inference 有界，可能不完整。
 - Subscription/Change Notification 仍不可用。

--- a/docs/security/security-model.md
+++ b/docs/security/security-model.md
@@ -111,7 +111,7 @@ Authorization is performed more than once:
 2. **Domain discovery:** whether the identity can learn about a child.
 3. **Child execution:** exact policy such as
    `child:call:doris_query:execute_query`.
-4. **Channel/provider:** whether Doris OAuth, semantic, ADBC, or custom
+4. **Channel/provider:** whether Doris OAuth, semantic, ADBC, MetricFlow, or custom
    provider access is enabled and allowlisted.
 5. **Doris RBAC:** whether the selected Doris identity can execute the actual
    statement or read the actual metadata.
@@ -196,8 +196,9 @@ caller-controlled SSRF targets.
 - Logs use redacted credential DTOs and safe representations.
 - Do not enable debug logging that serializes request headers or environment
   secrets at the reverse proxy or process supervisor.
-- `.env`, token files, OAuth client files, JWT keys, and private Ossie binding
-  manifests require owner-only access and must not be committed.
+- `.env`, token files, OAuth client files, JWT keys, private Ossie binding
+  manifests, and MetricFlow projects/provider commands require owner-only
+  access and must not be committed when they contain private definitions.
 
 ## Custom providers
 
@@ -213,8 +214,11 @@ extension.
 
 - Doris-backed OAuth is single-worker and process-local.
 - Process-local custom-provider rate limits are not a distributed quota.
-- ADBC is fail-closed for token-bound routes because the Flight client is
-  process-global.
+- ADBC is default-off, requires explicit user intent on every call, and is
+  fail-closed for token-bound routes because the Flight client is process-global.
+- The MetricFlow sidecar receives model requests but no Doris credentials. It
+  compiles SQL only; the MCP read-only guard, request route, Doris RBAC, and
+  result limits remain mandatory.
 - Native lineage delivery is asynchronous best effort; it is evidence, not a
   transactional authorization source.
 - Application-level SQL guards do not replace Doris grants and row policies.

--- a/docs/security/security-model.zh-CN.md
+++ b/docs/security/security-model.zh-CN.md
@@ -98,7 +98,7 @@ OAuth Token 的受保护数据调用不能静默回退到全局服务账号。
 2. **领域发现：** 身份是否有权知道某个 Child。
 3. **Child 执行：** 例如精确策略
    `child:call:doris_query:execute_query`。
-4. **Channel/Provider：** Doris OAuth、Semantic、ADBC 或自定义 Provider 是否
+4. **Channel/Provider：** Doris OAuth、Semantic、ADBC、MetricFlow 或自定义 Provider 是否
    启用且 Allowlist 允许。
 5. **Doris RBAC：** 所选 Doris 身份是否能执行真实语句或读取真实元数据。
 
@@ -169,8 +169,9 @@ Fail Closed，不会落到更高权限连接池。Query、Metadata、FE HTTP 与
 - 日志使用已脱敏 Credential DTO 和安全 `repr`。
 - Reverse Proxy 或 Process Supervisor 不能开启会序列化请求 Header/环境 Secret
   的 Debug 日志。
-- `.env`、Token File、OAuth Client File、JWT Key 和私有 Ossie Binding
-  Manifest 应为 Owner-only，且不能提交。
+- `.env`、Token File、OAuth Client File、JWT Key、私有 Ossie Binding Manifest
+  和包含私有定义的 MetricFlow Project/Provider Command 应为 Owner-only，且不能
+  提交。
 
 ## 自定义 Provider
 
@@ -185,7 +186,10 @@ Fail Closed，不会落到更高权限连接池。Query、Metadata、FE HTTP 与
 
 - Doris OAuth 仅单 Worker，状态在进程内。
 - 自定义 Provider 的进程内限流不是分布式 Quota。
-- ADBC 因 Flight Client 为进程全局，在 Token 绑定路由上 Fail Closed。
+- ADBC 默认关闭，每次调用都要求明确用户意图；因 Flight Client 为进程全局，
+  在 Token 绑定路由上 Fail Closed。
+- MetricFlow Sidecar 接收模型请求但不接收 Doris 凭据，只编译 SQL；MCP 只读
+  Guard、请求路由、Doris RBAC 与结果限额仍然强制执行。
 - 原生血缘异步 Best-effort，仅作为证据，不是事务授权源。
 - 应用层 SQL Guard 不能替代 Doris Grant 与 Row Policy。
 - Public Reverse Proxy 的 Host/Origin 形态必须显式验证，绑定 `0.0.0.0` 本身不会

--- a/docs/tool-registry.md
+++ b/docs/tool-registry.md
@@ -11,7 +11,7 @@
 | `doris_search` | 4 | `readonly_domain_enabled` | `authorized_child_discovery` |
 | `doris_governance` | 8 | `readonly_domain_enabled` | `authorized_child_discovery` |
 | `doris_lakehouse` | 3 | `readonly_domain_enabled` | `authorized_child_discovery` |
-| `doris_semantic` | 4 | `readonly_domain_enabled` | `authorized_child_discovery` |
+| `doris_semantic` | 12 | `readonly_domain_enabled` | `authorized_child_discovery` |
 
 ## Formal child tools
 
@@ -64,6 +64,14 @@
 | `doris_semantic.get_semantic_model_summary` | `child:doris_semantic:get_semantic_model_summary` | `child:call:doris_semantic:get_semantic_model_summary` | `ossie_model_summary` |
 | `doris_semantic.get_semantic_context` | `child:doris_semantic:get_semantic_context` | `child:call:doris_semantic:get_semantic_context` | `ossie_semantic_context` |
 | `doris_semantic.get_semantic_mapping_status` | `child:doris_semantic:get_semantic_mapping_status` | `child:call:doris_semantic:get_semantic_mapping_status` | `ossie_doris_mapping` |
+| `doris_semantic.list_metricflow_models` | `child:doris_semantic:list_metricflow_models` | `child:call:doris_semantic:list_metricflow_models` | `metricflow_model_registry` |
+| `doris_semantic.get_metricflow_status` | `child:doris_semantic:get_metricflow_status` | `child:call:doris_semantic:get_metricflow_status` | `metricflow_model_status` |
+| `doris_semantic.list_metricflow_metrics` | `child:doris_semantic:list_metricflow_metrics` | `child:call:doris_semantic:list_metricflow_metrics` | `metricflow_metric_registry` |
+| `doris_semantic.get_metricflow_group_bys` | `child:doris_semantic:get_metricflow_group_bys` | `child:call:doris_semantic:get_metricflow_group_bys` | `metricflow_group_by_registry` |
+| `doris_semantic.list_metricflow_saved_queries` | `child:doris_semantic:list_metricflow_saved_queries` | `child:call:doris_semantic:list_metricflow_saved_queries` | `metricflow_saved_query_registry` |
+| `doris_semantic.get_metricflow_dimension_values` | `child:doris_semantic:get_metricflow_dimension_values` | `child:call:doris_semantic:get_metricflow_dimension_values` | `metricflow_dimension_value_query` |
+| `doris_semantic.compile_metricflow_query` | `child:doris_semantic:compile_metricflow_query` | `child:call:doris_semantic:compile_metricflow_query` | `metricflow_doris_compile` |
+| `doris_semantic.execute_metricflow_query` | `child:doris_semantic:execute_metricflow_query` | `child:call:doris_semantic:execute_metricflow_query` | `metricflow_compile_mcp_execute` |
 
 ## Pre-1.0 migration coverage
 

--- a/doris_mcp_server/main.py
+++ b/doris_mcp_server/main.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import sys
@@ -70,7 +71,7 @@ def _multiworker_environment(
     workers: int,
 ) -> dict[str, str]:
     """Serialize resolved parent settings inherited by Uvicorn workers."""
-    return {
+    environment = {
         "DORIS_HOST": config.database.host,
         "DORIS_HOSTS": ",".join(config.database.hosts),
         "DORIS_PORT": str(config.database.port),
@@ -162,6 +163,16 @@ def _multiworker_environment(
         "DORIS_OAUTH_SEMANTIC_RESOURCES_ENABLED": str(
             config.semantic.oauth_resources_enabled
         ).lower(),
+        "METRICFLOW_ENABLED": str(config.semantic.metricflow_enabled).lower(),
+        "METRICFLOW_PROJECT_DIRECTORY": (
+            config.semantic.metricflow_project_directory
+        ),
+        "METRICFLOW_TIMEOUT_SECONDS": str(
+            config.semantic.metricflow_timeout_seconds
+        ),
+        "METRICFLOW_MAX_OUTPUT_BYTES": str(
+            config.semantic.metricflow_max_output_bytes
+        ),
         "MCP_STATE_HANDLE_SECRET": config.mcp_state_handle_secret,
         "MCP_STATE_HANDLE_TTL_SECONDS": str(config.mcp_state_handle_ttl_seconds),
         "SERVER_NAME": config.server_name,
@@ -171,6 +182,11 @@ def _multiworker_environment(
             config.security.allow_unauthenticated_non_loopback
         ).lower(),
     }
+    if config.semantic.metricflow_provider_command:
+        environment["METRICFLOW_PROVIDER_COMMAND_JSON"] = json.dumps(
+            config.semantic.metricflow_provider_command
+        )
+    return environment
 
 
 class DorisServer:

--- a/doris_mcp_server/semantic/metricflow.py
+++ b/doris_mcp_server/semantic/metricflow.py
@@ -1,0 +1,507 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bounded MetricFlow consumer protocol for the Doris Semantic domain."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import uuid
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+from ..utils.query_runtime import DorisQueryRuntime, ReadOnlySQLGuard
+from .runtime import SemanticRuntimeFailure
+
+METRICFLOW_PROVIDER_PROTOCOL = "doris-mcp-metricflow/v1"
+_MODEL_REF_RE = re.compile(r"^[A-Za-z0-9_.:/@-]{1,192}$")
+_PROVIDER_OPERATIONS = frozenset(
+    {
+        "list_models",
+        "get_status",
+        "list_metrics",
+        "get_group_bys",
+        "list_saved_queries",
+        "compile_dimension_values",
+        "compile_query",
+    }
+)
+
+
+def _bool_config(section: Any, name: str, default: bool) -> bool:
+    value = getattr(section, name, default)
+    return value if isinstance(value, bool) else default
+
+
+def _int_config(section: Any, name: str, default: int) -> int:
+    value = getattr(section, name, default)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return default
+
+
+def _str_config(section: Any, name: str, default: str = "") -> str:
+    value = getattr(section, name, default)
+    return value if isinstance(value, str) else default
+
+
+def _command_config(section: Any) -> tuple[str, ...]:
+    value = getattr(section, "metricflow_provider_command", ())
+    if not isinstance(value, list | tuple) or any(
+        not isinstance(part, str) for part in value
+    ):
+        return ()
+    return tuple(value)
+
+
+class MetricFlowProvider(Protocol):
+    """Compile and inspect MetricFlow models without executing Doris SQL."""
+
+    async def request(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+    ) -> Mapping[str, Any]: ...
+
+
+class MetricFlowProviderFailure(RuntimeError):
+    """Stable internal provider failure before MCP error normalization."""
+
+    def __init__(self, reason_code: str, message: str) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+class MetricFlowSidecarProvider:
+    """Invoke one administrator-configured JSON sidecar without a shell."""
+
+    def __init__(
+        self,
+        command: Sequence[str],
+        *,
+        project_directory: str = "",
+        timeout_seconds: int = 30,
+        max_output_bytes: int = 2 * 1024 * 1024,
+    ) -> None:
+        normalized = tuple(str(part).strip() for part in command)
+        if not normalized or any(not part for part in normalized):
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_NOT_CONFIGURED",
+                "MetricFlow provider command is not configured.",
+            )
+        if not Path(normalized[0]).is_absolute():
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_COMMAND_INVALID",
+                "MetricFlow provider executable must use an absolute path.",
+            )
+        self._command = normalized
+        self._project_directory = project_directory or None
+        self._timeout_seconds = timeout_seconds
+        self._max_output_bytes = max_output_bytes
+
+    async def request(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        if operation not in _PROVIDER_OPERATIONS:
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_OPERATION_UNSUPPORTED",
+                "MetricFlow provider operation is unsupported.",
+            )
+        request_id = str(uuid.uuid4())
+        payload = json.dumps(
+            {
+                "protocol_version": METRICFLOW_PROVIDER_PROTOCOL,
+                "request_id": request_id,
+                "operation": operation,
+                "arguments": dict(arguments),
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *self._command,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._project_directory,
+            )
+        except (OSError, ValueError) as exc:
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_START_FAILED",
+                "MetricFlow provider could not be started.",
+            ) from exc
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(payload),
+                timeout=self._timeout_seconds,
+            )
+        except TimeoutError as exc:
+            process.kill()
+            await process.wait()
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_TIMEOUT",
+                "MetricFlow provider timed out.",
+            ) from exc
+
+        if len(stdout) > self._max_output_bytes or len(stderr) > 64 * 1024:
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_OUTPUT_LIMIT_EXCEEDED",
+                "MetricFlow provider output exceeded its configured limit.",
+            )
+        if process.returncode != 0:
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_FAILED",
+                "MetricFlow provider returned a failed status.",
+            )
+        try:
+            response = json.loads(stdout.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_RESPONSE_INVALID",
+                "MetricFlow provider returned an invalid response.",
+            ) from exc
+        if not isinstance(response, Mapping):
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_RESPONSE_INVALID",
+                "MetricFlow provider returned an invalid response.",
+            )
+        if (
+            response.get("protocol_version") != METRICFLOW_PROVIDER_PROTOCOL
+            or response.get("request_id") != request_id
+        ):
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_PROTOCOL_MISMATCH",
+                "MetricFlow provider protocol validation failed.",
+            )
+        if response.get("ok") is not True:
+            error = response.get("error")
+            reason_code = "METRICFLOW_PROVIDER_REQUEST_FAILED"
+            if isinstance(error, Mapping):
+                candidate = error.get("reason_code")
+                if isinstance(candidate, str) and re.fullmatch(
+                    r"[A-Z][A-Z0-9_]{0,127}", candidate
+                ):
+                    reason_code = candidate
+            raise MetricFlowProviderFailure(
+                reason_code,
+                "MetricFlow provider rejected the request.",
+            )
+        data = response.get("data")
+        if not isinstance(data, Mapping):
+            raise MetricFlowProviderFailure(
+                "METRICFLOW_PROVIDER_RESPONSE_INVALID",
+                "MetricFlow provider response data must be an object.",
+            )
+        return cast(Mapping[str, Any], data)
+
+
+class MetricFlowSemanticRuntime:
+    """Expose MetricFlow metadata and compile-only operations to MCP."""
+
+    def __init__(
+        self,
+        query_runtime: DorisQueryRuntime,
+        *,
+        enabled: bool,
+        provider: MetricFlowProvider | None,
+    ) -> None:
+        self._query_runtime = query_runtime
+        self._enabled = enabled
+        self._provider = provider
+
+    @classmethod
+    def from_config(
+        cls,
+        query_runtime: DorisQueryRuntime,
+        semantic_config: Any | None,
+    ) -> MetricFlowSemanticRuntime:
+        enabled = _bool_config(
+            semantic_config,
+            "metricflow_enabled",
+            False,
+        )
+        provider: MetricFlowProvider | None = None
+        if enabled:
+            provider = MetricFlowSidecarProvider(
+                _command_config(semantic_config),
+                project_directory=_str_config(
+                    semantic_config,
+                    "metricflow_project_directory",
+                ),
+                timeout_seconds=_int_config(
+                    semantic_config,
+                    "metricflow_timeout_seconds",
+                    30,
+                ),
+                max_output_bytes=_int_config(
+                    semantic_config,
+                    "metricflow_max_output_bytes",
+                    2 * 1024 * 1024,
+                ),
+            )
+        return cls(query_runtime, enabled=enabled, provider=provider)
+
+    async def list_models(self) -> dict[str, Any]:
+        data = await self._request("list_models", {})
+        return _collection_result(data, "metricflow_model_registry")
+
+    async def get_status(self, *, model_ref: str) -> dict[str, Any]:
+        normalized_ref = _model_ref(model_ref)
+        data = await self._request(
+            "get_status",
+            {"model_ref": normalized_ref},
+        )
+        return _detail_result(data, "metricflow_provider_status")
+
+    async def list_metrics(
+        self,
+        *,
+        model_ref: str,
+        search: str | None,
+        include_dimensions: bool,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        data = await self._request(
+            "list_metrics",
+            {
+                "model_ref": _model_ref(model_ref),
+                "search": search,
+                "include_dimensions": include_dimensions,
+                "limit": limit,
+            },
+        )
+        return _collection_result(data, "metricflow_metric_registry")
+
+    async def get_group_bys(
+        self,
+        *,
+        model_ref: str,
+        metrics: Sequence[str],
+    ) -> dict[str, Any]:
+        data = await self._request(
+            "get_group_bys",
+            {
+                "model_ref": _model_ref(model_ref),
+                "metrics": list(metrics),
+            },
+        )
+        return _detail_result(data, "metricflow_group_by_registry")
+
+    async def list_saved_queries(
+        self,
+        *,
+        model_ref: str,
+        search: str | None,
+        limit: int | None,
+    ) -> dict[str, Any]:
+        data = await self._request(
+            "list_saved_queries",
+            {
+                "model_ref": _model_ref(model_ref),
+                "search": search,
+                "limit": limit,
+            },
+        )
+        return _collection_result(data, "metricflow_saved_query_registry")
+
+    async def get_dimension_values(
+        self,
+        *,
+        model_ref: str,
+        metrics: Sequence[str],
+        dimension: str,
+        start_time: str | None,
+        end_time: str | None,
+        limit: int | None,
+        timeout_ms: int | None,
+    ) -> dict[str, Any]:
+        compiled = await self._request(
+            "compile_dimension_values",
+            {
+                "model_ref": _model_ref(model_ref),
+                "metrics": list(metrics),
+                "dimension": dimension,
+                "start_time": start_time,
+                "end_time": end_time,
+                "limit": limit,
+            },
+        )
+        return await self._execute_compiled(
+            compiled,
+            model_ref=model_ref,
+            max_rows=limit,
+            timeout_ms=timeout_ms,
+        )
+
+    async def compile_query(
+        self,
+        *,
+        model_ref: str,
+        request: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        compiled = await self._compile(model_ref=model_ref, request=request)
+        return _detail_result(compiled, "metricflow_doris_compile")
+
+    async def execute_query(
+        self,
+        *,
+        model_ref: str,
+        request: Mapping[str, Any],
+        max_rows: int | None,
+        timeout_ms: int | None,
+    ) -> dict[str, Any]:
+        compiled = await self._compile(model_ref=model_ref, request=request)
+        return await self._execute_compiled(
+            compiled,
+            model_ref=model_ref,
+            max_rows=max_rows,
+            timeout_ms=timeout_ms,
+        )
+
+    async def _compile(
+        self,
+        *,
+        model_ref: str,
+        request: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        return await self._request(
+            "compile_query",
+            {
+                "model_ref": _model_ref(model_ref),
+                "request": dict(request),
+                "dialect": "doris",
+            },
+        )
+
+    async def _execute_compiled(
+        self,
+        compiled: Mapping[str, Any],
+        *,
+        model_ref: str,
+        max_rows: int | None,
+        timeout_ms: int | None,
+    ) -> dict[str, Any]:
+        sql = compiled.get("sql")
+        if not isinstance(sql, str) or not sql.strip():
+            raise SemanticRuntimeFailure(
+                "METRICFLOW_COMPILED_SQL_INVALID",
+                "MetricFlow provider did not return executable SQL.",
+                status_code=502,
+            )
+        statement = ReadOnlySQLGuard.validate(sql)
+        result = await self._query_runtime.execute_query(
+            sql=statement.sql,
+            max_rows=max_rows,
+            timeout_ms=timeout_ms,
+        )
+        metadata = result.get("metadata")
+        if isinstance(metadata, dict):
+            metadata.update(
+                {
+                    "semantic_provider": "metricflow",
+                    "semantic_model_ref": _model_ref(model_ref),
+                    "compile_execution_boundary": "mcp_query_runtime",
+                }
+            )
+        return result
+
+    async def _request(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        if not self._enabled or self._provider is None:
+            raise SemanticRuntimeFailure(
+                "METRICFLOW_DISABLED",
+                "MetricFlow provider is disabled.",
+                status_code=503,
+            )
+        try:
+            return await self._provider.request(operation, arguments)
+        except MetricFlowProviderFailure as exc:
+            raise SemanticRuntimeFailure(
+                exc.reason_code,
+                str(exc),
+                retryable=exc.reason_code
+                in {
+                    "METRICFLOW_PROVIDER_TIMEOUT",
+                    "METRICFLOW_PROVIDER_START_FAILED",
+                },
+                status_code=502,
+            ) from exc
+
+
+def _model_ref(value: str) -> str:
+    if not isinstance(value, str) or _MODEL_REF_RE.fullmatch(value) is None:
+        raise SemanticRuntimeFailure(
+            "METRICFLOW_MODEL_REF_INVALID",
+            "An exact MetricFlow model reference is required.",
+        )
+    return value
+
+
+def _collection_result(data: Mapping[str, Any], source: str) -> dict[str, Any]:
+    items = data.get("items")
+    if not isinstance(items, list) or any(
+        not isinstance(item, Mapping) for item in items
+    ):
+        raise SemanticRuntimeFailure(
+            "METRICFLOW_PROVIDER_RESPONSE_INVALID",
+            "MetricFlow provider collection response is invalid.",
+            status_code=502,
+        )
+    truncated = bool(data.get("truncated", False))
+    return {
+        "status": "partial" if truncated else "success",
+        "data": {
+            "items": [dict(item) for item in items],
+            "next_cursor": None,
+            "truncated": truncated,
+        },
+        "warnings": (["METRICFLOW_RESULT_TRUNCATED"] if truncated else []),
+        "metadata": {
+            "source": source,
+            "provider_protocol": METRICFLOW_PROVIDER_PROTOCOL,
+        },
+    }
+
+
+def _detail_result(data: Mapping[str, Any], source: str) -> dict[str, Any]:
+    return {
+        "status": "success",
+        "data": dict(data),
+        "warnings": [],
+        "metadata": {
+            "source": source,
+            "provider_protocol": METRICFLOW_PROVIDER_PROTOCOL,
+        },
+    }
+
+
+__all__ = [
+    "METRICFLOW_PROVIDER_PROTOCOL",
+    "MetricFlowProvider",
+    "MetricFlowProviderFailure",
+    "MetricFlowSemanticRuntime",
+    "MetricFlowSidecarProvider",
+]

--- a/doris_mcp_server/tools/capability_detector.py
+++ b/doris_mcp_server/tools/capability_detector.py
@@ -53,6 +53,9 @@ from .doris_version import (
 _NATIVE_LINEAGE_MINIMUM = parse_doris_version_comment(
     "Doris version doris-4.0.6"
 )
+_ADBC_RECOMMENDED_MINIMUM = parse_doris_version_comment(
+    "Doris version doris-2.1.5"
+)
 _LINEAGE_STORE_REQUIRED_COLUMNS = frozenset(
     {
         "event_id",
@@ -486,6 +489,9 @@ class DorisCapabilityDetector:
                     probes.update(evidence)
                 if domain_name == "doris_query":
                     probes.update(await self._probe_query_services(auth_context))
+                    probes["adbc_release_maturity"] = _adbc_release_maturity_probe(
+                        base.version_vector.master_fe
+                    )
                     probes["profile_or_audit_readable"] = _combine_query_evidence_probe(
                         probes
                     )
@@ -1694,6 +1700,27 @@ def _adbc_probe_evidence(
     }
 
 
+def _adbc_release_maturity_probe(
+    version: DorisVersion,
+) -> CapabilityProbeEvidence:
+    """Mark Doris 2.1.0-2.1.4 ADBC as early and runtime-gated."""
+    if not version.is_parsed:
+        status = CapabilityProbeStatus.UNKNOWN
+        reason = "DORIS_VERSION_UNKNOWN"
+    elif version.compare(_ADBC_RECOMMENDED_MINIMUM) < 0:
+        status = CapabilityProbeStatus.DEGRADED
+        reason = "ADBC_EARLY_2_1_RELEASE"
+    else:
+        status = CapabilityProbeStatus.SUPPORTED
+        reason = "ADBC_RECOMMENDED_RELEASE_BASELINE"
+    return CapabilityProbeEvidence(
+        probe_id="adbc_release_maturity",
+        status=status,
+        reason_code=reason,
+        evidence_sources=("doris_arrow_flight_sql_guide",),
+    )
+
+
 def _combine_query_evidence_probe(
     probes: Mapping[str, CapabilityProbeEvidence],
 ) -> CapabilityProbeEvidence:
@@ -2007,6 +2034,27 @@ def _semantic_adapter_evidence_probes() -> dict[str, CapabilityProbeEvidence]:
             status=CapabilityProbeStatus.DEGRADED,
             reason_code="SEMANTIC_TARGET_REQUIRES_CALL_TIME_VALIDATION",
             evidence_sources=("pinned_ossie_schema", "active_doris_route"),
+        )
+    derived["metricflow_provider_protocol_ready"] = CapabilityProbeEvidence(
+        probe_id="metricflow_provider_protocol_ready",
+        status=CapabilityProbeStatus.DEGRADED,
+        reason_code="METRICFLOW_PROVIDER_REQUIRES_CALL_TIME_VALIDATION",
+        evidence_sources=("provider_registry", "metricflow_provider_protocol"),
+    )
+    for probe_id in (
+        "explicit_metricflow_model_ref_valid",
+        "metricflow_model_metadata_readable",
+        "metricflow_compile_ready",
+        "metricflow_doris_dialect_ready",
+    ):
+        derived[probe_id] = CapabilityProbeEvidence(
+            probe_id=probe_id,
+            status=CapabilityProbeStatus.DEGRADED,
+            reason_code="METRICFLOW_TARGET_REQUIRES_CALL_TIME_VALIDATION",
+            evidence_sources=(
+                "metricflow_provider_protocol",
+                "active_doris_route",
+            ),
         )
     return derived
 

--- a/doris_mcp_server/tools/capability_registry.py
+++ b/doris_mcp_server/tools/capability_registry.py
@@ -150,6 +150,28 @@ class CapabilityProviderRegistry:
                     and isinstance(binding_manifest, str)
                     and bool(binding_manifest.strip())
                 )
+            elif provider_id == "metricflow_provider":
+                semantic_config = getattr(config, "semantic", None)
+                metricflow_enabled = getattr(
+                    semantic_config,
+                    "metricflow_enabled",
+                    False,
+                )
+                provider_command = getattr(
+                    semantic_config,
+                    "metricflow_provider_command",
+                    (),
+                )
+                configured = (
+                    configured
+                    and metricflow_enabled is True
+                    and isinstance(provider_command, list | tuple)
+                    and bool(provider_command)
+                    and all(
+                        isinstance(part, str) and bool(part.strip())
+                        for part in provider_command
+                    )
+                )
             providers[provider_id] = CapabilityProviderEvidence(
                 provider_id=provider_id,
                 status=(

--- a/doris_mcp_server/tools/domain_catalog.py
+++ b/doris_mcp_server/tools/domain_catalog.py
@@ -173,7 +173,7 @@ class DorisDomainCatalog(ContractModel):
         if actual != expected:
             raise DomainCatalogError(
                 "domain catalog must contain the exact ordered "
-                "8-domain/47-child contract"
+                "8-domain/55-child contract"
             )
 
         domain_names = tuple(domain.name for domain in self.domains)
@@ -473,6 +473,80 @@ def _string_array(
         "items": item_schema,
         "minItems": min_items,
         "uniqueItems": True,
+    }
+
+
+def _metricflow_name_array(description: str) -> dict[str, Any]:
+    return {
+        "type": "array",
+        "description": description,
+        "items": {
+            "type": "string",
+            "pattern": r"^[A-Za-z_][A-Za-z0-9_.:-]{0,191}$",
+            "maxLength": 192,
+        },
+        "minItems": 1,
+        "maxItems": 64,
+        "uniqueItems": True,
+    }
+
+
+def _metricflow_order_by_array() -> dict[str, Any]:
+    schema = _metricflow_name_array(
+        "Output fields in priority order; prefix a field with '-' for descending."
+    )
+    schema["items"] = {
+        "type": "string",
+        "pattern": r"^-?[A-Za-z_][A-Za-z0-9_.:-]{0,191}$",
+        "maxLength": 193,
+    }
+    return schema
+
+
+def _metricflow_model_ref() -> dict[str, Any]:
+    return _string(
+        "Exact MetricFlow model reference returned by model discovery.",
+        pattern=r"^[A-Za-z0-9_.:/@-]+$",
+        max_length=192,
+    )
+
+
+def _metricflow_query_request() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "description": "Structured MetricFlow query request.",
+        "properties": {
+            "metrics": _metricflow_name_array("Metrics to query."),
+            "group_by": _metricflow_name_array(
+                "Dimensions or entities used to group results."
+            ),
+            "saved_query": _string(
+                "Exact saved-query name.",
+                pattern=r"^[A-Za-z_][A-Za-z0-9_.:-]{0,191}$",
+                max_length=192,
+            ),
+            "where": {
+                "type": "array",
+                "description": "MetricFlow filter expressions.",
+                "items": {"type": "string", "minLength": 1, "maxLength": 2048},
+                "maxItems": 16,
+            },
+            "start_time": _string("Inclusive ISO-8601 start time.", max_length=64),
+            "end_time": _string("Inclusive ISO-8601 end time.", max_length=64),
+            "order_by": _metricflow_order_by_array(),
+            "limit": _integer("Maximum result rows.", minimum=1, maximum=100_000),
+        },
+        "oneOf": [
+            {
+                "required": ["metrics"],
+                "not": {"required": ["saved_query"]},
+            },
+            {
+                "required": ["saved_query"],
+                "not": {"required": ["metrics"]},
+            },
+        ],
+        "additionalProperties": False,
     }
 
 
@@ -1030,7 +1104,8 @@ DOMAIN_DEFINITIONS = (
         "doris_query",
         "Doris Query",
         "Execute read-only Doris SQL, inspect plans and profiles, review slow "
-        "queries, and use the optional ADBC provider.",
+        "queries, and use advanced ADBC only when the end user explicitly "
+        "requests ADBC or Arrow Flight SQL.",
         (
             _child(
                 "doris_query",
@@ -1208,16 +1283,38 @@ DOMAIN_DEFINITIONS = (
                 "doris_query",
                 "get_adbc_connection_info",
                 "Get ADBC connection info",
-                "Report sanitized ADBC provider configuration and reachability.",
-                _input_schema({}),
+                "Advanced only: report ADBC configuration after an explicit "
+                "end-user request for ADBC or Arrow Flight SQL.",
+                _input_schema(
+                    {
+                        "explicit_adbc": {
+                            "type": "boolean",
+                            "const": True,
+                            "description": (
+                                "Caller attests that the end user explicitly "
+                                "requested ADBC or Arrow Flight SQL."
+                            ),
+                        }
+                    },
+                    required=("explicit_adbc",),
+                ),
             ),
             _child(
                 "doris_query",
                 "execute_adbc_query",
                 "Execute ADBC query",
-                "Execute one read-only SQL statement through Arrow Flight SQL.",
+                "Advanced only: execute through Arrow Flight SQL when the end "
+                "user explicitly requested ADBC; use execute_query otherwise.",
                 _input_schema(
                     {
+                        "explicit_adbc": {
+                            "type": "boolean",
+                            "const": True,
+                            "description": (
+                                "Caller attests that the end user explicitly "
+                                "requested ADBC or Arrow Flight SQL."
+                            ),
+                        },
                         "sql": _string(
                             "Read-only SQL statement.",
                             max_length=1024 * 1024,
@@ -1237,7 +1334,7 @@ DOMAIN_DEFINITIONS = (
                             enum=("arrow", "pandas", "dict"),
                         ),
                     },
-                    required=("sql",),
+                    required=("explicit_adbc", "sql"),
                 ),
                 _QUERY_OUTPUT,
             ),
@@ -1847,8 +1944,9 @@ DOMAIN_DEFINITIONS = (
     _domain(
         "doris_semantic",
         "Doris Semantic",
-        "Discover validated Ossie models bound to Doris and read permission-"
-        "filtered semantic summaries, context, and mapping status.",
+        "Discover and use validated Ossie or MetricFlow models bound to Doris. "
+        "MetricFlow compiles SQL only; MCP executes it through the guarded "
+        "Doris Query runtime.",
         (
             _child(
                 "doris_semantic",
@@ -2000,6 +2098,168 @@ DOMAIN_DEFINITIONS = (
                     required=("model_ref",),
                 ),
                 _DIAGNOSTIC_OUTPUT,
+            ),
+            _child(
+                "doris_semantic",
+                "list_metricflow_models",
+                "List MetricFlow models",
+                "List exact MetricFlow model references exposed by the provider.",
+                _input_schema({}),
+                _COLLECTION_OUTPUT,
+            ),
+            _child(
+                "doris_semantic",
+                "get_metricflow_status",
+                "Get MetricFlow status",
+                "Validate one exact MetricFlow model, provider, and Doris dialect.",
+                _input_schema(
+                    {"model_ref": _metricflow_model_ref()},
+                    required=("model_ref",),
+                ),
+                _DETAIL_OUTPUT,
+            ),
+            _child(
+                "doris_semantic",
+                "list_metricflow_metrics",
+                "List MetricFlow metrics",
+                "List metrics for one exact MetricFlow model reference.",
+                _input_schema(
+                    {
+                        "model_ref": _metricflow_model_ref(),
+                        "search": _string(
+                            "Optional metric-name search term.",
+                            max_length=192,
+                        ),
+                        "include_dimensions": _boolean(
+                            "Include the dimensions reported for each metric."
+                        ),
+                        "limit": _integer(
+                            "Maximum metrics.",
+                            minimum=1,
+                            maximum=1000,
+                        ),
+                    },
+                    required=("model_ref",),
+                ),
+                _COLLECTION_OUTPUT,
+            ),
+            _child(
+                "doris_semantic",
+                "get_metricflow_group_bys",
+                "Get MetricFlow group-bys",
+                "List common MetricFlow dimensions and entities for metrics.",
+                _input_schema(
+                    {
+                        "model_ref": _metricflow_model_ref(),
+                        "metrics": _metricflow_name_array(
+                            "Exact MetricFlow metric names."
+                        ),
+                    },
+                    required=("model_ref", "metrics"),
+                ),
+                _DETAIL_OUTPUT,
+            ),
+            _child(
+                "doris_semantic",
+                "list_metricflow_saved_queries",
+                "List MetricFlow saved queries",
+                "List saved queries for one exact MetricFlow model reference.",
+                _input_schema(
+                    {
+                        "model_ref": _metricflow_model_ref(),
+                        "search": _string(
+                            "Optional saved-query search term.",
+                            max_length=192,
+                        ),
+                        "limit": _integer(
+                            "Maximum saved queries.",
+                            minimum=1,
+                            maximum=1000,
+                        ),
+                    },
+                    required=("model_ref",),
+                ),
+                _COLLECTION_OUTPUT,
+            ),
+            _child(
+                "doris_semantic",
+                "get_metricflow_dimension_values",
+                "Get MetricFlow dimension values",
+                "Compile a MetricFlow dimension-value query and execute it "
+                "through the guarded Doris Query runtime.",
+                _input_schema(
+                    {
+                        "model_ref": _metricflow_model_ref(),
+                        "metrics": _metricflow_name_array(
+                            "Metrics associated with the dimension."
+                        ),
+                        "dimension": _string(
+                            "Exact MetricFlow dimension name.",
+                            pattern=r"^[A-Za-z_][A-Za-z0-9_.:-]{0,191}$",
+                            max_length=192,
+                        ),
+                        "start_time": _string(
+                            "Inclusive ISO-8601 start time.",
+                            max_length=64,
+                        ),
+                        "end_time": _string(
+                            "Inclusive ISO-8601 end time.",
+                            max_length=64,
+                        ),
+                        "limit": _integer(
+                            "Maximum returned values.",
+                            minimum=1,
+                            maximum=10_000,
+                        ),
+                        "timeout_ms": _integer(
+                            "Execution timeout in milliseconds.",
+                            minimum=1,
+                            maximum=300_000,
+                        ),
+                    },
+                    required=("model_ref", "metrics", "dimension"),
+                ),
+                _QUERY_OUTPUT,
+            ),
+            _child(
+                "doris_semantic",
+                "compile_metricflow_query",
+                "Compile MetricFlow query",
+                "Compile a structured MetricFlow request to guarded Doris SQL "
+                "without executing it.",
+                _input_schema(
+                    {
+                        "model_ref": _metricflow_model_ref(),
+                        "request": _metricflow_query_request(),
+                    },
+                    required=("model_ref", "request"),
+                ),
+                _DETAIL_OUTPUT,
+            ),
+            _child(
+                "doris_semantic",
+                "execute_metricflow_query",
+                "Execute MetricFlow query",
+                "Compile a structured MetricFlow request, then execute the "
+                "read-only SQL through the guarded Doris Query runtime.",
+                _input_schema(
+                    {
+                        "model_ref": _metricflow_model_ref(),
+                        "request": _metricflow_query_request(),
+                        "max_rows": _integer(
+                            "Maximum returned rows.",
+                            minimum=1,
+                            maximum=100_000,
+                        ),
+                        "timeout_ms": _integer(
+                            "Execution timeout in milliseconds.",
+                            minimum=1,
+                            maximum=300_000,
+                        ),
+                    },
+                    required=("model_ref", "request"),
+                ),
+                _QUERY_OUTPUT,
             ),
         ),
     ),

--- a/doris_mcp_server/tools/domain_dispatcher.py
+++ b/doris_mcp_server/tools/domain_dispatcher.py
@@ -337,7 +337,7 @@ class DomainDispatcher:
 
     @property
     def formal_flat_names(self) -> tuple[str, ...]:
-        """Return all 47 formal flat names in catalog order."""
+        """Return all formal flat names in catalog order."""
         return tuple(self._flat_children)
 
     def handles_flat(self, name: str) -> bool:

--- a/doris_mcp_server/tools/domain_manifest.py
+++ b/doris_mcp_server/tools/domain_manifest.py
@@ -679,14 +679,37 @@ def _render_child(
         name=child.name,
         title=child.title,
         description=description,
-        input_schema=child.input_schema,
-        output_schema=child.output_schema,
+        input_schema=_compact_manifest_input_schema(child.input_schema),
+        output_schema={"type": "object"},
         version_support=ManifestVersionSupport.from_contract(
             child.support_contract
         ),
         availability=availability,
         annotations=child.annotations,
     )
+
+
+def _compact_manifest_input_schema(value: Any) -> Any:
+    """Expose the call signature while keeping full validation server-side."""
+    if isinstance(value, Mapping):
+        return {
+            str(key): _compact_manifest_input_schema(item)
+            for key, item in value.items()
+            if key
+            not in {
+                "description",
+                "examples",
+                "maxItems",
+                "maxLength",
+                "minItems",
+                "pattern",
+                "title",
+                "uniqueItems",
+            }
+        }
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+        return [_compact_manifest_input_schema(item) for item in value]
+    return value
 
 
 def _dynamic_description(

--- a/doris_mcp_server/tools/domain_models.py
+++ b/doris_mcp_server/tools/domain_models.py
@@ -362,7 +362,10 @@ class DomainDefinition(ContractModel):
     title: NonEmptyText
     description: NonEmptyText
     annotations: ToolContractAnnotations
-    children: Annotated[tuple[ChildToolDefinition, ...], Field(min_length=1)]
+    children: Annotated[
+        tuple[ChildToolDefinition, ...],
+        Field(min_length=1, max_length=12),
+    ]
     enablement_policy: BindingName
     discovery_policy: BindingName
     max_manifest_bytes: Annotated[

--- a/doris_mcp_server/tools/doris_feature_matrix.py
+++ b/doris_mcp_server/tools/doris_feature_matrix.py
@@ -39,11 +39,13 @@ from .domain_models import (
 )
 from .doris_version import DorisVersion, parse_doris_version_comment
 
-PROJECT_MINIMUM_DORIS_VERSION = "3.0.0"
+PROJECT_MINIMUM_DORIS_VERSION = "2.0.0"
 PROJECT_SUPPORTED_RANGE = f">={PROJECT_MINIMUM_DORIS_VERSION}"
-SOURCE_VERIFIED_ON = date(2026, 7, 31)
+SOURCE_VERIFIED_ON = date(2026, 8, 1)
 
 CERTIFICATION_TARGET_VERSIONS = (
+    "2.0.15",
+    "2.1.11",
     "3.0.3",
     "3.1.4",
     "4.0.5",
@@ -341,8 +343,21 @@ EXPECTED_DOMAIN_CHILDREN: Mapping[str, tuple[str, ...]] = MappingProxyType(
             "get_semantic_model_summary",
             "get_semantic_context",
             "get_semantic_mapping_status",
+            "list_metricflow_models",
+            "get_metricflow_status",
+            "list_metricflow_metrics",
+            "get_metricflow_group_bys",
+            "list_metricflow_saved_queries",
+            "get_metricflow_dimension_values",
+            "compile_metricflow_query",
+            "execute_metricflow_query",
         ),
     }
+)
+
+EXPECTED_TOP_LEVEL_DOMAIN_COUNT = len(EXPECTED_DOMAIN_CHILDREN)
+EXPECTED_FORMAL_CHILD_COUNT = sum(
+    len(children) for children in EXPECTED_DOMAIN_CHILDREN.values()
 )
 
 
@@ -358,8 +373,16 @@ class PatchCertificationCase(ContractModel):
 
     @model_validator(mode="after")
     def _validate_case(self) -> Self:
-        expected_tools = 8 if self.exposure_mode == "hierarchical" else 47
-        expected_manifests = 8 if self.exposure_mode == "hierarchical" else 0
+        expected_tools = (
+            EXPECTED_TOP_LEVEL_DOMAIN_COUNT
+            if self.exposure_mode == "hierarchical"
+            else EXPECTED_FORMAL_CHILD_COUNT
+        )
+        expected_manifests = (
+            EXPECTED_TOP_LEVEL_DOMAIN_COUNT
+            if self.exposure_mode == "hierarchical"
+            else 0
+        )
         if self.listed_tool_count != expected_tools:
             raise ValueError(
                 f"{self.exposure_mode} certification requires "
@@ -396,7 +419,13 @@ class PatchCertificationEvidence(ContractModel):
         tuple[Identifier, ...],
         Field(min_length=8, max_length=8),
     ]
-    child_contract_count: Annotated[int, Field(ge=47, le=47)]
+    child_contract_count: Annotated[
+        int,
+        Field(
+            ge=EXPECTED_FORMAL_CHILD_COUNT,
+            le=EXPECTED_FORMAL_CHILD_COUNT,
+        ),
+    ]
     evidence_sha256: Annotated[
         str,
         StringConstraints(
@@ -696,7 +725,7 @@ class DorisFeatureMatrix(ContractModel):
         }
         if actual != expected:
             raise ValueError(
-                "feature matrix must contain the exact ordered 8-domain/47-child "
+                "feature matrix must contain the exact ordered 8-domain/55-child "
                 "contract"
             )
         return self
@@ -988,6 +1017,69 @@ def _source(
 
 FEATURE_SOURCES = (
     _source(
+        "DORIS_DOCS_2_0",
+        FeatureSourceKind.DOCUMENTATION,
+        "Apache Doris 2.0 Documentation",
+        "https://doris.apache.org/docs/2.0/",
+        ">=2.0.0,<2.1.0",
+    ),
+    _source(
+        "DORIS_DOCS_2_1",
+        FeatureSourceKind.DOCUMENTATION,
+        "Apache Doris 2.1 Documentation",
+        "https://doris.apache.org/docs/2.1/",
+        ">=2.1.0,<3.0.0",
+    ),
+    _source(
+        "DORIS_RELEASE_2_0_0",
+        FeatureSourceKind.RELEASE_NOTE,
+        "Apache Doris 2.0.0 Release Notes",
+        "https://doris.apache.org/docs/3.0/releasenotes/v2.0/release-2.0.0",
+        ">=2.0.0,<2.1.0",
+    ),
+    _source(
+        "DORIS_RELEASE_2_1_0",
+        FeatureSourceKind.RELEASE_NOTE,
+        "Apache Doris 2.1.0 Release Notes",
+        "https://doris.apache.org/docs/3.x/releasenotes/v2.1/release-2.1.0/",
+        ">=2.1.0,<3.0.0",
+    ),
+    _source(
+        "DORIS_RELEASE_2_1_5",
+        FeatureSourceKind.RELEASE_NOTE,
+        "Apache Doris 2.1.5 Release Notes",
+        "https://doris.apache.org/docs/3.x/releasenotes/v2.1/release-2.1.5/",
+        ">=2.1.5,<3.0.0",
+    ),
+    _source(
+        "DORIS_RELEASE_2_1_8",
+        FeatureSourceKind.RELEASE_NOTE,
+        "Apache Doris 2.1.8 Release Notes",
+        "https://doris.apache.org/docs/3.x/releasenotes/v2.1/release-2.1.8/",
+        ">=2.1.8,<3.0.0",
+    ),
+    _source(
+        "DORIS_RELEASE_2_0_15",
+        FeatureSourceKind.RELEASE_NOTE,
+        "Apache Doris 2.0.15 Release Notes",
+        "https://doris.apache.org/docs/2.0/releasenotes/v2.0/release-2.0.15",
+        "==2.0.15",
+    ),
+    _source(
+        "DORIS_RELEASE_2_1_11",
+        FeatureSourceKind.RELEASE_NOTE,
+        "Apache Doris 2.1.11 Release Notes",
+        "https://doris.apache.org/releases/v2.1/release-2.1.11/",
+        "==2.1.11",
+    ),
+    _source(
+        "DORIS_ARROW_FLIGHT_SQL_GUIDE",
+        FeatureSourceKind.DOCUMENTATION,
+        "Apache Doris Arrow Flight SQL Guide",
+        ("https://doris.apache.org/docs/2.1/db-connect/arrow-flight-sql-connect/"),
+        ">=2.1.0",
+    ),
+    _source(
         "DORIS_DOCS_3X",
         FeatureSourceKind.DOCUMENTATION,
         "Apache Doris 3.x Documentation",
@@ -1000,6 +1092,20 @@ FEATURE_SOURCES = (
         "Apache Doris 4.x Documentation",
         "https://doris.apache.org/docs/4.x/",
         ">=4.0.0",
+    ),
+    _source(
+        "DORIS_RELEASE_3_0_0",
+        FeatureSourceKind.RELEASE_NOTE,
+        "Apache Doris 3.0.0 Release Notes",
+        "https://doris.apache.org/docs/3.x/releasenotes/v3.0/release-3.0.0/",
+        ">=3.0.0,<3.1.0",
+    ),
+    _source(
+        "DORIS_RELEASE_3_1_0",
+        FeatureSourceKind.RELEASE_NOTE,
+        "Apache Doris 3.1.0 Release Notes",
+        "https://doris.apache.org/docs/4.x/releasenotes/v3.1/release-3.1.0/",
+        ">=3.1.0,<4.0.0",
     ),
     _source(
         "DORIS_RELEASE_3_0_3",
@@ -1120,6 +1226,20 @@ FEATURE_SOURCES = (
         ),
         PROJECT_SUPPORTED_RANGE,
     ),
+    _source(
+        "METRICFLOW_COMMANDS",
+        FeatureSourceKind.PROVIDER_SPECIFICATION,
+        "MetricFlow Command and Consumer Operations",
+        "https://docs.getdbt.com/docs/build/metricflow-commands",
+        PROJECT_SUPPORTED_RANGE,
+    ),
+    _source(
+        "METRICFLOW_ENGINE",
+        FeatureSourceKind.PROVIDER_SPECIFICATION,
+        "MetricFlow Engine",
+        "https://github.com/dbt-labs/metricflow",
+        PROJECT_SUPPORTED_RANGE,
+    ),
 )
 
 
@@ -1136,7 +1256,12 @@ def _variant(
     probes: tuple[str, ...],
     evidence_quality: str = "native",
     callable_when_degraded: bool = False,
-    sources: tuple[str, ...] = ("DORIS_DOCS_3X", "DORIS_DOCS_4X"),
+    sources: tuple[str, ...] = (
+        "DORIS_DOCS_2_0",
+        "DORIS_DOCS_2_1",
+        "DORIS_DOCS_3X",
+        "DORIS_DOCS_4X",
+    ),
 ) -> CapabilityVariant:
     return CapabilityVariant(
         name=name,
@@ -1294,10 +1419,22 @@ FEATURE_DEFINITIONS = (
         P,
         _variant(
             "adbc_flight_sql",
+            ranges=(">=2.1.0",),
             endpoints=("flight_sql",),
             providers=("adbc_provider",),
-            probes=("adbc_driver_ready", "flight_sql_reachable"),
-            sources=("ARROW_ADBC_FLIGHT_SQL",),
+            probes=(
+                "adbc_driver_ready",
+                "flight_sql_reachable",
+                "adbc_release_maturity",
+            ),
+            callable_when_degraded=True,
+            sources=(
+                "DORIS_RELEASE_2_1_0",
+                "DORIS_RELEASE_2_1_5",
+                "DORIS_RELEASE_2_1_8",
+                "DORIS_ARROW_FLIGHT_SQL_GUIDE",
+                "ARROW_ADBC_FLIGHT_SQL",
+            ),
         ),
     ),
     _feature(
@@ -1306,14 +1443,23 @@ FEATURE_DEFINITIONS = (
         P,
         _variant(
             "adbc_read_only",
+            ranges=(">=2.1.0",),
             endpoints=("flight_sql",),
             providers=("adbc_provider",),
             probes=(
                 "adbc_driver_ready",
                 "flight_sql_reachable",
+                "adbc_release_maturity",
                 "read_only_sql_guard_ready",
             ),
-            sources=("ARROW_ADBC_FLIGHT_SQL",),
+            callable_when_degraded=True,
+            sources=(
+                "DORIS_RELEASE_2_1_0",
+                "DORIS_RELEASE_2_1_5",
+                "DORIS_RELEASE_2_1_8",
+                "DORIS_ARROW_FLIGHT_SQL_GUIDE",
+                "ARROW_ADBC_FLIGHT_SQL",
+            ),
         ),
     ),
     _feature(
@@ -1642,7 +1788,7 @@ FEATURE_DEFINITIONS = (
         F,
         _variant(
             "audit_sql_inference_primary",
-            ranges=(">=3.0.0,<4.0.6",),
+            ranges=(">=2.0.0,<4.0.6",),
             providers=("audit_log_provider",),
             probes=("audit_log_readable",),
             evidence_quality="inferred",
@@ -1779,7 +1925,9 @@ FEATURE_DEFINITIONS = (
         ),
         _variant(
             "variant_type",
+            ranges=(">=2.1.0",),
             probes=("variant_column_type_readable",),
+            sources=("DORIS_RELEASE_2_1_0",),
         ),
     ),
     _feature(
@@ -1832,6 +1980,136 @@ FEATURE_DEFINITIONS = (
             sources=("APACHE_OSSIE_CORE_SPEC", "DORIS_DOCS_4X"),
         ),
     ),
+    _feature(
+        "doris_semantic",
+        "list_metricflow_models",
+        P,
+        _variant(
+            "metricflow_model_registry",
+            providers=("metricflow_provider",),
+            probes=("metricflow_provider_protocol_ready",),
+            callable_when_degraded=True,
+            sources=("METRICFLOW_COMMANDS", "METRICFLOW_ENGINE"),
+        ),
+    ),
+    _feature(
+        "doris_semantic",
+        "get_metricflow_status",
+        P,
+        _variant(
+            "metricflow_model_status",
+            providers=("metricflow_provider",),
+            probes=(
+                "metricflow_provider_protocol_ready",
+                "explicit_metricflow_model_ref_valid",
+            ),
+            callable_when_degraded=True,
+            sources=("METRICFLOW_COMMANDS", "METRICFLOW_ENGINE"),
+        ),
+    ),
+    _feature(
+        "doris_semantic",
+        "list_metricflow_metrics",
+        P,
+        _variant(
+            "metricflow_metric_registry",
+            providers=("metricflow_provider",),
+            probes=(
+                "metricflow_provider_protocol_ready",
+                "explicit_metricflow_model_ref_valid",
+                "metricflow_model_metadata_readable",
+            ),
+            callable_when_degraded=True,
+            sources=("METRICFLOW_COMMANDS", "METRICFLOW_ENGINE"),
+        ),
+    ),
+    _feature(
+        "doris_semantic",
+        "get_metricflow_group_bys",
+        P,
+        _variant(
+            "metricflow_group_by_registry",
+            providers=("metricflow_provider",),
+            probes=(
+                "metricflow_provider_protocol_ready",
+                "explicit_metricflow_model_ref_valid",
+                "metricflow_model_metadata_readable",
+            ),
+            callable_when_degraded=True,
+            sources=("METRICFLOW_COMMANDS", "METRICFLOW_ENGINE"),
+        ),
+    ),
+    _feature(
+        "doris_semantic",
+        "list_metricflow_saved_queries",
+        P,
+        _variant(
+            "metricflow_saved_query_registry",
+            providers=("metricflow_provider",),
+            probes=(
+                "metricflow_provider_protocol_ready",
+                "explicit_metricflow_model_ref_valid",
+                "metricflow_model_metadata_readable",
+            ),
+            callable_when_degraded=True,
+            sources=("METRICFLOW_COMMANDS", "METRICFLOW_ENGINE"),
+        ),
+    ),
+    _feature(
+        "doris_semantic",
+        "get_metricflow_dimension_values",
+        P,
+        _variant(
+            "metricflow_dimension_value_query",
+            providers=("metricflow_provider",),
+            probes=(
+                "metricflow_provider_protocol_ready",
+                "explicit_metricflow_model_ref_valid",
+                "metricflow_compile_ready",
+                "metricflow_doris_dialect_ready",
+                "read_only_sql_guard_ready",
+            ),
+            callable_when_degraded=True,
+            sources=("METRICFLOW_COMMANDS", "METRICFLOW_ENGINE"),
+        ),
+    ),
+    _feature(
+        "doris_semantic",
+        "compile_metricflow_query",
+        P,
+        _variant(
+            "metricflow_doris_compile",
+            providers=("metricflow_provider",),
+            probes=(
+                "metricflow_provider_protocol_ready",
+                "explicit_metricflow_model_ref_valid",
+                "metricflow_compile_ready",
+                "metricflow_doris_dialect_ready",
+                "read_only_sql_guard_ready",
+            ),
+            callable_when_degraded=True,
+            sources=("METRICFLOW_COMMANDS", "METRICFLOW_ENGINE"),
+        ),
+    ),
+    _feature(
+        "doris_semantic",
+        "execute_metricflow_query",
+        P,
+        _variant(
+            "metricflow_compile_mcp_execute",
+            providers=("metricflow_provider",),
+            probes=(
+                "metricflow_provider_protocol_ready",
+                "explicit_metricflow_model_ref_valid",
+                "metricflow_compile_ready",
+                "metricflow_doris_dialect_ready",
+                "read_only_sql_guard_ready",
+                "query_execution_readable",
+            ),
+            callable_when_degraded=True,
+            sources=("METRICFLOW_COMMANDS", "METRICFLOW_ENGINE"),
+        ),
+    ),
 )
 
 # Every record below is backed by a sanitized local evidence artifact whose
@@ -1861,7 +2139,7 @@ PATCH_CERTIFICATION_EVIDENCE: tuple[PatchCertificationEvidence, ...] = (
             PatchCertificationCase(
                 transport="stdio",
                 exposure_mode="flat",
-                listed_tool_count=47,
+                listed_tool_count=EXPECTED_FORMAL_CHILD_COUNT,
                 domain_manifest_count=0,
                 read_only_query_passed=True,
                 write_operations_executed=0,
@@ -1877,17 +2155,17 @@ PATCH_CERTIFICATION_EVIDENCE: tuple[PatchCertificationEvidence, ...] = (
             PatchCertificationCase(
                 transport="streamable_http",
                 exposure_mode="flat",
-                listed_tool_count=47,
+                listed_tool_count=EXPECTED_FORMAL_CHILD_COUNT,
                 domain_manifest_count=0,
                 read_only_query_passed=True,
                 write_operations_executed=0,
             ),
         ),
         domain_names=tuple(EXPECTED_DOMAIN_CHILDREN),
-        child_contract_count=47,
+        child_contract_count=EXPECTED_FORMAL_CHILD_COUNT,
         evidence_sha256=(
-            "2ac431322d6b550bd8449ca80312105f4"
-            "cc9cfec57f9b89362c088a2f97d4e9a"
+            "a8d63aa4b5070489e362cfbf57e793c9"
+            "698f5d583c9cae19861eb73bca5c7a76"
         ),
         verified_on=SOURCE_VERIFIED_ON,
     ),
@@ -1917,7 +2195,9 @@ __all__ = [
     "CERTIFIED_DORIS_VERSIONS",
     "DORIS_FEATURE_MATRIX",
     "DORIS_PATCH_CERTIFICATION_MATRIX",
+    "EXPECTED_FORMAL_CHILD_COUNT",
     "EXPECTED_DOMAIN_CHILDREN",
+    "EXPECTED_TOP_LEVEL_DOMAIN_COUNT",
     "FEATURE_DEFINITIONS",
     "FEATURE_SOURCES",
     "PATCH_CERTIFICATION_EVIDENCE",

--- a/doris_mcp_server/tools/query_handlers.py
+++ b/doris_mcp_server/tools/query_handlers.py
@@ -148,6 +148,7 @@ class QueryToolHandlersMixin:
         if timeout_ms is None and arguments.get("timeout") is not None:
             timeout_ms = int(arguments["timeout"]) * 1000
         return await self.query_runtime.execute_adbc_query(
+            explicit_adbc=arguments.get("explicit_adbc") is True,
             sql=sql,
             max_rows=cast(int | None, arguments.get("max_rows")),
             timeout_ms=cast(int | None, timeout_ms),
@@ -164,8 +165,9 @@ class QueryToolHandlersMixin:
         self: _QueryHandlerOwner,
         arguments: dict[str, Any],
     ) -> dict[str, Any]:
-        del arguments
-        return await self.query_runtime.get_adbc_connection_info()
+        return await self.query_runtime.get_adbc_connection_info(
+            explicit_adbc=arguments.get("explicit_adbc") is True,
+        )
 
     async def _formal_doris_query_diagnose_query_performance_tool(
         self: _QueryHandlerOwner,

--- a/doris_mcp_server/tools/semantic_handlers.py
+++ b/doris_mcp_server/tools/semantic_handlers.py
@@ -15,19 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Formal Semantic-domain handlers backed by the Ossie adapter runtime."""
+"""Formal Semantic-domain handlers backed by Ossie and MetricFlow runtimes."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any, Protocol, cast
 
+from ..semantic.metricflow import MetricFlowSemanticRuntime
 from ..semantic.runtime import DorisSemanticRuntime
 from ..utils.db import DorisConnectionManager
+from ..utils.query_runtime import DorisQueryRuntime
 
 
 class _SemanticHandlerOwner(Protocol):
     semantic_runtime: DorisSemanticRuntime
+    metricflow_runtime: MetricFlowSemanticRuntime
 
 
 class SemanticToolHandlersMixin:
@@ -36,8 +39,14 @@ class SemanticToolHandlersMixin:
     def _initialize_semantic_handlers(
         self: _SemanticHandlerOwner,
         connection_manager: DorisConnectionManager,
+        query_runtime: DorisQueryRuntime,
     ) -> None:
         self.semantic_runtime = DorisSemanticRuntime(connection_manager)
+        config = getattr(connection_manager, "config", None)
+        self.metricflow_runtime = MetricFlowSemanticRuntime.from_config(
+            query_runtime,
+            getattr(config, "semantic", None),
+        )
 
     async def _formal_doris_semantic_list_semantic_models_tool(
         self: _SemanticHandlerOwner,
@@ -74,6 +83,85 @@ class SemanticToolHandlersMixin:
         return await self.semantic_runtime.get_semantic_mapping_status(
             model_ref=cast(str, arguments.get("model_ref")),
             datasource=cast(str | None, arguments.get("datasource")),
+        )
+
+    async def _formal_doris_semantic_list_metricflow_models_tool(
+        self: _SemanticHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        del arguments
+        return await self.metricflow_runtime.list_models()
+
+    async def _formal_doris_semantic_get_metricflow_status_tool(
+        self: _SemanticHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.metricflow_runtime.get_status(
+            model_ref=cast(str, arguments.get("model_ref")),
+        )
+
+    async def _formal_doris_semantic_list_metricflow_metrics_tool(
+        self: _SemanticHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.metricflow_runtime.list_metrics(
+            model_ref=cast(str, arguments.get("model_ref")),
+            search=cast(str | None, arguments.get("search")),
+            include_dimensions=bool(arguments.get("include_dimensions", True)),
+            limit=cast(int | None, arguments.get("limit")),
+        )
+
+    async def _formal_doris_semantic_get_metricflow_group_bys_tool(
+        self: _SemanticHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.metricflow_runtime.get_group_bys(
+            model_ref=cast(str, arguments.get("model_ref")),
+            metrics=cast(list[str], arguments.get("metrics")),
+        )
+
+    async def _formal_doris_semantic_list_metricflow_saved_queries_tool(
+        self: _SemanticHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.metricflow_runtime.list_saved_queries(
+            model_ref=cast(str, arguments.get("model_ref")),
+            search=cast(str | None, arguments.get("search")),
+            limit=cast(int | None, arguments.get("limit")),
+        )
+
+    async def _formal_doris_semantic_get_metricflow_dimension_values_tool(
+        self: _SemanticHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.metricflow_runtime.get_dimension_values(
+            model_ref=cast(str, arguments.get("model_ref")),
+            metrics=cast(list[str], arguments.get("metrics")),
+            dimension=cast(str, arguments.get("dimension")),
+            start_time=cast(str | None, arguments.get("start_time")),
+            end_time=cast(str | None, arguments.get("end_time")),
+            limit=cast(int | None, arguments.get("limit")),
+            timeout_ms=cast(int | None, arguments.get("timeout_ms")),
+        )
+
+    async def _formal_doris_semantic_compile_metricflow_query_tool(
+        self: _SemanticHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.metricflow_runtime.compile_query(
+            model_ref=cast(str, arguments.get("model_ref")),
+            request=cast(Mapping[str, Any], arguments.get("request")),
+        )
+
+    async def _formal_doris_semantic_execute_metricflow_query_tool(
+        self: _SemanticHandlerOwner,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        return await self.metricflow_runtime.execute_query(
+            model_ref=cast(str, arguments.get("model_ref")),
+            request=cast(Mapping[str, Any], arguments.get("request")),
+            max_rows=cast(int | None, arguments.get("max_rows")),
+            timeout_ms=cast(int | None, arguments.get("timeout_ms")),
         )
 
 

--- a/doris_mcp_server/tools/tools_manager.py
+++ b/doris_mcp_server/tools/tools_manager.py
@@ -134,7 +134,10 @@ class DorisToolsManager(
         )
         self._initialize_governance_handlers(connection_manager)
         self._initialize_lakehouse_handlers(connection_manager)
-        self._initialize_semantic_handlers(connection_manager)
+        self._initialize_semantic_handlers(
+            connection_manager,
+            self.query_runtime,
+        )
         self._capability_registry: CapabilityRegistry | None = None
         if domain_availability_provider is None:
             bound_handlers = BoundHandlerAvailabilityProvider(self)

--- a/doris_mcp_server/utils/config.py
+++ b/doris_mcp_server/utils/config.py
@@ -235,6 +235,25 @@ def _env_json_string_list_map(
     }
 
 
+def _env_json_string_list(name: str, default: list[str]) -> list[str]:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise AuthConfigError(f"{name} must be a valid JSON array") from exc
+    if (
+        not isinstance(parsed, list)
+        or not parsed
+        or any(not isinstance(item, str) or not item.strip() for item in parsed)
+    ):
+        raise AuthConfigError(
+            f"{name} must be a non-empty JSON array of non-empty strings"
+        )
+    return [item.strip() for item in parsed]
+
+
 def _coerce_csv_config(value: Any) -> list[str]:
     if value is None:
         return []
@@ -809,7 +828,7 @@ class ADBCConfig:
     connection_timeout: int = 30
 
     # Whether to enable ADBC tools
-    enabled: bool = True
+    enabled: bool = False
 
 
 @dataclass
@@ -915,6 +934,11 @@ class SemanticConfig:
     context_hard_max_bytes: int = 64 * 1024
     oauth_tools_enabled: bool = False
     oauth_resources_enabled: bool = False
+    metricflow_enabled: bool = False
+    metricflow_provider_command: list[str] = field(default_factory=list)
+    metricflow_project_directory: str = ""
+    metricflow_timeout_seconds: int = 30
+    metricflow_max_output_bytes: int = 2 * 1024 * 1024
 
 
 @dataclass
@@ -1749,6 +1773,30 @@ class DorisConfig:
                 ).lower()
                 == "true"
             )
+        if "METRICFLOW_ENABLED" in os.environ:
+            config.semantic.metricflow_enabled = (
+                os.getenv("METRICFLOW_ENABLED", "false").lower() == "true"
+            )
+        if "METRICFLOW_PROVIDER_COMMAND_JSON" in os.environ:
+            config.semantic.metricflow_provider_command = _env_json_string_list(
+                "METRICFLOW_PROVIDER_COMMAND_JSON",
+                config.semantic.metricflow_provider_command,
+            )
+        if "METRICFLOW_PROJECT_DIRECTORY" in os.environ:
+            config.semantic.metricflow_project_directory = os.getenv(
+                "METRICFLOW_PROJECT_DIRECTORY",
+                "",
+            ).strip()
+        if "METRICFLOW_TIMEOUT_SECONDS" in os.environ:
+            config.semantic.metricflow_timeout_seconds = _env_int(
+                "METRICFLOW_TIMEOUT_SECONDS",
+                config.semantic.metricflow_timeout_seconds,
+            )
+        if "METRICFLOW_MAX_OUTPUT_BYTES" in os.environ:
+            config.semantic.metricflow_max_output_bytes = _env_int(
+                "METRICFLOW_MAX_OUTPUT_BYTES",
+                config.semantic.metricflow_max_output_bytes,
+            )
         if "MCP_STATE_HANDLE_SECRET" in os.environ:
             config.mcp_state_handle_secret = os.getenv(
                 "MCP_STATE_HANDLE_SECRET",
@@ -1965,6 +2013,19 @@ class DorisConfig:
                 "oauth_tools_enabled": self.semantic.oauth_tools_enabled,
                 "oauth_resources_enabled": (
                     self.semantic.oauth_resources_enabled
+                ),
+                "metricflow_enabled": self.semantic.metricflow_enabled,
+                "metricflow_provider_configured": bool(
+                    self.semantic.metricflow_provider_command
+                ),
+                "metricflow_project_directory": (
+                    self.semantic.metricflow_project_directory
+                ),
+                "metricflow_timeout_seconds": (
+                    self.semantic.metricflow_timeout_seconds
+                ),
+                "metricflow_max_output_bytes": (
+                    self.semantic.metricflow_max_output_bytes
                 ),
             },
             "database": {
@@ -2330,6 +2391,31 @@ class DorisConfig:
             errors.append(
                 "Ossie context byte limit must not exceed the hard byte limit"
             )
+        if self.semantic.metricflow_enabled:
+            command = self.semantic.metricflow_provider_command
+            if (
+                not isinstance(command, list)
+                or not command
+                or any(
+                    not isinstance(part, str) or not part.strip() for part in command
+                )
+            ):
+                errors.append("Enabled MetricFlow support requires a provider command")
+            elif not Path(command[0]).is_absolute():
+                errors.append(
+                    "MetricFlow provider executable must use an absolute path"
+                )
+        if (
+            self.semantic.metricflow_project_directory
+            and not Path(self.semantic.metricflow_project_directory).is_absolute()
+        ):
+            errors.append("MetricFlow project directory must use an absolute path")
+        if not 1 <= self.semantic.metricflow_timeout_seconds <= 120:
+            errors.append("MetricFlow timeout must be in the range 1-120 seconds")
+        if not 1024 <= self.semantic.metricflow_max_output_bytes <= 8 * 1024 * 1024:
+            errors.append(
+                "MetricFlow output byte limit must be in the range 1024-8388608"
+            )
 
         raw_tool_providers: Any = self.mcp_tool_providers
         if not isinstance(raw_tool_providers, list):
@@ -2529,6 +2615,10 @@ class DorisConfig:
                 "oauth_tools_enabled": self.semantic.oauth_tools_enabled,
                 "oauth_resources_enabled": (
                     self.semantic.oauth_resources_enabled
+                ),
+                "metricflow_enabled": self.semantic.metricflow_enabled,
+                "metricflow_provider_configured": bool(
+                    self.semantic.metricflow_provider_command
                 ),
             },
         }

--- a/doris_mcp_server/utils/query_runtime.py
+++ b/doris_mcp_server/utils/query_runtime.py
@@ -604,8 +604,13 @@ class DorisQueryRuntime:
             },
         )
 
-    async def get_adbc_connection_info(self) -> dict[str, Any]:
+    async def get_adbc_connection_info(
+        self,
+        *,
+        explicit_adbc: bool,
+    ) -> dict[str, Any]:
         """Return a secret-free summary of the optional ADBC provider."""
+        _require_explicit_adbc_intent(explicit_adbc)
         raw = await self._adbc_query_tools.get_adbc_connection_info()
         if not isinstance(raw, Mapping):
             raise QueryRuntimeFailure(
@@ -654,12 +659,14 @@ class DorisQueryRuntime:
     async def execute_adbc_query(
         self,
         *,
+        explicit_adbc: bool,
         sql: str,
         max_rows: int | None = None,
         timeout_ms: int | None = None,
         result_format: str | None = None,
     ) -> dict[str, Any]:
         """Execute one strict read-only query through Arrow Flight SQL."""
+        _require_explicit_adbc_intent(explicit_adbc)
         statement = ReadOnlySQLGuard.validate(sql)
         ReadOnlySQLGuard.validate_parameters(statement.sql, None)
         if result_format not in {None, "arrow", "pandas", "dict"}:
@@ -1721,6 +1728,16 @@ def _profile_http_failure(status: int) -> QueryRuntimeFailure:
         status_code=503,
         retryable=True,
     )
+
+
+def _require_explicit_adbc_intent(explicit_adbc: bool) -> None:
+    if explicit_adbc is not True:
+        raise QueryRuntimeFailure(
+            "ADBC requires an explicit end-user request for ADBC or Arrow "
+            "Flight SQL; use doris_query.execute_query for normal queries.",
+            reason_code="ADBC_EXPLICIT_USER_INTENT_REQUIRED",
+            status_code=400,
+        )
 
 
 def _classify_adbc_failure(raw: Any) -> QueryRuntimeFailure:

--- a/test/integration/test_real_doris_transports.py
+++ b/test/integration/test_real_doris_transports.py
@@ -1382,7 +1382,7 @@ async def test_real_doris_flat_tool_list_stays_bounded_and_callable(
             tool.name: tool
             for tool in (await client.list_tools(cache_mode="bypass")).tools
         }
-        assert len(tools) == 47
+        assert len(tools) == 55
         assert "doris_query_execute_query" in tools
 
         result = await client.call_tool(
@@ -1397,6 +1397,201 @@ async def test_real_doris_flat_tool_list_stays_bounded_and_callable(
         assert "4.0.5-rc01" in json.dumps(
             result.structured_content,
             ensure_ascii=False,
+        )
+
+
+@pytest.mark.parametrize("transport", ["http", "stdio"])
+async def test_real_doris_metricflow_provider_contract_is_guarded_and_live(
+    transport: str,
+    tmp_path: Path,
+) -> None:
+    """Exercise every MetricFlow child and execute compiled SQL on real Doris."""
+    settings = _real_doris_settings()
+    provider_script = tmp_path / "metricflow_provider.py"
+    provider_script.write_text(
+        """
+import json
+import sys
+
+request = json.loads(sys.stdin.read())
+operation = request["operation"]
+arguments = request["arguments"]
+responses = {
+    "list_models": {
+        "items": [{"model_ref": "acceptance/main", "revision": "v1"}],
+    },
+    "get_status": {
+        "model_ref": arguments.get("model_ref"),
+        "valid": True,
+        "dialect": "doris",
+    },
+    "list_metrics": {
+        "items": [{"name": "acceptance_count", "dimensions": ["segment"]}],
+    },
+    "get_group_bys": {
+        "dimensions": ["segment"],
+        "entities": [],
+    },
+    "list_saved_queries": {
+        "items": [{"name": "acceptance_saved_query"}],
+    },
+    "compile_dimension_values": {
+        "sql": "SELECT 'enterprise' AS segment",
+    },
+    "compile_query": {
+        "sql": "SELECT @@version_comment AS doris_version",
+    },
+}
+data = responses.get(operation)
+if data is None:
+    response = {
+        "protocol_version": request["protocol_version"],
+        "request_id": request["request_id"],
+        "ok": False,
+        "error": {"reason_code": "METRICFLOW_OPERATION_UNSUPPORTED"},
+    }
+else:
+    response = {
+        "protocol_version": request["protocol_version"],
+        "request_id": request["request_id"],
+        "ok": True,
+        "data": data,
+    }
+sys.stdout.write(json.dumps(response))
+""".strip(),
+        encoding="utf-8",
+    )
+    environment = _server_environment(
+        settings,
+        user=settings.user,
+        password=settings.password,
+    )
+    environment.update(
+        {
+            "MCP_TOOL_EXPOSURE_MODE": "hierarchical",
+            "METRICFLOW_ENABLED": "true",
+            "METRICFLOW_PROVIDER_COMMAND_JSON": json.dumps(
+                [sys.executable, str(provider_script)]
+            ),
+            "METRICFLOW_PROJECT_DIRECTORY": str(tmp_path),
+        }
+    )
+
+    async with _transport_client(
+        transport,
+        environment,
+        read_timeout_seconds=60,
+    ) as client:
+        manifest = await _discover_domain(client, "doris_semantic")
+        children = {child["name"]: child for child in manifest["children"]}
+        metricflow_children = {
+            name: child
+            for name, child in children.items()
+            if "metricflow" in name
+        }
+        assert len(metricflow_children) == 8
+        assert all(
+            child["availability"]["callable"]
+            for child in metricflow_children.values()
+        )
+        manifest_version = manifest["manifest_version"]
+
+        models = await _call_domain_child(
+            client,
+            domain="doris_semantic",
+            child_tool="list_metricflow_models",
+            arguments={},
+            manifest_version=manifest_version,
+        )
+        assert models["data"]["items"][0]["model_ref"] == "acceptance/main"
+
+        status = await _call_domain_child(
+            client,
+            domain="doris_semantic",
+            child_tool="get_metricflow_status",
+            arguments={"model_ref": "acceptance/main"},
+            manifest_version=manifest_version,
+        )
+        assert status["data"]["dialect"] == "doris"
+
+        metrics = await _call_domain_child(
+            client,
+            domain="doris_semantic",
+            child_tool="list_metricflow_metrics",
+            arguments={
+                "model_ref": "acceptance/main",
+                "include_dimensions": True,
+                "limit": 20,
+            },
+            manifest_version=manifest_version,
+        )
+        assert metrics["data"]["items"][0]["name"] == "acceptance_count"
+
+        group_bys = await _call_domain_child(
+            client,
+            domain="doris_semantic",
+            child_tool="get_metricflow_group_bys",
+            arguments={
+                "model_ref": "acceptance/main",
+                "metrics": ["acceptance_count"],
+            },
+            manifest_version=manifest_version,
+        )
+        assert group_bys["data"]["dimensions"] == ["segment"]
+
+        saved_queries = await _call_domain_child(
+            client,
+            domain="doris_semantic",
+            child_tool="list_metricflow_saved_queries",
+            arguments={"model_ref": "acceptance/main", "limit": 20},
+            manifest_version=manifest_version,
+        )
+        assert saved_queries["data"]["items"][0]["name"] == (
+            "acceptance_saved_query"
+        )
+
+        dimension_values = await _call_domain_child(
+            client,
+            domain="doris_semantic",
+            child_tool="get_metricflow_dimension_values",
+            arguments={
+                "model_ref": "acceptance/main",
+                "metrics": ["acceptance_count"],
+                "dimension": "segment",
+                "limit": 20,
+            },
+            manifest_version=manifest_version,
+        )
+        assert dimension_values["data"]["rows"][0]["segment"] == "enterprise"
+        assert dimension_values["metadata"]["semantic_provider"] == "metricflow"
+
+        compiled = await _call_domain_child(
+            client,
+            domain="doris_semantic",
+            child_tool="compile_metricflow_query",
+            arguments={
+                "model_ref": "acceptance/main",
+                "request": {"metrics": ["acceptance_count"]},
+            },
+            manifest_version=manifest_version,
+        )
+        assert compiled["data"]["sql"].startswith("SELECT")
+
+        executed = await _call_domain_child(
+            client,
+            domain="doris_semantic",
+            child_tool="execute_metricflow_query",
+            arguments={
+                "model_ref": "acceptance/main",
+                "request": {"saved_query": "acceptance_saved_query"},
+                "max_rows": 1,
+            },
+            manifest_version=manifest_version,
+        )
+        assert "4.0.5-rc01" in executed["data"]["rows"][0]["doris_version"]
+        assert executed["metadata"]["semantic_provider"] == "metricflow"
+        assert executed["metadata"]["compile_execution_boundary"] == (
+            "mcp_query_runtime"
         )
 
 

--- a/test/protocol/test_mcp_v2_protocol.py
+++ b/test/protocol/test_mcp_v2_protocol.py
@@ -1404,7 +1404,7 @@ async def test_true_subprocess_stdio_formal_flat_mode_executes_and_recovers():
             tool.name: tool
             for tool in (await modern.list_tools(cache_mode="bypass")).tools
         }
-        assert len(tools) == 47
+        assert len(tools) == 55
         assert "doris_query_execute_query" in tools
         assert not set(EXPECTED_DOMAIN_CHILDREN).intersection(tools)
         assert "exec_query" not in tools

--- a/test/protocol/test_multiworker_config.py
+++ b/test/protocol/test_multiworker_config.py
@@ -14,7 +14,7 @@ from doris_mcp_server.multiworker_app import (
     readiness_check,
     root_info,
 )
-from doris_mcp_server.utils.config import DorisConfig
+from doris_mcp_server.utils.config import AuthConfigError, DorisConfig
 
 
 def test_legacy_http_adapter_is_default_off_and_requires_explicit_env(monkeypatch):
@@ -301,6 +301,14 @@ def test_semantic_runtime_controls_load_serialize_and_validate(
     monkeypatch.setenv("OSSIE_CONTEXT_HARD_MAX_BYTES", "32768")
     monkeypatch.setenv("DORIS_OAUTH_SEMANTIC_TOOLS_ENABLED", "true")
     monkeypatch.setenv("DORIS_OAUTH_SEMANTIC_RESOURCES_ENABLED", "true")
+    monkeypatch.setenv("METRICFLOW_ENABLED", "true")
+    monkeypatch.setenv(
+        "METRICFLOW_PROVIDER_COMMAND_JSON",
+        '["/usr/local/bin/metricflow-provider", "--stdio"]',
+    )
+    monkeypatch.setenv("METRICFLOW_PROJECT_DIRECTORY", "/srv/dbt")
+    monkeypatch.setenv("METRICFLOW_TIMEOUT_SECONDS", "45")
+    monkeypatch.setenv("METRICFLOW_MAX_OUTPUT_BYTES", "1048576")
 
     configured = DorisConfig.from_env()
 
@@ -319,6 +327,11 @@ def test_semantic_runtime_controls_load_serialize_and_validate(
         "context_hard_max_bytes": 32768,
         "oauth_tools_enabled": True,
         "oauth_resources_enabled": True,
+        "metricflow_enabled": True,
+        "metricflow_provider_configured": True,
+        "metricflow_project_directory": "/srv/dbt",
+        "metricflow_timeout_seconds": 45,
+        "metricflow_max_output_bytes": 1048576,
     }
     assert configured.validate() == []
 
@@ -380,6 +393,27 @@ def test_semantic_runtime_controls_load_serialize_and_validate(
         "Enabled Ossie support requires model directory and binding manifest"
         in incomplete.validate()
     )
+    incomplete.semantic.enabled = False
+    incomplete.semantic.metricflow_enabled = True
+    assert (
+        "Enabled MetricFlow support requires a provider command"
+        in incomplete.validate()
+    )
+    incomplete.semantic.metricflow_provider_command = ["metricflow-provider"]
+    assert (
+        "MetricFlow provider executable must use an absolute path"
+        in incomplete.validate()
+    )
+
+
+def test_metricflow_provider_command_rejects_empty_or_invalid_json(monkeypatch):
+    monkeypatch.setenv("METRICFLOW_PROVIDER_COMMAND_JSON", "[]")
+    with pytest.raises(AuthConfigError, match="non-empty JSON array"):
+        DorisConfig.from_env()
+
+    monkeypatch.setenv("METRICFLOW_PROVIDER_COMMAND_JSON", "not-json")
+    with pytest.raises(AuthConfigError, match="valid JSON array"):
+        DorisConfig.from_env()
 
 
 def test_state_handle_secret_and_ttl_are_configurable_without_serializing_secret(
@@ -455,6 +489,14 @@ def test_multiworker_environment_preserves_resolved_parent_config(monkeypatch):
     config.semantic.context_hard_max_bytes = 32768
     config.semantic.oauth_tools_enabled = True
     config.semantic.oauth_resources_enabled = True
+    config.semantic.metricflow_enabled = True
+    config.semantic.metricflow_provider_command = [
+        "/usr/local/bin/metricflow-provider",
+        "--stdio",
+    ]
+    config.semantic.metricflow_project_directory = "/srv/dbt"
+    config.semantic.metricflow_timeout_seconds = 45
+    config.semantic.metricflow_max_output_bytes = 1048576
     config.mcp_state_handle_secret = "parent-shared-state-handle-secret-value"
     config.mcp_state_handle_ttl_seconds = 45
 
@@ -527,6 +569,14 @@ def test_multiworker_environment_preserves_resolved_parent_config(monkeypatch):
     assert child_config.semantic.context_hard_max_bytes == 32768
     assert child_config.semantic.oauth_tools_enabled is True
     assert child_config.semantic.oauth_resources_enabled is True
+    assert child_config.semantic.metricflow_enabled is True
+    assert child_config.semantic.metricflow_provider_command == [
+        "/usr/local/bin/metricflow-provider",
+        "--stdio",
+    ]
+    assert child_config.semantic.metricflow_project_directory == "/srv/dbt"
+    assert child_config.semantic.metricflow_timeout_seconds == 45
+    assert child_config.semantic.metricflow_max_output_bytes == 1048576
     assert (
         child_config.mcp_state_handle_secret
         == "parent-shared-state-handle-secret-value"
@@ -536,6 +586,18 @@ def test_multiworker_environment_preserves_resolved_parent_config(monkeypatch):
     assert child_config.server_version == __version__
     assert child_config.transport == "http"
     assert child_config.workers == 2
+
+
+def test_multiworker_environment_omits_disabled_metricflow_command() -> None:
+    worker_env = _multiworker_environment(
+        DorisConfig(),
+        host="127.0.0.1",
+        port=31133,
+        workers=2,
+    )
+
+    assert worker_env["METRICFLOW_ENABLED"] == "false"
+    assert "METRICFLOW_PROVIDER_COMMAND_JSON" not in worker_env
 
 
 @pytest.mark.asyncio

--- a/test/semantic/test_metricflow_runtime.py
+++ b/test/semantic/test_metricflow_runtime.py
@@ -1,0 +1,306 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""MetricFlow consumer, compile, and guarded Doris execution tests."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from doris_mcp_server.semantic.metricflow import (
+    METRICFLOW_PROVIDER_PROTOCOL,
+    MetricFlowProviderFailure,
+    MetricFlowSemanticRuntime,
+    MetricFlowSidecarProvider,
+)
+from doris_mcp_server.semantic.runtime import SemanticRuntimeFailure
+from doris_mcp_server.utils.config import DorisConfig
+from doris_mcp_server.utils.query_runtime import QueryRuntimeFailure
+
+
+class _Provider:
+    def __init__(self, responses: Mapping[str, Mapping[str, Any]]) -> None:
+        self.responses = responses
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def request(
+        self,
+        operation: str,
+        arguments: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        self.calls.append((operation, dict(arguments)))
+        return self.responses[operation]
+
+
+def _query_runtime() -> Any:
+    return type(
+        "QueryRuntime",
+        (),
+        {
+            "execute_query": AsyncMock(
+                return_value={
+                    "status": "success",
+                    "data": {"columns": [], "rows": [], "truncated": False},
+                    "warnings": [],
+                    "metadata": {"source": "doris_query"},
+                    "evidence": [],
+                }
+            )
+        },
+    )()
+
+
+@pytest.mark.asyncio
+async def test_metricflow_metadata_operations_require_exact_model_refs() -> None:
+    provider = _Provider(
+        {
+            "list_models": {"items": [{"model_ref": "sales/main"}]},
+            "get_status": {"valid": True, "dialect": "doris"},
+            "list_metrics": {"items": [{"name": "revenue"}]},
+            "get_group_bys": {"dimensions": ["metric_time"]},
+            "list_saved_queries": {"items": [{"name": "weekly_sales"}]},
+        }
+    )
+    runtime = MetricFlowSemanticRuntime(
+        _query_runtime(),
+        enabled=True,
+        provider=provider,
+    )
+
+    models = await runtime.list_models()
+    status = await runtime.get_status(model_ref="sales/main")
+    metrics = await runtime.list_metrics(
+        model_ref="sales/main",
+        search="rev",
+        include_dimensions=True,
+        limit=20,
+    )
+    group_bys = await runtime.get_group_bys(
+        model_ref="sales/main",
+        metrics=["revenue"],
+    )
+    saved = await runtime.list_saved_queries(
+        model_ref="sales/main",
+        search=None,
+        limit=20,
+    )
+
+    assert models["data"]["items"] == [{"model_ref": "sales/main"}]
+    assert status["data"]["dialect"] == "doris"
+    assert metrics["data"]["items"] == [{"name": "revenue"}]
+    assert group_bys["data"]["dimensions"] == ["metric_time"]
+    assert saved["data"]["items"] == [{"name": "weekly_sales"}]
+    assert provider.calls[1] == (
+        "get_status",
+        {"model_ref": "sales/main"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_metricflow_compiles_without_executing_doris_sql() -> None:
+    provider = _Provider(
+        {
+            "compile_query": {
+                "sql": "SELECT SUM(amount) AS revenue FROM sales",
+                "columns": ["revenue"],
+            }
+        }
+    )
+    query_runtime = _query_runtime()
+    runtime = MetricFlowSemanticRuntime(
+        query_runtime,
+        enabled=True,
+        provider=provider,
+    )
+
+    result = await runtime.compile_query(
+        model_ref="sales/main",
+        request={"metrics": ["revenue"]},
+    )
+
+    assert result["data"]["sql"].startswith("SELECT")
+    assert provider.calls == [
+        (
+            "compile_query",
+            {
+                "model_ref": "sales/main",
+                "request": {"metrics": ["revenue"]},
+                "dialect": "doris",
+            },
+        )
+    ]
+    query_runtime.execute_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_metricflow_execution_returns_to_guarded_mcp_query_runtime() -> None:
+    provider = _Provider(
+        {"compile_query": {"sql": "SELECT SUM(amount) AS revenue FROM sales"}}
+    )
+    query_runtime = _query_runtime()
+    runtime = MetricFlowSemanticRuntime(
+        query_runtime,
+        enabled=True,
+        provider=provider,
+    )
+
+    result = await runtime.execute_query(
+        model_ref="sales/main",
+        request={
+            "metrics": ["revenue"],
+            "order_by": ["-revenue"],
+        },
+        max_rows=100,
+        timeout_ms=5000,
+    )
+
+    query_runtime.execute_query.assert_awaited_once_with(
+        sql="SELECT SUM(amount) AS revenue FROM sales",
+        max_rows=100,
+        timeout_ms=5000,
+    )
+    assert result["metadata"]["semantic_provider"] == "metricflow"
+    assert result["metadata"]["semantic_model_ref"] == "sales/main"
+    assert result["metadata"]["compile_execution_boundary"] == ("mcp_query_runtime")
+
+
+@pytest.mark.asyncio
+async def test_metricflow_rejects_implicit_models_and_unsafe_compiled_sql() -> None:
+    provider = _Provider({"compile_query": {"sql": "DROP TABLE sales"}})
+    query_runtime = _query_runtime()
+    runtime = MetricFlowSemanticRuntime(
+        query_runtime,
+        enabled=True,
+        provider=provider,
+    )
+
+    with pytest.raises(SemanticRuntimeFailure) as model_error:
+        await runtime.get_status(model_ref="")
+    with pytest.raises(QueryRuntimeFailure) as sql_error:
+        await runtime.execute_query(
+            model_ref="sales/main",
+            request={"metrics": ["revenue"]},
+            max_rows=100,
+            timeout_ms=5000,
+        )
+
+    assert model_error.value.reason_code == "METRICFLOW_MODEL_REF_INVALID"
+    assert sql_error.value.reason_code == "QUERY_READ_ONLY_VIOLATION"
+    query_runtime.execute_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_metricflow_disabled_and_provider_failures_are_sanitized() -> None:
+    disabled = MetricFlowSemanticRuntime(
+        _query_runtime(),
+        enabled=False,
+        provider=None,
+    )
+
+    with pytest.raises(SemanticRuntimeFailure) as disabled_error:
+        await disabled.list_models()
+
+    assert disabled_error.value.reason_code == "METRICFLOW_DISABLED"
+    assert disabled_error.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_metricflow_sidecar_protocol_round_trip(tmp_path: Path) -> None:
+    script = tmp_path / "provider.py"
+    script.write_text(
+        """
+import json
+import sys
+
+request = json.loads(sys.stdin.read())
+response = {
+    "protocol_version": request["protocol_version"],
+    "request_id": request["request_id"],
+    "ok": True,
+    "data": {"items": [{"model_ref": "sales/main"}]},
+}
+sys.stdout.write(json.dumps(response))
+""".strip(),
+        encoding="utf-8",
+    )
+    provider = MetricFlowSidecarProvider(
+        [sys.executable, str(script)],
+        timeout_seconds=5,
+    )
+
+    result = await provider.request("list_models", {})
+
+    assert result == {"items": [{"model_ref": "sales/main"}]}
+
+
+@pytest.mark.asyncio
+async def test_metricflow_sidecar_rejects_protocol_mismatch(tmp_path: Path) -> None:
+    script = tmp_path / "provider.py"
+    script.write_text(
+        """
+import json
+import sys
+
+request = json.loads(sys.stdin.read())
+sys.stdout.write(json.dumps({
+    "protocol_version": "wrong",
+    "request_id": request["request_id"],
+    "ok": True,
+    "data": {},
+}))
+""".strip(),
+        encoding="utf-8",
+    )
+    provider = MetricFlowSidecarProvider(
+        [sys.executable, str(script)],
+        timeout_seconds=5,
+    )
+
+    with pytest.raises(MetricFlowProviderFailure) as error:
+        await provider.request("get_status", {"model_ref": "sales/main"})
+
+    assert error.value.reason_code == "METRICFLOW_PROVIDER_PROTOCOL_MISMATCH"
+    assert METRICFLOW_PROVIDER_PROTOCOL not in str(error.value)
+
+
+def test_metricflow_and_adbc_are_opt_in_advanced_providers() -> None:
+    config = DorisConfig()
+
+    assert config.adbc.enabled is False
+    assert config.semantic.metricflow_enabled is False
+    assert config.semantic.metricflow_provider_command == []
+
+    config.semantic.metricflow_enabled = True
+    assert "Enabled MetricFlow support requires a provider command" in (
+        config.validate()
+    )
+
+
+def test_unstructured_mock_config_does_not_enable_metricflow() -> None:
+    runtime = MetricFlowSemanticRuntime.from_config(
+        _query_runtime(),
+        Mock(),
+    )
+
+    assert runtime._enabled is False
+    assert runtime._provider is None

--- a/test/test_release_artifacts.py
+++ b/test/test_release_artifacts.py
@@ -75,9 +75,9 @@ def test_generated_tool_catalog_matches_the_runtime_source() -> None:
 
     assert catalog == DORIS_DOMAIN_CATALOG.render_markdown()
     assert summary.domain_count == 8
-    assert summary.child_count == 47
+    assert summary.child_count == 55
     assert summary.migrated_flat_tool_count == 25
-    assert len(FORMAL_CHILD_FEATURE_IDS) == 47
+    assert len(FORMAL_CHILD_FEATURE_IDS) == 55
     assert all(f"`{feature_id}`" in catalog for feature_id in FORMAL_CHILD_FEATURE_IDS)
 
 

--- a/test/tools/test_capability_detector.py
+++ b/test/tools/test_capability_detector.py
@@ -541,10 +541,54 @@ async def test_detector_marks_adbc_callable_only_after_live_probes() -> None:
     assert query.probe("adbc_driver_ready").status is CapabilityProbeStatus.SUPPORTED
     assert query.probe("flight_sql_reachable").status is CapabilityProbeStatus.SUPPORTED
     assert query.probe("flight_sql").status is CapabilityProbeStatus.SUPPORTED
+    assert (
+        query.probe("adbc_release_maturity").status is CapabilityProbeStatus.SUPPORTED
+    )
     adbc_tools._import_adbc_modules.assert_awaited_once_with()
     adbc_tools._check_arrow_flight_ports.assert_awaited_once_with(
         connectivity_timeout=1.0
     )
+
+
+@pytest.mark.asyncio
+async def test_detector_marks_early_2_1_adbc_as_degraded() -> None:
+    connection = _ProbeConnection()
+    connection.row_overrides["SELECT @@version_comment;"] = [
+        {"@@version_comment": "Doris version doris-2.1.4-rc03-43f06a5e26"}
+    ]
+    connection.row_overrides["SHOW FRONTENDS"] = [
+        {
+            "Name": "fe-1",
+            "Role": "FOLLOWER",
+            "IsMaster": "true",
+            "Version": "doris-2.1.4-rc03-43f06a5e26",
+        }
+    ]
+    connection.row_overrides["SHOW BACKENDS"] = [
+        {"BackendId": "1", "Version": "doris-2.1.4-rc03-43f06a5e26"}
+    ]
+    manager = _ProbeConnectionManager(connection)
+    manager.config.adbc.enabled = True
+    detector = DorisCapabilityDetector(
+        manager,  # type: ignore[arg-type]
+        adbc_query_tools=SimpleNamespace(
+            _import_adbc_modules=AsyncMock(return_value={"success": True}),
+            _check_arrow_flight_ports=AsyncMock(
+                return_value={"success": True, "be_available_count": 1}
+            ),
+        ),
+    )
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    query = await detector.detect_domain(base, "doris_query", None)
+
+    maturity = query.probe("adbc_release_maturity")
+    assert maturity.status is CapabilityProbeStatus.DEGRADED
+    assert maturity.reason_code == "ADBC_EARLY_2_1_RELEASE"
 
 
 @pytest.mark.asyncio

--- a/test/tools/test_capability_registry.py
+++ b/test/tools/test_capability_registry.py
@@ -659,6 +659,106 @@ def test_ossie_provider_rejects_unstructured_mock_configuration() -> None:
     assert provider.reason_code == "PROVIDER_NOT_CONFIGURED"
 
 
+@pytest.mark.parametrize(
+    ("enabled", "command", "bound", "expected_status"),
+    [
+        (
+            False,
+            ["/usr/bin/metricflow-provider"],
+            True,
+            CapabilityProbeStatus.MISCONFIGURED,
+        ),
+        (True, [], True, CapabilityProbeStatus.MISCONFIGURED),
+        (
+            True,
+            ["/usr/bin/metricflow-provider"],
+            False,
+            CapabilityProbeStatus.MISCONFIGURED,
+        ),
+        (True, ["/usr/bin/metricflow-provider"], True, CapabilityProbeStatus.SUPPORTED),
+    ],
+)
+def test_metricflow_provider_requires_opt_in_command_and_bound_consumer(
+    enabled: bool,
+    command: list[str],
+    bound: bool,
+    expected_status: CapabilityProbeStatus,
+) -> None:
+    handlers = (
+        _BoundHandlers(
+            "doris_semantic.list_metricflow_models",
+            "doris_semantic.execute_metricflow_query",
+        )
+        if bound
+        else _BoundHandlers()
+    )
+    registry = CapabilityProviderRegistry.from_runtime(
+        matrix=DORIS_FEATURE_MATRIX,
+        bound_handlers=handlers,  # type: ignore[arg-type]
+        config=SimpleNamespace(
+            adbc=SimpleNamespace(enabled=False),
+            semantic=SimpleNamespace(
+                metricflow_enabled=enabled,
+                metricflow_provider_command=command,
+            ),
+        ),
+    )
+
+    provider = registry.snapshot().providers["metricflow_provider"]
+
+    assert provider.status is expected_status
+
+
+def test_metricflow_call_time_probes_remain_discoverable_and_callable() -> None:
+    feature_id = "doris_semantic.execute_metricflow_query"
+    evaluator = CapabilityEvaluator(
+        matrix=DORIS_FEATURE_MATRIX,
+        bound_handlers=_BoundHandlers(feature_id),  # type: ignore[arg-type]
+    )
+    providers = CapabilityProviderRegistry(
+        {
+            "metricflow_provider": CapabilityProviderEvidence(
+                provider_id="metricflow_provider",
+                status=CapabilityProbeStatus.SUPPORTED,
+                reason_code="PROVIDER_CONFIGURED",
+            )
+        }
+    ).snapshot()
+    probe_ids = (
+        DORIS_FEATURE_MATRIX.get_feature(
+            "doris_semantic",
+            "execute_metricflow_query",
+        )
+        .support_contract.variants[0]
+        .required_probes
+    )
+    probes = {
+        probe_id: CapabilityProbeEvidence(
+            probe_id=probe_id,
+            status=CapabilityProbeStatus.DEGRADED,
+            reason_code="METRICFLOW_REQUIRES_CALL_TIME_VALIDATION",
+        )
+        for probe_id in probe_ids
+    }
+    domain = DORIS_DOMAIN_CATALOG.resolve_domain("doris_semantic")
+    child = DORIS_DOMAIN_CATALOG.resolve_child(
+        "doris_semantic",
+        "execute_metricflow_query",
+    )
+
+    availability = evaluator.evaluate(
+        snapshot=_snapshot(probes=probes),
+        providers=providers,
+        domain=domain,
+        child=child,
+        auth_context=None,
+    )
+
+    assert availability.status is AvailabilityStatus.DEGRADED
+    assert availability.callable is True
+    assert availability.active_variant == "metricflow_compile_mcp_execute"
+
+
 def test_semantic_availability_keeps_call_time_validation_callable() -> None:
     bound = _BoundHandlers(
         "doris_semantic.list_semantic_models",
@@ -969,6 +1069,7 @@ async def test_provider_down_advances_generation_and_fails_closed() -> None:
                 "adbc_driver_ready",
                 "flight_sql",
                 "flight_sql_reachable",
+                "adbc_release_maturity",
                 "read_only_sql_guard_ready",
             )
         },
@@ -1035,6 +1136,7 @@ async def test_manifest_uses_one_provider_generation_during_refresh() -> None:
                 "adbc_driver_ready",
                 "flight_sql",
                 "flight_sql_reachable",
+                "adbc_release_maturity",
                 "read_only_sql_guard_ready",
             )
         },

--- a/test/tools/test_domain_catalog.py
+++ b/test/tools/test_domain_catalog.py
@@ -98,11 +98,11 @@ def _wire_output(child: ChildToolDefinition) -> dict[str, Any]:
     return cast(dict[str, Any], child.to_wire()["output_schema"])
 
 
-def test_catalog_has_exact_ordered_eight_domain_forty_seven_child_shape() -> None:
+def test_catalog_has_exact_ordered_eight_domain_fifty_five_child_shape() -> None:
     summary = DORIS_DOMAIN_CATALOG.summary()
 
     assert summary.domain_count == 8
-    assert summary.child_count == 47
+    assert summary.child_count == 55
     assert summary.migrated_flat_tool_count == 25
     assert tuple(domain.name for domain in summary.domains) == tuple(
         EXPECTED_DOMAIN_CHILDREN
@@ -118,7 +118,7 @@ def test_catalog_has_exact_ordered_eight_domain_forty_seven_child_shape() -> Non
         4,
         8,
         3,
-        4,
+        12,
     )
 
 
@@ -208,7 +208,11 @@ def test_query_schemas_publish_bounded_execution_limits() -> None:
         ("doris_catalog", "list_tables", {"database"}),
         ("doris_catalog", "get_table_context", {"database", "table"}),
         ("doris_query", "execute_query", {"sql"}),
-        ("doris_query", "execute_adbc_query", {"sql"}),
+        (
+            "doris_query",
+            "execute_adbc_query",
+            {"explicit_adbc", "sql"},
+        ),
         ("doris_pipeline", "monitor_data_freshness", {"database", "table"}),
         (
             "doris_lakehouse",
@@ -247,6 +251,13 @@ def test_semantic_content_children_require_explicit_model_ref() -> None:
         "get_semantic_model_summary",
         "get_semantic_context",
         "get_semantic_mapping_status",
+        "get_metricflow_status",
+        "list_metricflow_metrics",
+        "get_metricflow_group_bys",
+        "list_metricflow_saved_queries",
+        "get_metricflow_dimension_values",
+        "compile_metricflow_query",
+        "execute_metricflow_query",
     ):
         assert "model_ref" in schemas[name]["required"]
         assert "model_ref" in schemas[name]["properties"]
@@ -440,7 +451,7 @@ def test_catalog_markdown_is_deterministic_and_complete() -> None:
 
     assert first == second
     assert first.startswith("# Doris MCP Hierarchical Domain Catalog")
-    assert first.count("| `doris_") >= 47 + 8
+    assert first.count("| `doris_") >= 55 + 8
     assert "`doris_query.execute_adbc_query`" in first
     assert "`get_table_schema`" in first
     assert "`doris_catalog.get_table_context`" in first

--- a/test/tools/test_domain_dispatcher.py
+++ b/test/tools/test_domain_dispatcher.py
@@ -129,12 +129,12 @@ def test_exposure_mode_and_flat_name_are_exact() -> None:
         ToolExposureMode.parse("legacy")
 
 
-def test_dispatcher_registers_exactly_47_formal_flat_names() -> None:
+def test_dispatcher_registers_exactly_55_formal_flat_names() -> None:
     manager = _manager()
     names = manager.domain_dispatcher.formal_flat_names
 
-    assert len(names) == 47
-    assert len(set(names)) == 47
+    assert len(names) == 55
+    assert len(set(names)) == 55
     assert "doris_query_execute_query" in names
     assert not set(CURRENT_FLAT_TOOL_NAMES).intersection(names)
     assert manager.domain_dispatcher.handles_flat("doris_query_execute_query")
@@ -177,12 +177,12 @@ def test_lakehouse_domain_binds_all_three_children() -> None:
     )
 
 
-def test_semantic_domain_binds_all_four_children() -> None:
+def test_semantic_domain_binds_all_twelve_children() -> None:
     manager = _manager()
     bound = BoundHandlerAvailabilityProvider(manager)
     semantic = DORIS_DOMAIN_CATALOG.resolve_domain("doris_semantic")
 
-    assert len(semantic.children) == 4
+    assert len(semantic.children) == 12
     assert all(
         bound.is_bound(semantic.name, child.name)
         for child in semantic.children
@@ -396,7 +396,7 @@ async def test_hierarchical_discovery_and_execution_use_one_exact_handler() -> N
 
 
 @pytest.mark.asyncio
-async def test_flat_mode_lists_47_formal_tools_and_uses_same_handler() -> None:
+async def test_flat_mode_lists_55_formal_tools_and_uses_same_handler() -> None:
     manager = _manager(
         "doris_query.execute_query",
         mode=ToolExposureMode.FLAT,
@@ -412,7 +412,7 @@ async def test_flat_mode_lists_47_formal_tools_and_uses_same_handler() -> None:
         )
     )
 
-    assert len(tools) == 47
+    assert len(tools) == 55
     assert tools[5].name == "doris_query_execute_query"
     assert tools[5].description.startswith("[AVAILABLE |")
     assert tools[5].input_schema["required"] == ["sql"]

--- a/test/tools/test_domain_manifest.py
+++ b/test/tools/test_domain_manifest.py
@@ -332,6 +332,36 @@ async def test_realistic_runtime_evidence_stays_within_manifest_budget() -> None
 
 
 @pytest.mark.asyncio
+async def test_fully_available_semantic_manifest_stays_within_budget() -> None:
+    provider = StaticAvailabilityProvider(
+        _availability(
+            status=AvailabilityStatus.AVAILABLE,
+            reason_code="CAPABILITY_VERIFIED",
+            active_variant="metricflow_compile_mcp_execute",
+            detected_versions={
+                "master_fe": ("4.0.5",),
+                "be": ("4.0.5",),
+            },
+            evidence_sources=(
+                "version_probe",
+                "sql_probe",
+                "provider_config",
+                "metricflow_provider_protocol_ready",
+            ),
+        )
+    )
+
+    manifest = await _service(provider).call("doris_semantic", {}, None)
+
+    assert len(manifest.children) == 12
+    assert all(child.availability.callable for child in manifest.children)
+    assert (
+        len(manifest.to_canonical_json().encode("utf-8"))
+        <= MAX_DOMAIN_MANIFEST_BYTES
+    )
+
+
+@pytest.mark.asyncio
 async def test_explicit_child_grants_hide_every_unauthorized_child() -> None:
     provider = StaticAvailabilityProvider(_availability())
     context = AuthContext(
@@ -479,7 +509,7 @@ async def test_authorized_unavailable_children_remain_discoverable() -> None:
         None,
     )
 
-    assert len(manifest.children) == 4
+    assert len(manifest.children) == 12
     assert all(not child.availability.callable for child in manifest.children)
     assert all(
         child.description.startswith(
@@ -504,6 +534,29 @@ async def test_public_version_support_omits_internal_execution_contracts() -> No
     assert '"required_providers"' not in serialized
     assert '"handler_name"' not in serialized
     assert '"authorization_policy"' not in serialized
+
+
+@pytest.mark.asyncio
+async def test_public_manifest_compacts_prose_but_preserves_input_constraints() -> None:
+    manifest = await _service().call("doris_semantic", {}, None)
+    execute = next(
+        child for child in manifest.children if child.name == "execute_metricflow_query"
+    )
+    schema = execute.to_wire()["input_schema"]
+
+    assert "description" not in json.dumps(schema)
+    assert schema["required"] == ["model_ref", "request"]
+    assert schema["properties"]["model_ref"] == {"type": "string"}
+    assert schema["properties"]["request"]["oneOf"]
+    assert schema["properties"]["max_rows"] == {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100_000,
+    }
+    assert execute.to_wire()["output_schema"] == {"type": "object"}
+    assert (
+        len(manifest.to_canonical_json().encode("utf-8")) <= MAX_DOMAIN_MANIFEST_BYTES
+    )
 
 
 @pytest.mark.asyncio

--- a/test/tools/test_doris_feature_matrix.py
+++ b/test/tools/test_doris_feature_matrix.py
@@ -72,7 +72,7 @@ def _certification_cases() -> tuple[PatchCertificationCase, ...]:
         PatchCertificationCase(
             transport=transport,
             exposure_mode=mode,
-            listed_tool_count=8 if mode == "hierarchical" else 47,
+            listed_tool_count=8 if mode == "hierarchical" else 55,
             domain_manifest_count=8 if mode == "hierarchical" else 0,
             read_only_query_passed=True,
             write_operations_executed=0,
@@ -98,14 +98,14 @@ def _certification_evidence(
         deployment_mode="cloud",
         cases=_certification_cases(),
         domain_names=tuple(EXPECTED_DOMAIN_CHILDREN),
-        child_contract_count=47,
+        child_contract_count=55,
         evidence_sha256="a" * 64,
-        verified_on="2026-07-31",
+        verified_on="2026-08-01",
     )
 
 
-def test_matrix_contains_exact_8_domain_47_child_contract() -> None:
-    assert len(DORIS_FEATURE_MATRIX.features) == 47
+def test_matrix_contains_exact_8_domain_55_child_contract() -> None:
+    assert len(DORIS_FEATURE_MATRIX.features) == 55
     assert tuple(EXPECTED_DOMAIN_CHILDREN) == (
         "doris_catalog",
         "doris_query",
@@ -124,7 +124,7 @@ def test_matrix_contains_exact_8_domain_47_child_contract() -> None:
         "doris_search": 4,
         "doris_governance": 8,
         "doris_lakehouse": 3,
-        "doris_semantic": 4,
+        "doris_semantic": 12,
     }
     for domain, expected_children in EXPECTED_DOMAIN_CHILDREN.items():
         actual_children = tuple(
@@ -150,8 +150,70 @@ def test_adbc_is_inside_query_and_variant_is_inside_lakehouse() -> None:
     assert execute_adbc.support_contract.variants[0].required_probes == (
         "adbc_driver_ready",
         "flight_sql_reachable",
+        "adbc_release_maturity",
         "read_only_sql_guard_ready",
     )
+
+
+def test_doris_2_x_uses_per_feature_gates_instead_of_a_global_rejection() -> None:
+    baseline = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_catalog",
+        child_name="list_tables",
+        versions=_vector("2.0.0"),
+    )
+    adbc_20 = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_query",
+        child_name="execute_adbc_query",
+        versions=_vector("2.0.15"),
+    )
+    adbc_21 = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_query",
+        child_name="execute_adbc_query",
+        versions=_vector("2.1.0"),
+    )
+    variant_20 = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_lakehouse",
+        child_name="inspect_variant_column",
+        versions=_vector("2.0.15"),
+    )
+    variant_21 = DORIS_FEATURE_MATRIX.evaluate(
+        domain="doris_lakehouse",
+        child_name="inspect_variant_column",
+        versions=_vector("2.1.0"),
+    )
+
+    assert baseline.compatible is True
+    assert adbc_20.compatible is False
+    assert adbc_20.reason_code == "VERSION_RANGE_NOT_MATCHED"
+    assert adbc_21.compatible is True
+    assert variant_20.compatible is False
+    assert variant_21.compatible is True
+
+
+def test_metricflow_consumer_operations_cover_the_official_command_surface() -> None:
+    semantic_children = EXPECTED_DOMAIN_CHILDREN["doris_semantic"]
+
+    assert semantic_children[4:] == (
+        "list_metricflow_models",
+        "get_metricflow_status",
+        "list_metricflow_metrics",
+        "get_metricflow_group_bys",
+        "list_metricflow_saved_queries",
+        "get_metricflow_dimension_values",
+        "compile_metricflow_query",
+        "execute_metricflow_query",
+    )
+    for child_name in semantic_children[4:]:
+        feature = DORIS_FEATURE_MATRIX.get_feature(
+            "doris_semantic",
+            child_name,
+        )
+        variant = feature.support_contract.variants[0]
+        assert variant.required_providers == ("metricflow_provider",)
+        assert {
+            "METRICFLOW_COMMANDS",
+            "METRICFLOW_ENGINE",
+        } <= set(variant.source_references)
 
 
 def test_search_prefers_vector_hybrid_and_keeps_text_fallback() -> None:
@@ -202,7 +264,7 @@ def test_lakehouse_prefers_4_1_capabilities_and_keeps_baseline_fallbacks() -> No
         "iceberg_row_lineage",
     )
     assert table_advanced.callable_when_degraded is True
-    assert table_baseline.supported_ranges == (">=3.0.0",)
+    assert table_baseline.supported_ranges == (">=2.0.0",)
 
     assert tuple(
         variant.name for variant in variant_feature.support_contract.variants
@@ -221,7 +283,7 @@ def test_lakehouse_prefers_4_1_capabilities_and_keeps_baseline_fallbacks() -> No
         "storage_v3",
     )
     assert variant_advanced.callable_when_degraded is True
-    assert variant_baseline.supported_ranges == (">=3.0.0",)
+    assert variant_baseline.supported_ranges == (">=2.1.0",)
 
 
 def test_every_contract_is_fail_closed_and_has_resolvable_sources() -> None:
@@ -243,7 +305,7 @@ def test_sources_are_https_authorities_with_branch_ranges() -> None:
     for source in DORIS_FEATURE_MATRIX.sources:
         assert source.url.startswith("https://")
         assert source.applicable_ranges
-        assert source.verified_on.isoformat() == "2026-07-31"
+        assert source.verified_on.isoformat() == "2026-08-01"
         for expression in source.applicable_ranges:
             assert DorisVersionRange(expression).expression == expression
 
@@ -256,7 +318,7 @@ def test_sources_are_https_authorities_with_branch_ranges() -> None:
 
 
 def test_only_evidence_backed_targets_are_claimed_as_certified() -> None:
-    assert PROJECT_MINIMUM_DORIS_VERSION == "3.0.0"
+    assert PROJECT_MINIMUM_DORIS_VERSION == "2.0.0"
     assert DORIS_FEATURE_MATRIX.certification_targets == (CERTIFICATION_TARGET_VERSIONS)
     assert DORIS_FEATURE_MATRIX.certified_versions == ("4.0.5",)
     assert CERTIFIED_DORIS_VERSIONS == ("4.0.5",)
@@ -268,7 +330,7 @@ def test_only_evidence_backed_targets_are_claimed_as_certified() -> None:
     ) == ("4.0.5",)
     assert (
         DORIS_PATCH_CERTIFICATION_MATRIX.evidence[0].evidence_sha256
-        == "2ac431322d6b550bd8449ca80312105f4cc9cfec57f9b89362c088a2f97d4e9a"
+        == "a8d63aa4b5070489e362cfbf57e793c9698f5d583c9cae19861eb73bca5c7a76"
     )
     assert {
         "DORIS_RELEASE_3_0_3",
@@ -313,7 +375,7 @@ def test_certification_uses_three_part_core_for_rc_and_ga_builds() -> None:
 def test_complete_real_host_evidence_certifies_its_three_part_patch() -> None:
     evidence = _certification_evidence()
     matrix = DorisPatchCertificationMatrix(
-        minimum_supported_version="3.0.0",
+        minimum_supported_version="2.0.0",
         target_versions=CERTIFICATION_TARGET_VERSIONS,
         evidence=(evidence,),
     )
@@ -542,7 +604,7 @@ def test_lineage_native_and_audit_paths_are_both_explicit() -> None:
     variants = {variant.name: variant for variant in feature.support_contract.variants}
 
     assert variants["audit_sql_inference_primary"].supported_ranges == (
-        ">=3.0.0,<4.0.6",
+        ">=2.0.0,<4.0.6",
     )
     assert variants["native_lineage_events"].supported_ranges == (">=4.0.6",)
     assert variants["audit_sql_inference_fallback"].supported_ranges == (">=4.0.6",)
@@ -740,16 +802,16 @@ def test_an_unparseable_component_version_fails_closed() -> None:
     )
 
 
-def test_version_below_3_0_0_is_rejected_before_child_evaluation() -> None:
+def test_version_below_2_0_0_is_rejected_before_child_evaluation() -> None:
     result = DORIS_FEATURE_MATRIX.evaluate(
         domain="doris_catalog",
         child_name="list_tables",
-        versions=_vector("2.1.8"),
+        versions=_vector("1.2.8"),
     )
 
     assert result.compatible is False
     assert result.reason_code == "DORIS_VERSION_BELOW_MINIMUM"
-    assert result.minimum_supported_version == "3.0.0"
+    assert result.minimum_supported_version == "2.0.0"
 
 
 def test_target_patch_is_distinct_from_certified_patch() -> None:
@@ -831,7 +893,7 @@ def test_matrix_rejects_missing_or_reordered_children() -> None:
     payload = _matrix_payload()
     payload["features"] = payload["features"][:-1]
 
-    with pytest.raises(ValidationError, match="8-domain/47-child"):
+    with pytest.raises(ValidationError, match="8-domain/55-child"):
         DorisFeatureMatrix.model_validate(payload)
 
 
@@ -954,6 +1016,6 @@ def test_matrix_wire_serialization_is_stable_and_immutable() -> None:
     second = DORIS_FEATURE_MATRIX.to_canonical_json()
 
     assert first == second
-    assert '"minimum_supported_version":"3.0.0"' in first
+    assert '"minimum_supported_version":"2.0.0"' in first
     with pytest.raises(ValidationError):
         DORIS_FEATURE_MATRIX.minimum_supported_version = "4.0.0"

--- a/test/tools/test_semantic_handlers.py
+++ b/test/tools/test_semantic_handlers.py
@@ -53,9 +53,22 @@ class _Runtime:
         return {"operation": "mapping"}
 
 
+class _MetricFlowRuntime:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def __getattr__(self, operation: str):
+        async def call(**kwargs: Any) -> dict[str, Any]:
+            self.calls.append((operation, kwargs))
+            return {"operation": operation}
+
+        return call
+
+
 class _Owner(SemanticToolHandlersMixin):
     def __init__(self) -> None:
         self.semantic_runtime = _Runtime()  # type: ignore[assignment]
+        self.metricflow_runtime = _MetricFlowRuntime()  # type: ignore[assignment]
 
 
 @pytest.mark.asyncio
@@ -157,6 +170,95 @@ async def test_semantic_handler_defaults_do_not_guess_model() -> None:
             {
                 "model_ref": "retail/main",
                 "datasource": None,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_metricflow_handlers_route_exact_models_and_query_arguments() -> None:
+    owner = _Owner()
+    request = {
+        "metrics": ["revenue"],
+        "group_by": ["metric_time"],
+        "order_by": ["-revenue"],
+    }
+
+    await owner._formal_doris_semantic_list_metricflow_models_tool({})
+    await owner._formal_doris_semantic_get_metricflow_status_tool(
+        {"model_ref": "sales/main"}
+    )
+    await owner._formal_doris_semantic_list_metricflow_metrics_tool(
+        {"model_ref": "sales/main"}
+    )
+    await owner._formal_doris_semantic_get_metricflow_group_bys_tool(
+        {"model_ref": "sales/main", "metrics": ["revenue"]}
+    )
+    await owner._formal_doris_semantic_list_metricflow_saved_queries_tool(
+        {"model_ref": "sales/main"}
+    )
+    await owner._formal_doris_semantic_get_metricflow_dimension_values_tool(
+        {
+            "model_ref": "sales/main",
+            "metrics": ["revenue"],
+            "dimension": "metric_time",
+        }
+    )
+    await owner._formal_doris_semantic_compile_metricflow_query_tool(
+        {"model_ref": "sales/main", "request": request}
+    )
+    await owner._formal_doris_semantic_execute_metricflow_query_tool(
+        {
+            "model_ref": "sales/main",
+            "request": request,
+            "max_rows": 100,
+            "timeout_ms": 5000,
+        }
+    )
+
+    assert owner.metricflow_runtime.calls == [
+        ("list_models", {}),
+        ("get_status", {"model_ref": "sales/main"}),
+        (
+            "list_metrics",
+            {
+                "model_ref": "sales/main",
+                "search": None,
+                "include_dimensions": True,
+                "limit": None,
+            },
+        ),
+        (
+            "get_group_bys",
+            {"model_ref": "sales/main", "metrics": ["revenue"]},
+        ),
+        (
+            "list_saved_queries",
+            {"model_ref": "sales/main", "search": None, "limit": None},
+        ),
+        (
+            "get_dimension_values",
+            {
+                "model_ref": "sales/main",
+                "metrics": ["revenue"],
+                "dimension": "metric_time",
+                "start_time": None,
+                "end_time": None,
+                "limit": None,
+                "timeout_ms": None,
+            },
+        ),
+        (
+            "compile_query",
+            {"model_ref": "sales/main", "request": request},
+        ),
+        (
+            "execute_query",
+            {
+                "model_ref": "sales/main",
+                "request": request,
+                "max_rows": 100,
+                "timeout_ms": 5000,
             },
         ),
     ]

--- a/test/tools/test_tool_catalog_boundary.py
+++ b/test/tools/test_tool_catalog_boundary.py
@@ -76,7 +76,7 @@ def test_migration_catalog_remains_a_build_time_validation_artifact() -> None:
 
     assert not hasattr(manager, "tool_registry")
     assert len(migration_registry.advertised_names) == 25
-    assert len(manager.domain_dispatcher.formal_flat_names) == 47
+    assert len(manager.domain_dispatcher.formal_flat_names) == 55
     assert not set(migration_registry.advertised_names).intersection(
         manager.domain_dispatcher.formal_flat_names
     )

--- a/test/utils/test_query_runtime.py
+++ b/test/utils/test_query_runtime.py
@@ -664,11 +664,15 @@ async def test_adbc_guard_runs_before_provider_and_normalizes_rows() -> None:
     runtime, _, _ = _runtime(adbc=adbc)
 
     with pytest.raises(QueryRuntimeFailure) as error:
-        await runtime.execute_adbc_query(sql="DROP TABLE customer")
+        await runtime.execute_adbc_query(
+            explicit_adbc=True,
+            sql="DROP TABLE customer",
+        )
     assert error.value.reason_code == "QUERY_READ_ONLY_VIOLATION"
     adbc.exec_adbc_query.assert_not_awaited()
 
     result = await runtime.execute_adbc_query(
+        explicit_adbc=True,
         sql="SELECT id FROM customer",
         max_rows=10,
         timeout_ms=2000,
@@ -686,6 +690,28 @@ async def test_adbc_guard_runs_before_provider_and_normalizes_rows() -> None:
 
 
 @pytest.mark.asyncio
+async def test_adbc_requires_explicit_end_user_intent_before_provider() -> None:
+    adbc = SimpleNamespace(
+        exec_adbc_query=AsyncMock(),
+        get_adbc_connection_info=AsyncMock(),
+    )
+    runtime, _, _ = _runtime(adbc=adbc)
+
+    with pytest.raises(QueryRuntimeFailure) as query_error:
+        await runtime.execute_adbc_query(
+            explicit_adbc=False,
+            sql="SELECT 1",
+        )
+    with pytest.raises(QueryRuntimeFailure) as info_error:
+        await runtime.get_adbc_connection_info(explicit_adbc=False)
+
+    assert query_error.value.reason_code == "ADBC_EXPLICIT_USER_INTENT_REQUIRED"
+    assert info_error.value.reason_code == "ADBC_EXPLICIT_USER_INTENT_REQUIRED"
+    adbc.exec_adbc_query.assert_not_awaited()
+    adbc.get_adbc_connection_info.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_adbc_rejects_invalid_runtime_options_before_provider() -> None:
     adbc = SimpleNamespace(
         exec_adbc_query=AsyncMock(),
@@ -695,11 +721,13 @@ async def test_adbc_rejects_invalid_runtime_options_before_provider() -> None:
 
     with pytest.raises(QueryRuntimeFailure, match="format"):
         await runtime.execute_adbc_query(
+            explicit_adbc=True,
             sql="SELECT 1",
             result_format="csv",
         )
     with pytest.raises(QueryRuntimeFailure, match="timeout_ms"):
         await runtime.execute_adbc_query(
+            explicit_adbc=True,
             sql="SELECT 1",
             timeout_ms=0,
         )
@@ -735,7 +763,7 @@ async def test_adbc_connection_info_never_returns_endpoint_or_identity() -> None
     )
     runtime, _, _ = _runtime(adbc=adbc)
 
-    result = await runtime.get_adbc_connection_info()
+    result = await runtime.get_adbc_connection_info(explicit_adbc=True)
     serialized = repr(result)
 
     assert result["data"]["status"] == "ready"


### PR DESCRIPTION
## Summary

- add eight bounded MetricFlow consumer capabilities to `doris_semantic`, with exact `model_ref` selection and an operator-supplied provider contract
- lower the project compatibility baseline to Doris 2.0.0 and resolve every child capability from normalized version, runtime probes, provider readiness, deployment mode, and permissions
- make ADBC an advanced, default-off, explicit-only query path; ordinary read-only SQL continues to use `execute_query`
- compact progressive manifests so the complete 12-child semantic domain remains below the 16 KiB exposure budget without weakening internal validation
- update the generated 8-domain/55-child registry, bilingual documentation, release notes, migration guidance, and changelog

## Architecture and behavior

MetricFlow remains the semantic metric definition and compilation engine. Doris MCP Server acts as a bounded consumer: it discovers models and metrics, obtains provider-compiled SQL, revalidates that SQL through the existing read-only guard, and executes it through the normal Doris query runtime. The server does not infer `model_ref`, author semantic models, invoke a shell, or bundle a native Doris MetricFlow/dbt adapter.

ADBC stays inside `doris_query` as an advanced path. Both connection discovery and execution require explicit end-user ADBC intent represented by `explicit_adbc=true`; the feature is disabled by default and cannot silently replace ordinary query execution.

Doris 2.0.0 is the global compatibility floor. Later features remain visible in manifests with structured availability evidence and `callable=false` when the connected route lacks the required version, provider, runtime endpoint, deployment mode, or permission. Release certification remains separate from runtime support.

## Validation

- `uv lock --check`
- generated tool catalog drift check
- Ruff, Mypy, and Bandit gates
- `1772 passed, 83 skipped` with warnings treated as errors
- total coverage `67.73%`; protocol `90.34%`, authentication `81.55%`, core managers `87.03%`
- source distribution, wheel build, clean-wheel import/CLI smoke, and runtime dependency boundary
- `26 passed` against a live Doris `4.0.5-rc01` cluster over stdio and Streamable HTTP
- all eight MetricFlow children exercised through a temporary provider-contract sidecar, including guarded execution of compiled SQL against live Doris

## Limits

- the repository does not bundle a stock Doris MetricFlow/dbt adapter; operators must configure a compatible provider
- the live certification target in this change is Doris 4.0.5; Doris 2.0/2.1 compatibility is implemented and tested by capability contracts but remains target-uncertified until the same live-cluster gate is run
- ADBC remains default-off, explicit-only, and unavailable on token-bound routes

Updates #189. The release issue must remain open until the 1.0.0 release process is complete.
