### PR TITLE
fix(cluster): honor read-only active task fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ under **Unreleased** until a new version is selected and published.
 
 ### Fixed
 
+- Aligned `doris_cluster.list_active_tasks` capability detection with its
+  read-only execution fallbacks, so restricted Doris accounts can use the
+  `information_schema.active_queries` or process-list source when
+  `SHOW PROC \"/current_queries\"` is unavailable. The public input schema now
+  advertises only the query and compaction task types implemented by the
+  runtime.
 - Prevented MetricFlow sidecar processes from inheriting Doris credentials,
   bearer tokens, OAuth/JWT secrets, and unrelated MCP Server environment
   configuration by launching each provider with a fixed minimal environment.

--- a/doris_mcp_server/tools/capability_detector.py
+++ b/doris_mcp_server/tools/capability_detector.py
@@ -204,9 +204,20 @@ _DOMAIN_PROBES: Mapping[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
         (
             'SHOW PROC "/current_queries"',
             (
-                "legacy_task_views_readable",
+                "current_queries_proc_readable",
                 "unified_task_progress_readable",
             ),
+        ),
+        (
+            (
+                "SELECT 1 AS active_query_probe "
+                "FROM information_schema.active_queries LIMIT 1"
+            ),
+            ("active_queries_view_readable",),
+        ),
+        (
+            "SHOW FULL PROCESSLIST",
+            ("processlist_readable",),
         ),
         (
             (
@@ -1849,6 +1860,16 @@ def _combine_query_evidence_probe(
 def _combine_cluster_evidence_probes(
     probes: Mapping[str, CapabilityProbeEvidence],
 ) -> dict[str, CapabilityProbeEvidence]:
+    active_tasks = _combine_any_runtime_probe(
+        "legacy_task_views_readable",
+        probes,
+        (
+            "current_queries_proc_readable",
+            "active_queries_view_readable",
+            "processlist_readable",
+        ),
+        supported_reason="LEGACY_TASK_VIEW_READABLE",
+    )
     audit = probes.get("metrics_history_readable")
     storage = probes.get("resource_storage_history_readable")
     full = (
@@ -1905,6 +1926,7 @@ def _combine_cluster_evidence_probes(
         reason_code="PARTITION_CREATION_HISTORY_ONLY",
     )
     return {
+        active_tasks.probe_id: active_tasks,
         full.probe_id: full,
         audit_only.probe_id: audit_only,
         storage_only.probe_id: storage_only,

--- a/doris_mcp_server/tools/domain_catalog.py
+++ b/doris_mcp_server/tools/domain_catalog.py
@@ -1415,10 +1415,13 @@ DOMAIN_DEFINITIONS = (
                 "doris_cluster",
                 "list_active_tasks",
                 "List active tasks",
-                "List visible query, load, schema-change, and compaction tasks.",
+                "List visible active query and compaction tasks.",
                 _input_schema(
                     {
-                        "task_types": _string_array("Task types to include."),
+                        "task_types": _string_array(
+                            "Task types to include.",
+                            enum=("query", "compaction"),
+                        ),
                         "states": _string_array("Task states to include."),
                         "limit": _integer("Maximum results.", minimum=1),
                     }

--- a/test/tools/test_capability_detector.py
+++ b/test/tools/test_capability_detector.py
@@ -252,6 +252,36 @@ async def test_cluster_history_keeps_storage_fallback_without_audit_access() -> 
 
 
 @pytest.mark.asyncio
+async def test_cluster_active_tasks_accepts_read_only_query_view_fallback() -> None:
+    connection = _ProbeConnection()
+    proc_probe = 'SHOW PROC "/current_queries"'
+    connection.failures[proc_probe] = RuntimeError(
+        "Access denied; user lacks ADMIN privilege"
+    )
+    manager = _ProbeConnectionManager(connection)
+    detector = DorisCapabilityDetector(manager)  # type: ignore[arg-type]
+    base = await detector.detect_base(
+        None,
+        capability_generation=1,
+        provider_generation="provider.cluster",
+    )
+
+    cluster = await detector.detect_domain(base, "doris_cluster", None)
+
+    assert (
+        cluster.probe("current_queries_proc_readable").status
+        is not CapabilityProbeStatus.SUPPORTED
+    )
+    assert (
+        cluster.probe("active_queries_view_readable").status
+        is CapabilityProbeStatus.SUPPORTED
+    )
+    active_tasks = cluster.probe("legacy_task_views_readable")
+    assert active_tasks.status is CapabilityProbeStatus.SUPPORTED
+    assert active_tasks.reason_code == "LEGACY_TASK_VIEW_READABLE"
+
+
+@pytest.mark.asyncio
 async def test_lakehouse_probes_derive_target_sensitive_advanced_facets() -> None:
     connection = _ProbeConnection()
     manager = _ProbeConnectionManager(connection)

--- a/test/tools/test_domain_catalog.py
+++ b/test/tools/test_domain_catalog.py
@@ -131,6 +131,18 @@ def test_adbc_is_inside_query_and_cluster_has_exactly_eleven_children() -> None:
     assert len(cluster.children) == 11
 
 
+def test_cluster_active_task_contract_matches_runtime_sources() -> None:
+    child = DORIS_DOMAIN_CATALOG.resolve_child(
+        "doris_cluster",
+        "list_active_tasks",
+    )
+    task_types = _wire_input(child)["properties"]["task_types"]
+
+    assert task_types["items"]["enum"] == ["query", "compaction"]
+    assert "load" not in child.canonical_description.casefold()
+    assert "schema-change" not in child.canonical_description.casefold()
+
+
 def test_every_child_uses_the_exact_feature_matrix_contract() -> None:
     feature_contracts = {
         feature.feature_id: feature.support_contract

--- a/test/utils/test_cluster_runtime.py
+++ b/test/utils/test_cluster_runtime.py
@@ -179,6 +179,41 @@ async def test_list_cluster_nodes_normalizes_real_fe_and_be_rows() -> None:
 
 
 @pytest.mark.asyncio
+async def test_active_tasks_falls_back_to_read_only_active_queries_view() -> None:
+    proc_statement = 'SHOW PROC "/current_queries"'
+    view_statement = "SELECT * FROM information_schema.active_queries"
+    runtime, manager, _ = _runtime(
+        rows={
+            view_statement: [
+                {
+                    "QUERY_ID": "query-1",
+                    "STATE": "RUNNING",
+                    "COMMAND": "Query",
+                }
+            ]
+        },
+        failures={proc_statement: RuntimeError(1105, "access denied")},
+    )
+
+    result = await runtime.list_active_tasks(
+        task_types=["query"],
+        states=None,
+        limit=10,
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["items"] == [
+        {
+            "query_id": "query-1",
+            "state": "RUNNING",
+            "command": "Query",
+            "task_type": "query",
+        }
+    ]
+    assert manager.calls == [proc_statement, view_statement]
+
+
+@pytest.mark.asyncio
 async def test_memory_stats_only_returns_observed_metrics() -> None:
     runtime, _, _ = _runtime()
 


### PR DESCRIPTION
## Summary

- align `doris_cluster.list_active_tasks` capability detection with the runtime's existing read-only fallback chain
- expose the child when either the active-query view or process list is readable even if `SHOW PROC \"/current_queries\"` is denied
- narrow the public `task_types` schema and description to the query and compaction task types actually implemented

## Root cause

The capability detector checked only `SHOW PROC \"/current_queries\"`, while the execution runtime already fell back to `information_schema.active_queries` and `SHOW FULL PROCESSLIST`. Restricted Doris accounts could therefore execute a safe fallback but never discover or call the child because availability was rejected first.

## User impact

Read-only enterprise identities can now use active-query inspection without receiving broader administrative privileges. Load and schema-change status remain in the pipeline domain instead of being overstated by the cluster task contract.

## Validation

- `uv lock --check`
- `uv run --frozen python generate_tool_catalog.py --check`
- `uv run --frozen ruff check .`
- `uv run --frozen mypy doris_mcp_server`
- `uv run --frozen bandit -q -c pyproject.toml -r doris_mcp_server doris_mcp_client generate_requirements.py generate_tool_catalog.py`
- `uv run --frozen pytest -q -W error` (`1827 passed, 85 skipped`, coverage `67.98%`)

The real Doris 4.0.5 restricted-reader case that exposed this mismatch will be repeated against the exact committed candidate before downstream acceptance.
