### PR TITLE
fix: constrain resource growth selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ under **Unreleased** until a new version is selected and published.
 
 ### Fixed
 
+- Declared the exact `storage`, `query_volume`, and `user_activity` selectors
+  for resource-growth analysis, including their recorded evidence sources, so
+  Hosts reject ambiguous values before dispatching a Doris query.
 - Updated JWT decoding type contracts for PyJWT 2.13 while preserving the
   existing signature, claim, audience, issuer, and unsafe-debug validation
   behavior.

--- a/doris_mcp_server/tools/domain_catalog.py
+++ b/doris_mcp_server/tools/domain_catalog.py
@@ -1509,7 +1509,14 @@ DOMAIN_DEFINITIONS = (
                 "missing history.",
                 _input_schema(
                     {
-                        "resource": _string("Resource type."),
+                        "resource": _string(
+                            "Recorded resource series to analyze: storage uses "
+                            "partition creation evidence, query_volume counts "
+                            "audit-log queries, and user_activity counts distinct "
+                            "audit-log users. Omit to request every available "
+                            "series.",
+                            enum=("storage", "query_volume", "user_activity"),
+                        ),
                         "window_days": _integer(
                             "Lookback window in days.",
                             minimum=1,

--- a/test/tools/test_domain_dispatcher.py
+++ b/test/tools/test_domain_dispatcher.py
@@ -153,6 +153,45 @@ def test_cluster_domain_binds_all_eleven_children() -> None:
     )
 
 
+def test_resource_growth_declares_exact_resource_selectors() -> None:
+    child = DORIS_DOMAIN_CATALOG.resolve_child(
+        "doris_cluster",
+        "analyze_resource_growth",
+    )
+
+    assert child.input_schema["properties"]["resource"]["enum"] == (
+        "storage",
+        "query_volume",
+        "user_activity",
+    )
+
+
+@pytest.mark.asyncio
+async def test_resource_growth_rejects_ambiguous_selector_before_runtime() -> None:
+    manager = _manager("doris_cluster.analyze_resource_growth")
+    manager.cluster_runtime.analyze_resource_growth = AsyncMock()
+
+    result = await manager.domain_dispatcher.call_domain(
+        "doris_cluster",
+        {
+            "child_tool": "analyze_resource_growth",
+            "arguments": {
+                "resource": "query",
+                "window_days": 7,
+                "granularity": "day",
+            },
+        },
+        None,
+    )
+
+    assert result.mode == "error"
+    assert result.error.code is DomainErrorCode.CHILD_ARGUMENTS_INVALID
+    assert [dict(item) for item in result.error.details["violations"]] == [
+        {"instancePath": "/resource", "keyword": "enum"}
+    ]
+    manager.cluster_runtime.analyze_resource_growth.assert_not_awaited()
+
+
 def test_governance_domain_binds_all_eight_children() -> None:
     manager = _manager()
     bound = BoundHandlerAvailabilityProvider(manager)


### PR DESCRIPTION
## Summary
- declare the exact `storage`, `query_volume`, and `user_activity` resource selectors in the Child input schema
- describe the recorded Doris evidence source for each selector
- reject ambiguous values before invoking the runtime
- update the changelog and contract regression coverage

## Root cause
The manifest exposed `resource` as an unconstrained string. A Host could therefore generate an intuitive value such as `query`, while the runtime only accepts `query_volume`. The mismatch surfaced late and made the MCP tool appear unreliable.

## Contract behavior
This change keeps the public contract deterministic: the Manifest publishes the three canonical values and does not guess aliases. Invalid selectors return `CHILD_ARGUMENTS_INVALID` before any Doris query is dispatched.

## Validation
- focused resource-growth and dispatcher tests: 4 passed
- full suite on the latest master: 1778 passed, 83 skipped
- `mypy doris_mcp_server`
- `ruff check .`
- `git diff --check`