### PR TITLE
fix: classify Doris permission probe failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ under **Unreleased** until a new version is selected and published.
 - Documented the strict `/mcp` versus `/mcp/legacy` endpoint boundary in the
   protocol, Host, quick-start, deployment, troubleshooting, migration, and
   release guides without restoring pre-1.0 tool names or weakening security.
+- Classified Doris runtime probe errors whose messages explicitly report
+  denied access or missing privileges as permission failures, including Doris
+  error 1105 responses, instead of exposing a generic probe failure.
 - Added the Apache SkyWalking Eyes release gate, its bounded repository
   configuration, and the missing ASF license headers required for source
   release verification.

--- a/doris_mcp_server/tools/capability_detector.py
+++ b/doris_mcp_server/tools/capability_detector.py
@@ -1348,7 +1348,11 @@ def _classify_probe_error(
         (value for value in getattr(error, "args", ()) if isinstance(value, int)),
         None,
     )
-    if error_code in {1044, 1045, 1142, 1227}:
+    message = str(error).casefold()
+    if error_code in {1044, 1045, 1142, 1227} or any(
+        marker in message
+        for marker in ("access denied", "permission denied", "privilege")
+    ):
         return (
             CapabilityProbeStatus.UNKNOWN,
             "PROBE_PERMISSION_DENIED",

--- a/test/tools/test_capability_detector.py
+++ b/test/tools/test_capability_detector.py
@@ -488,12 +488,25 @@ async def test_pipeline_probes_isolate_an_unsupported_source_connection() -> Non
     assert len({id(connection) for connection in manager.domain_connections}) == 7
 
 
+@pytest.mark.parametrize(
+    ("error_code", "message"),
+    (
+        (1142, "permission denied"),
+        (
+            1105,
+            "errCode = 2, detailMessage = Permission denied: user lacks privilege",
+        ),
+    ),
+)
 @pytest.mark.asyncio
-async def test_detector_marks_permission_failure_unknown_not_unsupported() -> None:
+async def test_detector_marks_permission_failure_unknown_not_unsupported(
+    error_code: int,
+    message: str,
+) -> None:
     connection = _ProbeConnection()
     connection.failures["SHOW BACKENDS"] = RuntimeError(
-        1142,
-        "permission denied",
+        error_code,
+        message,
     )
     detector = DorisCapabilityDetector(  # type: ignore[arg-type]
         _ProbeConnectionManager(connection)


### PR DESCRIPTION
## Summary
- classify Doris permission-denied messages as permission probe failures
- cover Doris 1105 authorization errors without treating every 1105 as an authorization failure
- update the changelog

## Root cause
Doris may return generic error code 1105 with an explicit `Permission denied` message. The detector only recognized dedicated MySQL authorization codes, so capability manifests exposed `RUNTIME_PROBE_FAILED` instead of an actionable permission result.

## Validation
- `pytest --no-cov -q test/tools/test_capability_detector.py test/tools/test_capability_runtime_integration.py test/tools/test_capability_registry.py test/tools/test_doris_feature_matrix.py test/tools/test_domain_manifest.py`
- `pytest -q` (1773 passed, 83 skipped)
- `ruff check doris_mcp_server/ test/`
- `git diff --check`