### PR TITLE
fix: probe Query Profile with an owned query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ under **Unreleased** until a new version is selected and published.
 - Classified Doris runtime probe errors whose messages explicitly report
   denied access or missing privileges as permission failures, including Doris
   error 1105 responses, instead of exposing a generic probe failure.
+- Replaced the Query Profile capability check that used a synthetic query ID
+  with an owned, bounded profiled query and trace lookup, preventing valid Doris
+  Profile APIs from being hidden by a false-negative probe.
 - Added the Apache SkyWalking Eyes release gate, its bounded repository
   configuration, and the missing ASF license headers required for source
   release verification.

--- a/doris_mcp_server/tools/capability_detector.py
+++ b/doris_mcp_server/tools/capability_detector.py
@@ -21,12 +21,14 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from types import MappingProxyType
 from typing import Any
+from urllib.parse import quote
 
 from ..utils.adbc_query_tools import DorisADBCQueryTools
 from ..utils.db import DorisConnection, DorisConnectionManager, DorisRouteIdentity
@@ -875,7 +877,36 @@ class DorisCapabilityDetector:
                 reason_code="PROFILE_API_CREDENTIAL_ROUTE_UNAVAILABLE",
                 evidence_sources=("credential_route_policy",),
             )
+        trace_id = uuid.uuid4().hex
         try:
+            route = self.route_identity(auth_context)
+            session_id = f"capability-profile:{route.fingerprint[:16]}"
+            async with (
+                self._connection_manager.get_connection_context_for_auth_context(
+                    session_id,
+                    auth_context,
+                ) as connection
+            ):
+                try:
+                    await connection.execute(
+                        f'SET session_context="trace_id:{trace_id}"',
+                        auth_context=None,
+                        mask_result=False,
+                    )
+                    await connection.execute(
+                        "SET enable_profile=true",
+                        auth_context=None,
+                        mask_result=False,
+                    )
+                    await connection.execute(
+                        "SELECT 1 AS capability_probe",
+                        auth_context=auth_context,
+                        mask_result=False,
+                        max_rows=1,
+                        max_bytes=1024,
+                    )
+                finally:
+                    connection.is_healthy = False
             config_resolver = getattr(
                 self._connection_manager,
                 "get_database_config_for_auth_context",
@@ -887,15 +918,28 @@ class DorisCapabilityDetector:
                 else database_config_for_request(self._connection_manager)
             )
             client = DorisHTTPClient.from_database_config(db_config)
+            hosts = configured_fe_http_hosts(db_config)
+            query_id = await self._resolve_profile_probe_query_id(
+                client,
+                hosts=hosts,
+                port=db_config.fe_http_port,
+                trace_id=trace_id,
+            )
+            if query_id is None:
+                return CapabilityProbeEvidence(
+                    probe_id="query_profile_api_readable",
+                    status=CapabilityProbeStatus.DEGRADED,
+                    reason_code="PROFILE_API_QUERY_ID_UNAVAILABLE",
+                    evidence_sources=("doris_fe_http", "runtime_probe"),
+                )
             response = await client.get_first_available(
                 role="fe",
-                hosts=configured_fe_http_hosts(db_config),
+                hosts=hosts,
                 port=db_config.fe_http_port,
-                path="/rest/v2/manager/query/query_info",
-                params={
-                    "query_id": ("0000000000000000-0000000000000000"),
-                    "is_all_node": "false",
-                },
+                path=(
+                    "/rest/v2/manager/query/profile/text/"
+                    f"{quote(query_id, safe='')}"
+                ),
                 headers={"Accept": "application/json, text/plain"},
             )
         except DorisHTTPPolicyError:
@@ -926,6 +970,37 @@ class DorisCapabilityDetector:
             reason_code=reason,
             evidence_sources=("doris_fe_http", "runtime_probe"),
         )
+
+    async def _resolve_profile_probe_query_id(
+        self,
+        client: DorisHTTPClient,
+        *,
+        hosts: tuple[str, ...],
+        port: int,
+        trace_id: str,
+    ) -> str | None:
+        for delay in (0.0, 0.2, 0.5):
+            if delay:
+                await asyncio.sleep(delay)
+            response = await client.get_first_available(
+                role="fe",
+                hosts=hosts,
+                port=port,
+                path=f"/rest/v2/manager/query/trace_id/{trace_id}",
+                headers={"Accept": "application/json"},
+            )
+            if response.status != 200:
+                continue
+            try:
+                payload = json.loads(response.text())
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, Mapping) or _profile_api_code(payload) != 0:
+                continue
+            query_id = payload.get("data")
+            if isinstance(query_id, str) and query_id.strip():
+                return query_id.strip()
+        return None
 
     async def _probe_lineage_plugin_status(
         self,

--- a/test/tools/test_capability_detector.py
+++ b/test/tools/test_capability_detector.py
@@ -783,6 +783,71 @@ def test_profile_api_probe_classification_is_fail_closed(
 
 
 @pytest.mark.asyncio
+async def test_profile_api_probe_uses_an_owned_profiled_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _ProbeConnection()
+    manager = _ProbeConnectionManager(connection)
+    database_config = SimpleNamespace(
+        user="reader",
+        password="secret",
+        host="fe-1",
+        hosts=["fe-1"],
+        fe_http_host="fe-1",
+        fe_http_hosts=["fe-1"],
+        fe_http_port=8030,
+    )
+    manager.config.database = database_config
+    manager.selected_database_config = database_config
+    calls: list[dict[str, Any]] = []
+
+    class _HTTPClient:
+        async def get_first_available(self, **kwargs: Any) -> DorisHTTPResponse:
+            calls.append(kwargs)
+            if "/trace_id/" in kwargs["path"]:
+                body = b'{"code":0,"data":"query/id"}'
+            else:
+                body = b'{"code":0,"data":"profile"}'
+            return DorisHTTPResponse(
+                status=200,
+                headers={"content-type": "application/json"},
+                body=body,
+                url=f"http://fe-1:8030{kwargs['path']}",
+            )
+
+    monkeypatch.setattr(
+        "doris_mcp_server.tools.capability_detector."
+        "DorisHTTPClient.from_database_config",
+        lambda _config: _HTTPClient(),
+    )
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.a",
+    )
+
+    query = await detector.detect_domain(base, "doris_query", None)
+
+    profile = query.probe("query_profile_api_readable")
+    assert profile is not None
+    assert profile.status is CapabilityProbeStatus.SUPPORTED
+    assert profile.reason_code == "PROFILE_API_READABLE"
+    assert any(
+        statement.startswith('SET session_context="trace_id:')
+        for statement in connection.statements
+    )
+    assert "SET enable_profile=true" in connection.statements
+    assert connection.is_healthy is False
+    assert len(calls) == 2
+    assert "/query/query_info" not in calls[0]["path"]
+    assert "/trace_id/" in calls[0]["path"]
+    assert calls[1]["path"].endswith("/profile/text/query%2Fid")
+    assert "params" not in calls[0]
+    assert "params" not in calls[1]
+
+
+@pytest.mark.asyncio
 async def test_detector_retains_visible_backend_with_unknown_version() -> None:
     connection = _ProbeConnection()
     connection.row_overrides["SHOW BACKENDS"] = [


### PR DESCRIPTION
## Summary
- replace the synthetic Query Profile probe ID with an owned, bounded profiled query
- resolve the generated Query ID through the Doris trace endpoint and verify the actual profile endpoint
- discard the stateful probe connection and URL-escape the returned Query ID
- update the changelog and regression coverage

## Root cause
On Doris 4.0.5, `/rest/v2/manager/query/query_info` returned HTTP 200 with `code=500` for the synthetic all-zero Query ID even though the same account could create and read its own Query Profile. The capability detector therefore hid a working feature as `PROFILE_API_INVALID_RESPONSE`.

## Safety and reliability
- executes only a read-only `SELECT 1 AS capability_probe`
- bounds the result to one row and 1 KiB
- marks the session-state connection unhealthy so profiling settings cannot leak into the pool
- retries the bounded trace lookup before reporting degraded availability
- verifies the same profile endpoint used by the runtime

## Validation
- real Doris 4.0.5 probe: synthetic `query_info` returned `code=500`; owned trace and profile requests both returned `code=0`
- focused capability and query-runtime suite: 221 passed
- full suite: 1776 passed, 83 skipped
- `mypy doris_mcp_server`
- `ruff check .`
- `git diff --check`