### PR TITLE
Add MCP 2025-06-18 legacy Host compatibility coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ under **Unreleased** until a new version is selected and published.
 
 ### Added
 
+- Added an explicit Dify 1.16.1 compatibility profile for MCP `2025-06-18`
+  through the default-off `/mcp/legacy` endpoint, with initialize, stateless
+  tool-discovery, and tool-call regression coverage.
 - Added eight default-off MetricFlow consumer children to `doris_semantic`
   for exact-model discovery, status, metrics, group-bys, saved queries,
   dimension values, Doris SQL compilation, and bounded execution through the
@@ -62,6 +65,9 @@ under **Unreleased** until a new version is selected and published.
 
 ### Fixed
 
+- Documented the strict `/mcp` versus `/mcp/legacy` endpoint boundary in the
+  protocol, Host, quick-start, deployment, troubleshooting, migration, and
+  release guides without restoring pre-1.0 tool names or weakening security.
 - Added the Apache SkyWalking Eyes release gate, its bounded repository
   configuration, and the missing ASF license headers required for source
   release verification.
@@ -83,7 +89,7 @@ under **Unreleased** until a new version is selected and published.
 ### Added
 
 - MCP `2026-07-28` stateless protocol support on Streamable HTTP and stdio,
-  with a `2025-11-25` migration path.
+  with HTTP migration paths for `2025-06-18` and `2025-11-25`.
 - Doris-backed OAuth with per-user Doris connection pools and operation gates.
 - Client ID Metadata Document discovery for Doris-backed OAuth, including
   bounded retrieval, DNS pinning, cache-control handling, and consent-screen

--- a/README.md
+++ b/README.md
@@ -115,8 +115,14 @@ doris-mcp-server \
 Endpoints:
 
 - MCP: `POST http://127.0.0.1:3000/mcp`
+- legacy MCP (opt-in): `POST http://127.0.0.1:3000/mcp/legacy`
 - liveness: `GET http://127.0.0.1:3000/live`
 - Doris-backed readiness: `GET http://127.0.0.1:3000/ready`
+
+Hosts limited to handshake-era Streamable HTTP, including Dify 1.16.1 with
+MCP `2025-06-18`, must set `ENABLE_LEGACY_HTTP_ADAPTER=true` and connect to
+`/mcp/legacy`. The adapter changes only the protocol boundary; it preserves the
+same 1.0 tools, authorization, capability gates, and read-only execution.
 
 Or run stdio for a local Host:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -112,8 +112,14 @@ doris-mcp-server \
 服务端点：
 
 - MCP：`POST http://127.0.0.1:3000/mcp`
+- 旧版 MCP（显式开启）：`POST http://127.0.0.1:3000/mcp/legacy`
 - 存活检查：`GET http://127.0.0.1:3000/live`
 - Doris 就绪检查：`GET http://127.0.0.1:3000/ready`
+
+仅支持 Handshake-era Streamable HTTP 的 Host，包括使用 MCP `2025-06-18` 的
+Dify 1.16.1，需要设置 `ENABLE_LEGACY_HTTP_ADAPTER=true` 并连接
+`/mcp/legacy`。Adapter 只改变协议边界，仍使用相同的 1.0 Tool、授权、能力 Gate
+和只读执行链路。
 
 也可以为本地 Host 启动 stdio：
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -100,6 +100,11 @@ The modern MCP endpoint is:
 POST http://127.0.0.1:3000/mcp
 ```
 
+For a validated handshake-era Host such as Dify 1.16.1 using MCP
+`2025-06-18`, restart with `ENABLE_LEGACY_HTTP_ADAPTER=true` and configure the
+Host URL as `http://127.0.0.1:3000/mcp/legacy`. Do not send legacy traffic to
+`/mcp`.
+
 Health endpoints:
 
 ```bash

--- a/docs/getting-started/quickstart.zh-CN.md
+++ b/docs/getting-started/quickstart.zh-CN.md
@@ -98,6 +98,10 @@ doris-mcp-server \
 POST http://127.0.0.1:3000/mcp
 ```
 
+对于已经验证的 Handshake-era Host，例如使用 MCP `2025-06-18` 的 Dify
+1.16.1，请设置 `ENABLE_LEGACY_HTTP_ADAPTER=true` 后重启，并把 Host URL 配置为
+`http://127.0.0.1:3000/mcp/legacy`。不能把旧协议流量发送到 `/mcp`。
+
 健康端点：
 
 ```bash

--- a/docs/integrations/hosts.md
+++ b/docs/integrations/hosts.md
@@ -147,6 +147,30 @@ Authorization: Bearer <token>
 Do not put credentials in the URL. Remote access requires HTTPS and validated
 Host/Origin/proxy policy.
 
+## Protocol endpoint compatibility
+
+Choose the endpoint from the Host's implemented MCP protocol. Do not rely on
+automatic downgrade or send an old handshake to the modern endpoint.
+
+| Host profile | Protocol | Endpoint | Status |
+|---|---|---|---|
+| Modern MCP Host | `2026-07-28` | `/mcp` | Preferred and release-gated |
+| Dify 1.16.1 | `2025-06-18` | `/mcp/legacy` | Validated with initialize, tool discovery, and tool calls |
+| Legacy SDK v2 client | `2025-11-25` | `/mcp/legacy` | Regression-tested migration path |
+
+Enable the compatibility endpoint explicitly:
+
+```bash
+export ENABLE_LEGACY_HTTP_ADAPTER=true
+doris-mcp-server --transport http --host 127.0.0.1 --port 3000
+```
+
+The legacy endpoint is a protocol adapter over the same Server. It does not
+restore removed tool names, weaken authentication or authorization, bypass
+Doris capability checks, or change read-only execution. Tool exposure mode is
+an independent startup choice; use `hierarchical` unless the Host specifically
+requires `flat`.
+
 ## Built-in command-line client
 
 `doris-mcp-client` is useful for connection and protocol diagnostics. It is not
@@ -189,7 +213,7 @@ Hosts should:
 
 | Requirement | Hierarchical | Flat |
 |---|---:|---:|
-| MCP `2026-07-28` tool list/call | required | required |
+| tool list/call on the selected protocol endpoint | required | required |
 | call a domain with `{}` | required | not required |
 | feed discovered child schemas to model | required | not required |
 | handle structured content | recommended | recommended |

--- a/docs/integrations/hosts.zh-CN.md
+++ b/docs/integrations/hosts.zh-CN.md
@@ -133,6 +133,28 @@ Authorization: Bearer <token>
 
 不能把凭据放 URL。远程访问需要 HTTPS 与已校验 Host/Origin/Proxy Policy。
 
+## 协议端点兼容性
+
+应根据 Host 实现的 MCP 协议选择端点，不能依赖自动降级，也不能把旧初始化请求
+发送到现代端点。
+
+| Host Profile | 协议 | 端点 | 状态 |
+|---|---|---|---|
+| 现代 MCP Host | `2026-07-28` | `/mcp` | 首选且经过 Release Gate |
+| Dify 1.16.1 | `2025-06-18` | `/mcp/legacy` | 已验证初始化、Tool Discovery 与 Tool Call |
+| 旧 SDK v2 Client | `2025-11-25` | `/mcp/legacy` | 有回归测试的迁移路径 |
+
+显式开启兼容端点：
+
+```bash
+export ENABLE_LEGACY_HTTP_ADAPTER=true
+doris-mcp-server --transport http --host 127.0.0.1 --port 3000
+```
+
+Legacy 端点是同一 Server 上的协议 Adapter，不会恢复已删除的 Tool 名称、降低认证
+或授权、绕过 Doris 能力检查或改变只读执行。Tool Exposure Mode 是独立的启动级
+选择；除非 Host 明确要求 `flat`，否则应使用 `hierarchical`。
+
 ## 内置命令行 Client
 
 `doris-mcp-client` 用于连接与协议诊断。它不是 Server Executable，不能在 Host
@@ -172,7 +194,7 @@ Host 应当：
 
 | 要求 | Hierarchical | Flat |
 |---|---:|---:|
-| MCP `2026-07-28` Tool List/Call | 必需 | 必需 |
+| 在所选协议端点完成 Tool List/Call | 必需 | 必需 |
 | 用 `{}` 调用领域 | 必需 | 不需要 |
 | 把发现 Child Schema 交给模型 | 必需 | 不需要 |
 | 处理 Structured Content | 推荐 | 推荐 |

--- a/docs/migration-1.0.0.md
+++ b/docs/migration-1.0.0.md
@@ -120,8 +120,9 @@ guess a model from the prompt.
 ## Protocol and transport
 
 MCP `2026-07-28` is the modern protocol on Streamable HTTP and stdio. The
-isolated `2025-11-25` HTTP migration adapter remains default-off at
-`/mcp/legacy` and does not restore pre-1.0 tool names. Enable it only for a
+isolated HTTP migration adapter remains default-off at `/mcp/legacy` and has
+regression coverage for `2025-06-18` (including Dify 1.16.1) and
+`2025-11-25`. It does not restore pre-1.0 tool names. Enable it only for a
 bounded protocol migration by setting `ENABLE_LEGACY_HTTP_ADAPTER=true`.
 
 ## Doris version handling

--- a/docs/migration/1.0.0.md
+++ b/docs/migration/1.0.0.md
@@ -165,8 +165,10 @@ For HTTP `2026-07-28`:
 5. accept modern structured content and typed errors.
 
 For a bounded legacy HTTP migration, enable the adapter and point only the old
-client to `/mcp/legacy`. Do not point legacy traffic at `/mcp` and do not keep
-the adapter as a permanent architecture.
+client to `/mcp/legacy`. The regression-tested HTTP profiles are `2025-06-18`
+(including Dify 1.16.1) and `2025-11-25`. Do not point legacy traffic at
+`/mcp`; the adapter preserves the 1.0 tool and security contracts and is not a
+pre-1.0 compatibility alias.
 
 ## Doris version and capability migration
 

--- a/docs/migration/1.0.0.zh-CN.md
+++ b/docs/migration/1.0.0.zh-CN.md
@@ -158,8 +158,10 @@ HTTP `2026-07-28`：
    Session、HTTP GET Stream、Last-Event-ID 和 Resumable SSE 假设；
 5. 接受现代 Structured Content 与类型化错误。
 
-有界旧 HTTP 迁移可以启用 Adapter，只让旧 Client 连接 `/mcp/legacy`。不能把旧
-流量发到 `/mcp`，也不能把 Adapter 当作永久架构。
+有界旧 HTTP 迁移可以启用 Adapter，只让旧 Client 连接 `/mcp/legacy`。经过回归
+测试的 HTTP Profile 是 `2025-06-18`（包括 Dify 1.16.1）和 `2025-11-25`。
+不能把旧流量发到 `/mcp`；Adapter 保留 1.0 Tool 与安全合同，不是 1.0 以前的
+兼容 Alias。
 
 ## Doris 版本与能力迁移
 

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -88,6 +88,17 @@ Endpoints:
 - `GET /health` — compatibility health view;
 - `/mcp/legacy` — default-off protocol migration adapter.
 
+Enable `/mcp/legacy` only for validated handshake-era clients such as Dify
+1.16.1 (`2025-06-18`) or SDK v2 clients using `2025-11-25`:
+
+```bash
+export ENABLE_LEGACY_HTTP_ADAPTER=true
+```
+
+Configure those Hosts with the exact `/mcp/legacy` URL. Keep modern
+`2026-07-28` Hosts on `/mcp`; the Server never silently downgrades that
+endpoint.
+
 Keep the Server on loopback until authentication, Host/Origin policy, proxy
 behavior, TLS termination, timeouts, and secret injection are tested together.
 

--- a/docs/operations/deployment.zh-CN.md
+++ b/docs/operations/deployment.zh-CN.md
@@ -84,6 +84,16 @@ doris-mcp-server --transport http --host 127.0.0.1 --port 3000
 - `GET /health`——兼容健康视图；
 - `/mcp/legacy`——默认关闭的协议迁移 Adapter。
 
+只为已验证的 Handshake-era Client 开启 `/mcp/legacy`，例如 Dify 1.16.1
+（`2025-06-18`）或使用 `2025-11-25` 的 SDK v2 Client：
+
+```bash
+export ENABLE_LEGACY_HTTP_ADAPTER=true
+```
+
+这些 Host 必须配置精确的 `/mcp/legacy` URL；现代 `2026-07-28` Host 继续使用
+`/mcp`，Server 不会在该端点静默降级。
+
 在认证、Host/Origin、Proxy、TLS、Timeout 和 Secret 注入经过联合测试前，Server
 应保持回环绑定。
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -111,8 +111,9 @@ Ensure:
 
 ### Unsupported protocol (`-32022`)
 
-Use MCP `2026-07-28`. A `2025-11-25` HTTP client must use the explicitly
-enabled `/mcp/legacy` endpoint. HTTP+SSE clients must migrate.
+Use `/mcp` for MCP `2026-07-28`. Validated `2025-06-18` clients such as Dify
+1.16.1 and `2025-11-25` clients must use the explicitly enabled
+`/mcp/legacy` endpoint. HTTP+SSE clients must migrate.
 
 ## Authentication or authorization fails
 

--- a/docs/operations/troubleshooting.zh-CN.md
+++ b/docs/operations/troubleshooting.zh-CN.md
@@ -106,8 +106,9 @@ Proxy Rewrite、TLS Scheme 和 Trusted Proxy CIDR。不要全局信任 Forwarded
 
 ### 不支持协议（`-32022`）
 
-使用 MCP `2026-07-28`。`2025-11-25` HTTP Client 必须连接显式启用的
-`/mcp/legacy`；HTTP+SSE Client 必须迁移。
+MCP `2026-07-28` 使用 `/mcp`。Dify 1.16.1 等已经验证的 `2025-06-18`
+Client 和 `2025-11-25` Client 必须连接显式启用的 `/mcp/legacy`；HTTP+SSE
+Client 必须迁移。
 
 ## Authentication 或 Authorization 失败
 

--- a/docs/protocol/mcp-2026-07-28.md
+++ b/docs/protocol/mcp-2026-07-28.md
@@ -37,11 +37,13 @@ Authoritative protocol references:
 |---|---|---|---|
 | `2026-07-28` | Preferred at `/mcp` | Preferred | Stateless, self-contained requests; release-gated |
 | `2025-11-25` | Opt-in at `/mcp/legacy` | Migration only | Legacy initialization accepted; no HTTP session is created |
-| `2025-06-18` and older | Not guaranteed | Not guaranteed | Upgrade the client |
+| `2025-06-18` | Opt-in at `/mcp/legacy` | Not release-gated | HTTP initialization, stateless tool discovery, and tool calls are regression-tested; Dify 1.16.1 validated |
+| `2025-03-26` and older | Not guaranteed | Not guaranteed | Upgrade the client |
 | HTTP+SSE `2024-11-05` | Not supported | Not applicable | Retired separate SSE endpoint is absent |
 
 `ENABLE_LEGACY_HTTP_ADAPTER=true` enables only the isolated legacy HTTP path.
-It does not change `/mcp`, restore pre-1.0 tool names, or create a session.
+It does not change `/mcp`, restore pre-1.0 tool names, create a session, bypass
+authorization, or change the Server's tool catalog.
 
 ## Modern request metadata
 

--- a/docs/protocol/mcp-2026-07-28.zh-CN.md
+++ b/docs/protocol/mcp-2026-07-28.zh-CN.md
@@ -37,11 +37,13 @@ Apache Doris MCP Server 在 Streamable HTTP 和 stdio 上共用一套 MCP SDK v2
 |---|---|---|---|
 | `2026-07-28` | `/mcp` 首选 | 首选 | 无状态、自包含请求，经过完整 Release Gate |
 | `2025-11-25` | `/mcp/legacy` 显式开启 | 仅迁移 | 接受旧初始化，但不创建 HTTP Session |
-| `2025-06-18` 及更早 | 不保证 | 不保证 | 应升级 Client |
+| `2025-06-18` | `/mcp/legacy` 显式开启 | 未纳入发布门禁 | HTTP 旧初始化、无状态 Tool Discovery 和 Tool Call 有回归测试；Dify 1.16.1 已验证 |
+| `2025-03-26` 及更早 | 不保证 | 不保证 | 应升级 Client |
 | HTTP+SSE `2024-11-05` | 不支持 | 不适用 | 独立 SSE 端点已移除 |
 
 `ENABLE_LEGACY_HTTP_ADAPTER=true` 只启用隔离的旧 HTTP 路径，不会改变
-`/mcp`、恢复 1.0 以前 Tool 名称或创建 Session。
+`/mcp`、恢复 1.0 以前 Tool 名称、创建 Session、绕过授权或改变 Server Tool
+Catalog。
 
 ## 现代请求元数据
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -84,7 +84,7 @@ All FE/BE destinations are operator configuration, never caller arguments.
 | `SERVER_NAME` | product instance name, not product version |
 | `MCP_ALLOWED_HOSTS` | validated HTTP Host policy inputs |
 | `MCP_ALLOWED_ORIGINS` | validated Origin policy inputs |
-| `ENABLE_LEGACY_HTTP_ADAPTER` | default-off `/mcp/legacy` adapter |
+| `ENABLE_LEGACY_HTTP_ADAPTER` | default-off `/mcp/legacy` adapter for validated `2025-06-18` and `2025-11-25` clients |
 | `MCP_LIST_PAGE_SIZE` | entries per protocol list page (`1`–`1000`) |
 | `MCP_STATE_HANDLE_SECRET` | shared HMAC secret for independent replicas |
 | `MCP_STATE_HANDLE_TTL_SECONDS` | explicit handle lifetime (`1`–`3600`) |

--- a/docs/reference/configuration.zh-CN.md
+++ b/docs/reference/configuration.zh-CN.md
@@ -81,7 +81,7 @@ HTTP 安全：
 | `SERVER_NAME` | 产品实例名，不是产品版本 |
 | `MCP_ALLOWED_HOSTS` | 已校验 HTTP Host Policy 输入 |
 | `MCP_ALLOWED_ORIGINS` | 已校验 Origin Policy 输入 |
-| `ENABLE_LEGACY_HTTP_ADAPTER` | 默认关闭的 `/mcp/legacy` Adapter |
+| `ENABLE_LEGACY_HTTP_ADAPTER` | 默认关闭的 `/mcp/legacy` Adapter，用于已验证的 `2025-06-18` 和 `2025-11-25` Client |
 | `MCP_LIST_PAGE_SIZE` | 每个协议 List Page 条目数（`1`–`1000`） |
 | `MCP_STATE_HANDLE_SECRET` | 独立 Replica 共享 HMAC Secret |
 | `MCP_STATE_HANDLE_TTL_SECONDS` | 显式句柄有效期（`1`–`3600`） |

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -112,7 +112,8 @@ support results.
 - Sanitized W3C trace-context propagation.
 - Honest subscription boundary: no `subscriptions/listen` without a real
   cross-worker event source.
-- Default-off isolated `2025-11-25` HTTP migration adapter at `/mcp/legacy`.
+- Default-off isolated `2025-06-18` and `2025-11-25` HTTP migration adapter at
+  `/mcp/legacy`, including a validated Dify 1.16.1 profile.
 
 ## Security
 

--- a/docs/releases/1.0.0.zh-CN.md
+++ b/docs/releases/1.0.0.zh-CN.md
@@ -104,7 +104,8 @@ Domain 一直注册，因此模型可以在同一对话中从 Catalog 切换到 
 - 清洗后的 W3C Trace Context 传播。
 - 诚实 Subscription 边界：没有真实跨 Worker Event Source 就不提供
   `subscriptions/listen`。
-- 默认关闭、隔离在 `/mcp/legacy` 的 `2025-11-25` HTTP Migration Adapter。
+- 默认关闭、隔离在 `/mcp/legacy` 的 `2025-06-18` 与 `2025-11-25` HTTP
+  Migration Adapter，其中包括已验证的 Dify 1.16.1 Profile。
 
 ## 安全
 

--- a/test/protocol/test_http_transport_boundaries.py
+++ b/test/protocol/test_http_transport_boundaries.py
@@ -55,13 +55,13 @@ def _modern_headers() -> dict[str, str]:
     }
 
 
-def _legacy_initialize() -> dict:
+def _legacy_initialize(protocol_version: str = "2025-11-25") -> dict:
     return {
         "jsonrpc": "2.0",
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": protocol_version,
             "capabilities": {},
             "clientInfo": {
                 "name": "legacy-http-boundary-test",
@@ -145,8 +145,11 @@ async def test_modern_core_is_exact_post_only_and_never_falls_back_to_legacy():
         assert inexact_path.status_code == 404
 
 
+@pytest.mark.parametrize("protocol_version", ["2025-06-18", "2025-11-25"])
 @pytest.mark.asyncio
-async def test_opt_in_legacy_adapter_accepts_only_handshake_era_traffic():
+async def test_opt_in_legacy_adapter_accepts_only_handshake_era_traffic(
+    protocol_version: str,
+):
     app = _transport(legacy_adapter_enabled=True)
 
     async with (
@@ -159,11 +162,11 @@ async def test_opt_in_legacy_adapter_accepts_only_handshake_era_traffic():
     ):
         initialized = await client.post(
             LEGACY_MCP_PATH,
-            json=_legacy_initialize(),
+            json=_legacy_initialize(protocol_version),
             headers=_legacy_headers(),
         )
         assert initialized.status_code == 200
-        assert initialized.json()["result"]["protocolVersion"] == "2025-11-25"
+        assert initialized.json()["result"]["protocolVersion"] == protocol_version
         assert "mcp-session-id" not in initialized.headers
 
         modern_on_legacy = await client.post(

--- a/test/protocol/test_mcp_v2_protocol.py
+++ b/test/protocol/test_mcp_v2_protocol.py
@@ -729,6 +729,81 @@ async def test_http_rejects_untrusted_origin_and_legacy_adapter_is_stateless():
 
 
 @pytest.mark.asyncio
+async def test_legacy_http_adapter_serves_2025_06_18_host_tools():
+    app = DorisMCPHTTPTransport(
+        app=create_test_server(),
+        security_settings=create_transport_security("127.0.0.1"),
+        legacy_adapter_enabled=True,
+    )
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    initialize = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "dify", "version": "1.16.1"},
+        },
+    }
+
+    async with (
+        app.run(),
+        httpx2.ASGITransport(app.handle_request) as transport,
+        httpx2.AsyncClient(
+            transport=transport,
+            base_url="http://127.0.0.1:3000",
+        ) as client,
+    ):
+        initialized = await client.post(
+            LEGACY_MCP_PATH,
+            json=initialize,
+            headers=headers,
+        )
+        assert initialized.status_code == 200
+        assert initialized.json()["result"]["protocolVersion"] == "2025-06-18"
+        assert "mcp-session-id" not in initialized.headers
+
+        listed = await client.post(
+            LEGACY_MCP_PATH,
+            json={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {},
+            },
+            headers={**headers, "MCP-Protocol-Version": "2025-06-18"},
+        )
+        assert listed.status_code == 200
+        assert [tool["name"] for tool in listed.json()["result"]["tools"]] == [
+            "echo",
+            "fail",
+        ]
+
+        called = await client.post(
+            LEGACY_MCP_PATH,
+            json={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "echo",
+                    "arguments": {"value": "legacy"},
+                },
+            },
+            headers={**headers, "MCP-Protocol-Version": "2025-06-18"},
+        )
+        assert called.status_code == 200
+        assert called.json()["result"]["structuredContent"] == {
+            "name": "echo",
+            "arguments": {"value": "legacy"},
+        }
+
+
+@pytest.mark.asyncio
 async def test_http_validates_request_meta_and_required_client_capabilities():
     server = create_test_server(
         {


### PR DESCRIPTION
## Summary

- add MCP `2025-06-18` HTTP regression coverage for `/mcp/legacy`, including `initialize`, stateless `tools/list`, and `tools/call`
- document the validated Dify 1.16.1 Host profile and strict `/mcp` versus `/mcp/legacy` endpoint selection in English and Simplified Chinese
- preserve the existing 1.0 tool catalog, authorization, Doris capability gates, and read-only execution boundary
- update `CHANGELOG.md`

## Compatibility boundary

- `/mcp` remains strict MCP `2026-07-28`
- `/mcp/legacy` remains default-off through `ENABLE_LEGACY_HTTP_ADAPTER=true`
- the adapter does not restore pre-1.0 tool names, bypass authorization, or change tool exposure mode
- HTTP+SSE remains unsupported

## Verification

- `uv run ruff check .`
- `uv run mypy doris_mcp_server`
- `uv run pytest -q -W error` — 1774 passed, 83 skipped, 67.73% coverage
- domain coverage gates — protocol 90.34%, authentication 81.55%, core managers 87.03%
- `uv run pytest -q --no-cov test/test_release_artifacts.py` — 5 passed
- clean sdist and wheel build; the sdist contains the updated compatibility contract