### PR TITLE
chore(deps): apply transitive security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ under **Unreleased** until a new version is selected and published.
 
 ### Fixed
 
+- Updated the locked Marshmallow and Virtualenv transitive dependencies to
+  releases that address CVE-2025-68480 and symlink-based TOCTOU vulnerabilities
+  in development-environment creation.
 - Required at least two recorded time buckets before exposing or executing
   resource-growth analysis, so readable-but-empty audit and partition metadata
   no longer masquerade as historical evidence.

--- a/uv.lock
+++ b/uv.lock
@@ -1364,11 +1364,11 @@ wheels = [
 
 [[package]]
 name = "marshmallow"
-version = "4.0.0"
+version = "4.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/ff/26df5a9f5ac57ccf693a5854916ab47243039d2aa9e0fe5f5a0331e7b74b/marshmallow-4.0.0.tar.gz", hash = "sha256:3b6e80aac299a7935cfb97ed01d1854fb90b5079430969af92118ea1b12a8d55", size = 220507 }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e1/5edfd1edf05d3cc98415b0810ca45fa19d7dee6def0d0ec639eb4eb14e20/marshmallow-4.1.2.tar.gz", hash = "sha256:083f250643d2e75fd363f256aeb6b1af369a7513ad37647ce4a601f6966e3ba5", size = 220974 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/26/6cc45d156f44dbe1d5696d9e54042e4dcaf7b946c0b86df6a97d29706f32/marshmallow-4.0.0-py3-none-any.whl", hash = "sha256:e7b0528337e9990fd64950f8a6b3a1baabed09ad17a0dfb844d701151f92d203", size = 48420 },
+    { url = "https://files.pythonhosted.org/packages/af/b6/66d1748fb45453e337c8a334dafed7b818e72ac9cf9d105a56e0cf21865f/marshmallow-4.1.2-py3-none-any.whl", hash = "sha256:a8cfa18bd8d0e5f7339e734edf84815fe8db1bdb57358c7ccc05472b746eeadc", size = 48360 },
 ]
 
 [[package]]
@@ -3120,16 +3120,16 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.31.2"
+version = "20.36.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316 }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982 },
+    { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- update the locked Marshmallow transitive dependency from 4.0.0 to 4.1.2 to address CVE-2025-68480
- update the locked Virtualenv transitive dependency from 20.31.2 to 20.36.1 to include the symlink-based TOCTOU hardening
- document both security-related dependency updates under Unreleased
- supersede Dependabot PRs #215 and #216 with one reviewed lockfile change

## Validation

- uv lock --check
- uv sync --locked --all-groups
- ruff check .
- mypy doris_mcp_server
- bandit -q -c pyproject.toml -r doris_mcp_server
- python generate_tool_catalog.py --check
- pytest -q -W error: 1859 passed, 85 skipped, 68.11% coverage
- built sdist and wheel successfully
- inspected release archives for excluded ledger, audit-report, and environment files
- installed the wheel into a clean Python 3.12 environment and verified package and CLI version 1.0.0

No runtime code or direct dependency constraint was changed.