### PR TITLE
fix: isolate MetricFlow sidecar environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ under **Unreleased** until a new version is selected and published.
 
 ### Fixed
 
+- Prevented MetricFlow sidecar processes from inheriting Doris credentials,
+  bearer tokens, OAuth/JWT secrets, and unrelated MCP Server environment
+  configuration by launching each provider with a fixed minimal environment.
 - Accepted `+` revision metadata in exact Ossie and MetricFlow model
   references across binding loading, runtime lookup, and public Child schemas.
 - Enforced the canonical read-only SQL allowlist again at the production

--- a/docs/integrations/metricflow.md
+++ b/docs/integrations/metricflow.md
@@ -72,7 +72,10 @@ compiled SQL and send it through the same bounded runtime as
 
 The Server starts the configured executable without a shell, sends one JSON
 object on stdin, reads one bounded JSON object from stdout, and then waits for
-the process to exit. The protocol version is `doris-mcp-metricflow/v1`.
+the process to exit. The Server supplies only a fixed locale and unbuffered-I/O
+environment, so Doris credentials, bearer tokens, OAuth/JWT secrets, and
+unrelated server configuration are not inherited. The protocol version is
+`doris-mcp-metricflow/v1`.
 
 Request:
 

--- a/doris_mcp_server/semantic/metricflow.py
+++ b/doris_mcp_server/semantic/metricflow.py
@@ -24,6 +24,7 @@ import re
 import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Protocol, cast
 
 from ..utils.query_runtime import DorisQueryRuntime, ReadOnlySQLGuard
@@ -41,6 +42,13 @@ _PROVIDER_OPERATIONS = frozenset(
         "list_saved_queries",
         "compile_dimension_values",
         "compile_query",
+    }
+)
+_SIDECAR_ENVIRONMENT: Mapping[str, str] = MappingProxyType(
+    {
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PYTHONUNBUFFERED": "1",
     }
 )
 
@@ -145,6 +153,7 @@ class MetricFlowSidecarProvider:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=self._project_directory,
+                env=dict(_SIDECAR_ENVIRONMENT),
             )
         except (OSError, ValueError) as exc:
             raise MetricFlowProviderFailure(

--- a/test/semantic/test_metricflow_runtime.py
+++ b/test/semantic/test_metricflow_runtime.py
@@ -226,11 +226,24 @@ async def test_metricflow_disabled_and_provider_failures_are_sanitized() -> None
 
 
 @pytest.mark.asyncio
-async def test_metricflow_sidecar_protocol_round_trip(tmp_path: Path) -> None:
+async def test_metricflow_sidecar_protocol_round_trip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret_names = (
+        "DORIS_PASSWORD",
+        "MCP_STATE_HANDLE_SECRET",
+        "TOKEN_ADMIN",
+        "OAUTH_CLIENT_SECRET",
+        "JWT_SECRET",
+    )
+    for name in secret_names:
+        monkeypatch.setenv(name, f"secret-{name.lower()}")
     script = tmp_path / "provider.py"
     script.write_text(
         """
 import json
+import os
 import sys
 
 request = json.loads(sys.stdin.read())
@@ -238,7 +251,10 @@ response = {
     "protocol_version": request["protocol_version"],
     "request_id": request["request_id"],
     "ok": True,
-    "data": {"items": [{"model_ref": "sales/main"}]},
+    "data": {
+        "items": [{"model_ref": "sales/main"}],
+        "environment": dict(sorted(os.environ.items())),
+    },
 }
 sys.stdout.write(json.dumps(response))
 """.strip(),
@@ -251,7 +267,25 @@ sys.stdout.write(json.dumps(response))
 
     result = await provider.request("list_models", {})
 
-    assert result == {"items": [{"model_ref": "sales/main"}]}
+    assert result["items"] == [{"model_ref": "sales/main"}]
+    environment = result["environment"]
+    assert {
+        "LANG": environment["LANG"],
+        "LC_ALL": environment["LC_ALL"],
+        "PYTHONUNBUFFERED": environment["PYTHONUNBUFFERED"],
+    } == {
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PYTHONUNBUFFERED": "1",
+    }
+    assert set(environment) <= {
+        "LANG",
+        "LC_ALL",
+        "PYTHONUNBUFFERED",
+        "__CF_USER_TEXT_ENCODING",
+    }
+    for name in secret_names:
+        assert name not in environment
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Launch every MetricFlow provider sidecar with a fixed minimal locale and unbuffered-I/O environment.
- Prevent Doris credentials, bearer tokens, OAuth/JWT secrets, and unrelated MCP Server configuration from reaching the compiler process through environment inheritance.
- Add a real subprocess regression test with five secret sentinels and document the enforced process boundary.
- Record the security fix in the changelog.

## Root cause

The MetricFlow JSON protocol never placed Doris credentials in request payloads, but `asyncio.create_subprocess_exec` inherited the entire MCP Server process environment by default. A provider process could therefore observe database passwords and authentication material despite the documented compile-only boundary.

## Security behavior

The Server now supplies only `LANG`, `LC_ALL`, and `PYTHONUNBUFFERED` when starting the sidecar. The executable remains absolute, no shell is used, request and response sizes stay bounded, and compiled SQL still returns to the guarded Doris query runtime for execution.

## Validation

- Full test suite: 1,824 passed, 85 skipped
- Coverage: 67.84%; protocol 89.96%, authentication 81.65%, core managers 87.03%
- Ruff, Mypy, Bandit, lockfile, and generated tool-catalog checks passed
- Source distribution and wheel build passed
- Clean Python 3.12 wheel installation and CLI smoke passed
- Real subprocess regression confirmed that Doris, token, OAuth, and JWT secret sentinels are absent from the child environment
- `git diff --check` passed
